### PR TITLE
fixed stray comment delimiter

### DIFF
--- a/src/comunpack.c
+++ b/src/comunpack.c
@@ -45,7 +45,7 @@
 //   MACHINE: 
 //
 //$$$
-int comunpack(unsigned char *cpack,g2int lensec,g2int idrsnum,g2int *idrstmpl,g2int ndpts,g2float *fld)//
+int comunpack(unsigned char *cpack,g2int lensec,g2int idrsnum,g2int *idrstmpl,g2int ndpts,g2float *fld)
 {
 
       g2int   nbitsd=0,isign;

--- a/src/grib2.h
+++ b/src/grib2.h
@@ -146,7 +146,6 @@
  *                     that holds the data.
  *   </pre>
 */
- */
 #ifndef _grib2_H
 #define _grib2_H
 #include<stdio.h>


### PR DESCRIPTION
Part of #5 

Fixed the stray comment delimiter that was causing compile failure.