### PR TITLE
fix the inmem issue casued by jasper lib upgrade

### DIFF
--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "grib2.h"
+#include <string.h>
 #include "jasper/jasper.h"
 #define JAS_1_700_2
 
@@ -121,7 +122,7 @@ int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
     image.clrspc_=JAS_CLRSPC_SGRAY;         /* grayscale Image */
     image.cmprof_=0; 
 #endif
-    image.inmem_=1;
+//    image.inmem_=1;
 
     cmpt.tlx_=0;
     cmpt.tly_=0;

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -5,7 +5,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include "grib2.h"
-#include <string.h>
 #include "jasper/jasper.h"
 #define JAS_1_700_2
 


### PR DESCRIPTION
SInce jasper no long support inmem union, we remove it to stop the compiling bug caused by it.
The testing of compiling is kept on 
/gpfs/dell2/emc/modeling/noscrub/Hang.Lei/libs/github/NCEPLIBS-g2c
Could please the code manager create a new tag after the review?
Thanks,