### PR TITLE
whitespace cleanup

### DIFF
--- a/src/compack.c
+++ b/src/compack.c
@@ -42,33 +42,33 @@ void compack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
              unsigned char *cpack,g2int *lcpack)
 {
 
-      static g2int zero=0;
-      g2int  *ifld,*gref,*glen,*gwidth;
-      g2int  *jmin, *jmax, *lbit;
-      g2int  i,j,n,nbits,imin,imax,left;
-      g2int  isd,itemp,ilmax,ngwidthref=0,nbitsgwidth=0;
-      g2int  nglenref=0,nglenlast=0,iofst,ival1,ival2;
-      g2int  minsd,nbitsd=0,maxorig,nbitorig,ngroups;
-      g2int  lg,ng,igmax,iwmax,nbitsgref;
-      g2int  glength,grpwidth,nbitsglen=0;
-      g2int  kfildo, minpk, inc, maxgrps, ibit, jbit, kbit, novref, lbitref;
-      g2int  missopt, miss1, miss2, ier;
-      g2float  bscale,dscale,rmax,rmin,temp;
-      static g2int simple_alg = 0;
-      static g2float alog2=0.69314718;       //  ln(2.0)
-      static g2int one=1;
+    static g2int zero=0;
+    g2int  *ifld,*gref,*glen,*gwidth;
+    g2int  *jmin, *jmax, *lbit;
+    g2int  i,j,n,nbits,imin,imax,left;
+    g2int  isd,itemp,ilmax,ngwidthref=0,nbitsgwidth=0;
+    g2int  nglenref=0,nglenlast=0,iofst,ival1,ival2;
+    g2int  minsd,nbitsd=0,maxorig,nbitorig,ngroups;
+    g2int  lg,ng,igmax,iwmax,nbitsgref;
+    g2int  glength,grpwidth,nbitsglen=0;
+    g2int  kfildo, minpk, inc, maxgrps, ibit, jbit, kbit, novref, lbitref;
+    g2int  missopt, miss1, miss2, ier;
+    g2float  bscale,dscale,rmax,rmin,temp;
+    static g2int simple_alg = 0;
+    static g2float alog2=0.69314718;       //  ln(2.0)
+    static g2int one=1;
 
-      bscale=int_power(2.0,-idrstmpl[1]);
-      dscale=int_power(10.0,idrstmpl[2]);
+    bscale=int_power(2.0,-idrstmpl[1]);
+    dscale=int_power(10.0,idrstmpl[2]);
 //
 //  Find max and min values in the data
 //
-      rmax=fld[0];
-      rmin=fld[0];
-      for (j=1;j<ndpts;j++) {
+    rmax=fld[0];
+    rmin=fld[0];
+    for (j=1;j<ndpts;j++) {
         if (fld[j] > rmax) rmax=fld[j];
         if (fld[j] < rmin) rmin=fld[j];
-      }
+    }
 
 //
 //  If max and min values are not equal, pack up field.
@@ -76,7 +76,7 @@ void compack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
 //  value (rmin) is the value for each point in the field and
 //  set nbits to 0.
 //
-      if (rmin != rmax) {
+    if (rmin != rmax) {
         iofst=0;
         ifld=calloc(ndpts,sizeof(g2int));
         gref=calloc(ndpts,sizeof(g2int));
@@ -86,194 +86,194 @@ void compack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
         //  Scale original data
         //
         if (idrstmpl[1] == 0) {        //  No binary scaling
-           imin=(g2int)rint(rmin*dscale);
-           //imax=(g2int)rint(rmax*dscale);
-           rmin=(g2float)imin;
-           for (j=0;j<ndpts;j++) 
-              ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
+            imin=(g2int)rint(rmin*dscale);
+            //imax=(g2int)rint(rmax*dscale);
+            rmin=(g2float)imin;
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
         }
         else {                             //  Use binary scaling factor
-           rmin=rmin*dscale;
-           //rmax=rmax*dscale;
-           for (j=0;j<ndpts;j++) 
-             ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
+            rmin=rmin*dscale;
+            //rmax=rmax*dscale;
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
         }
         //
         //  Calculate Spatial differences, if using DRS Template 5.3
         //
         if (idrsnum == 3) {        // spatial differences
-           if (idrstmpl[16]!=1 && idrstmpl[16]!=2) idrstmpl[16]=1;
-           if (idrstmpl[16] == 1) {      // first order
-              ival1=ifld[0];
-              for (j=ndpts-1;j>0;j--) 
-                 ifld[j]=ifld[j]-ifld[j-1];
-              ifld[0]=0;
-           }
-           else if (idrstmpl[16] == 2) {      // second order
-              ival1=ifld[0];
-              ival2=ifld[1];
-              for (j=ndpts-1;j>1;j--) 
-                 ifld[j]=ifld[j]-(2*ifld[j-1])+ifld[j-2];
-              ifld[0]=0;
-              ifld[1]=0;
-           }
-           //
-           //  subtract min value from spatial diff field
-           //
-           isd=idrstmpl[16];
-           minsd=ifld[isd];
-           for (j=isd;j<ndpts;j++)  if ( ifld[j] < minsd ) minsd=ifld[j];
-           for (j=isd;j<ndpts;j++)  ifld[j]=ifld[j]-minsd;
-           //
-           //   find num of bits need to store minsd and add 1 extra bit
-           //   to indicate sign
-           //
-           temp=log((double)(abs(minsd)+1))/alog2;
-           nbitsd=(g2int)ceil(temp)+1;
-           //
-           //   find num of bits need to store ifld[0] ( and ifld[1]
-           //   if using 2nd order differencing )
-           //
-           maxorig=ival1;
-           if (idrstmpl[16]==2 && ival2>ival1) maxorig=ival2;
-           temp=log((double)(maxorig+1))/alog2;
-           nbitorig=(g2int)ceil(temp)+1;
-           if (nbitorig > nbitsd) nbitsd=nbitorig;
-           //   increase number of bits to even multiple of 8 ( octet )
-           if ( (nbitsd%8) != 0) nbitsd=nbitsd+(8-(nbitsd%8));
-           //
-           //  Store extra spatial differencing info into the packed
-           //  data section.
-           //
-           if (nbitsd != 0) {
-              //   pack first original value
-              if (ival1 >= 0) {
-                 sbit(cpack,&ival1,iofst,nbitsd);
-                 iofst=iofst+nbitsd;
-              }
-              else {
-                 sbit(cpack,&one,iofst,1);
-                 iofst=iofst+1;
-                 itemp=abs(ival1);
-                 sbit(cpack,&itemp,iofst,nbitsd-1);
-                 iofst=iofst+nbitsd-1;
-              }
-              if (idrstmpl[16] == 2) {
-               //  pack second original value
-                 if (ival2 >= 0) {
-                    sbit(cpack,&ival2,iofst,nbitsd);
+            if (idrstmpl[16]!=1 && idrstmpl[16]!=2) idrstmpl[16]=1;
+            if (idrstmpl[16] == 1) {      // first order
+                ival1=ifld[0];
+                for (j=ndpts-1;j>0;j--)
+                    ifld[j]=ifld[j]-ifld[j-1];
+                ifld[0]=0;
+            }
+            else if (idrstmpl[16] == 2) {      // second order
+                ival1=ifld[0];
+                ival2=ifld[1];
+                for (j=ndpts-1;j>1;j--)
+                    ifld[j]=ifld[j]-(2*ifld[j-1])+ifld[j-2];
+                ifld[0]=0;
+                ifld[1]=0;
+            }
+            //
+            //  subtract min value from spatial diff field
+            //
+            isd=idrstmpl[16];
+            minsd=ifld[isd];
+            for (j=isd;j<ndpts;j++)  if ( ifld[j] < minsd ) minsd=ifld[j];
+            for (j=isd;j<ndpts;j++)  ifld[j]=ifld[j]-minsd;
+            //
+            //   find num of bits need to store minsd and add 1 extra bit
+            //   to indicate sign
+            //
+            temp=log((double)(abs(minsd)+1))/alog2;
+            nbitsd=(g2int)ceil(temp)+1;
+            //
+            //   find num of bits need to store ifld[0] ( and ifld[1]
+            //   if using 2nd order differencing )
+            //
+            maxorig=ival1;
+            if (idrstmpl[16]==2 && ival2>ival1) maxorig=ival2;
+            temp=log((double)(maxorig+1))/alog2;
+            nbitorig=(g2int)ceil(temp)+1;
+            if (nbitorig > nbitsd) nbitsd=nbitorig;
+            //   increase number of bits to even multiple of 8 ( octet )
+            if ( (nbitsd%8) != 0) nbitsd=nbitsd+(8-(nbitsd%8));
+            //
+            //  Store extra spatial differencing info into the packed
+            //  data section.
+            //
+            if (nbitsd != 0) {
+                //   pack first original value
+                if (ival1 >= 0) {
+                    sbit(cpack,&ival1,iofst,nbitsd);
                     iofst=iofst+nbitsd;
-                 }
-                 else {
+                }
+                else {
                     sbit(cpack,&one,iofst,1);
                     iofst=iofst+1;
-                    itemp=abs(ival2);
+                    itemp=abs(ival1);
                     sbit(cpack,&itemp,iofst,nbitsd-1);
                     iofst=iofst+nbitsd-1;
-                 }
-              }
-              //  pack overall min of spatial differences
-              if (minsd >= 0) {
-                 sbit(cpack,&minsd,iofst,nbitsd);
-                 iofst=iofst+nbitsd;
-              }
-              else {
-                 sbit(cpack,&one,iofst,1);
-                 iofst=iofst+1;
-                 itemp=abs(minsd);
-                 sbit(cpack,&itemp,iofst,nbitsd-1);
-                 iofst=iofst+nbitsd-1;
-              }
-           }
-           //printf("SDp %ld %ld %ld %ld\n",ival1,ival2,minsd,nbitsd);
+                }
+                if (idrstmpl[16] == 2) {
+                    //  pack second original value
+                    if (ival2 >= 0) {
+                        sbit(cpack,&ival2,iofst,nbitsd);
+                        iofst=iofst+nbitsd;
+                    }
+                    else {
+                        sbit(cpack,&one,iofst,1);
+                        iofst=iofst+1;
+                        itemp=abs(ival2);
+                        sbit(cpack,&itemp,iofst,nbitsd-1);
+                        iofst=iofst+nbitsd-1;
+                    }
+                }
+                //  pack overall min of spatial differences
+                if (minsd >= 0) {
+                    sbit(cpack,&minsd,iofst,nbitsd);
+                    iofst=iofst+nbitsd;
+                }
+                else {
+                    sbit(cpack,&one,iofst,1);
+                    iofst=iofst+1;
+                    itemp=abs(minsd);
+                    sbit(cpack,&itemp,iofst,nbitsd-1);
+                    iofst=iofst+nbitsd-1;
+                }
+            }
+            //printf("SDp %ld %ld %ld %ld\n",ival1,ival2,minsd,nbitsd);
         }     //  end of spatial diff section
         //
         //   Determine Groups to be used.
         //
         if ( simple_alg == 1 ) {
-           //  set group length to 10;  calculate number of groups
-           //  and length of last group
-           ngroups=ndpts/10;
-           for (j=0;j<ngroups;j++) glen[j]=10;
-           itemp=ndpts%10;
-           if (itemp != 0) {
-              ngroups=ngroups+1;
-              glen[ngroups-1]=itemp;
-           }
+            //  set group length to 10;  calculate number of groups
+            //  and length of last group
+            ngroups=ndpts/10;
+            for (j=0;j<ngroups;j++) glen[j]=10;
+            itemp=ndpts%10;
+            if (itemp != 0) {
+                ngroups=ngroups+1;
+                glen[ngroups-1]=itemp;
+            }
         }
         else {
-           // Use Dr. Glahn's algorithm for determining grouping.
-           //
-           kfildo=6;
-           minpk=10;
-           inc=1;
-           maxgrps=(ndpts/minpk)+1;
-           jmin = calloc(maxgrps,sizeof(g2int));
-           jmax = calloc(maxgrps,sizeof(g2int));
-           lbit = calloc(maxgrps,sizeof(g2int));
-           missopt=0;
-           pack_gp(&kfildo,ifld,&ndpts,&missopt,&minpk,&inc,&miss1,&miss2,
-                        jmin,jmax,lbit,glen,&maxgrps,&ngroups,&ibit,&jbit,
-                        &kbit,&novref,&lbitref,&ier);
-           //print *,'SAGier = ',ier,ibit,jbit,kbit,novref,lbitref
-           for ( ng=0; ng<ngroups; ng++) glen[ng]=glen[ng]+novref;
-           free(jmin);
-           free(jmax);
-           free(lbit);
+            // Use Dr. Glahn's algorithm for determining grouping.
+            //
+            kfildo=6;
+            minpk=10;
+            inc=1;
+            maxgrps=(ndpts/minpk)+1;
+            jmin = calloc(maxgrps,sizeof(g2int));
+            jmax = calloc(maxgrps,sizeof(g2int));
+            lbit = calloc(maxgrps,sizeof(g2int));
+            missopt=0;
+            pack_gp(&kfildo,ifld,&ndpts,&missopt,&minpk,&inc,&miss1,&miss2,
+                    jmin,jmax,lbit,glen,&maxgrps,&ngroups,&ibit,&jbit,
+                    &kbit,&novref,&lbitref,&ier);
+            //print *,'SAGier = ',ier,ibit,jbit,kbit,novref,lbitref
+            for ( ng=0; ng<ngroups; ng++) glen[ng]=glen[ng]+novref;
+            free(jmin);
+            free(jmax);
+            free(lbit);
         }
-        //  
+        //
         //  For each group, find the group's reference value
         //  and the number of bits needed to hold the remaining values
         //
         n=0;
         for (ng=0;ng<ngroups;ng++) {
-           //    find max and min values of group
-           gref[ng]=ifld[n];
-           imax=ifld[n];
-           j=n+1;
-           for (lg=1;lg<glen[ng];lg++) {
-              if (ifld[j] < gref[ng]) gref[ng]=ifld[j]; 
-              if (ifld[j] > imax) imax=ifld[j];
-              j++;
-           }
-           //   calc num of bits needed to hold data
-           if ( gref[ng] != imax ) {
-              temp=log((double)(imax-gref[ng]+1))/alog2;
-              gwidth[ng]=(g2int)ceil(temp);
-           }
-           else 
-              gwidth[ng]=0;
-           //   Subtract min from data
-           j=n;
-           for (lg=0;lg<glen[ng];lg++) {
-              ifld[j]=ifld[j]-gref[ng];
-              j++;
-           }
-           //   increment fld array counter
-           n=n+glen[ng];
+            //    find max and min values of group
+            gref[ng]=ifld[n];
+            imax=ifld[n];
+            j=n+1;
+            for (lg=1;lg<glen[ng];lg++) {
+                if (ifld[j] < gref[ng]) gref[ng]=ifld[j];
+                if (ifld[j] > imax) imax=ifld[j];
+                j++;
+            }
+            //   calc num of bits needed to hold data
+            if ( gref[ng] != imax ) {
+                temp=log((double)(imax-gref[ng]+1))/alog2;
+                gwidth[ng]=(g2int)ceil(temp);
+            }
+            else
+                gwidth[ng]=0;
+            //   Subtract min from data
+            j=n;
+            for (lg=0;lg<glen[ng];lg++) {
+                ifld[j]=ifld[j]-gref[ng];
+                j++;
+            }
+            //   increment fld array counter
+            n=n+glen[ng];
         }
-        //  
-        //  Find max of the group references and calc num of bits needed 
+        //
+        //  Find max of the group references and calc num of bits needed
         //  to pack each groups reference value, then
         //  pack up group reference values
         //
         igmax=gref[0];
         for (j=1;j<ngroups;j++) if (gref[j] > igmax) igmax=gref[j];
         if (igmax != 0) {
-           temp=log((double)(igmax+1))/alog2;
-           nbitsgref=(g2int)ceil(temp);
-           sbits(cpack,gref,iofst,nbitsgref,0,ngroups);
-           itemp=nbitsgref*ngroups;
-           iofst=iofst+itemp;
-           //         Pad last octet with Zeros, if necessary,
-           if ( (itemp%8) != 0) {
-              left=8-(itemp%8);
-              sbit(cpack,&zero,iofst,left);
-              iofst=iofst+left;
-           }
+            temp=log((double)(igmax+1))/alog2;
+            nbitsgref=(g2int)ceil(temp);
+            sbits(cpack,gref,iofst,nbitsgref,0,ngroups);
+            itemp=nbitsgref*ngroups;
+            iofst=iofst+itemp;
+            //         Pad last octet with Zeros, if necessary,
+            if ( (itemp%8) != 0) {
+                left=8-(itemp%8);
+                sbit(cpack,&zero,iofst,left);
+                iofst=iofst+left;
+            }
         }
         else
-           nbitsgref=0;
+            nbitsgref=0;
         //
         //  Find max/min of the group widths and calc num of bits needed
         //  to pack each groups width value, then
@@ -282,27 +282,27 @@ void compack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
         iwmax=gwidth[0];
         ngwidthref=gwidth[0];
         for (j=1;j<ngroups;j++) {
-           if (gwidth[j] > iwmax) iwmax=gwidth[j];
-           if (gwidth[j] < ngwidthref) ngwidthref=gwidth[j];
+            if (gwidth[j] > iwmax) iwmax=gwidth[j];
+            if (gwidth[j] < ngwidthref) ngwidthref=gwidth[j];
         }
         if (iwmax != ngwidthref) {
-           temp=log((double)(iwmax-ngwidthref+1))/alog2;
-           nbitsgwidth=(g2int)ceil(temp);
-           for (i=0;i<ngroups;i++) 
-              gwidth[i]=gwidth[i]-ngwidthref;
-           sbits(cpack,gwidth,iofst,nbitsgwidth,0,ngroups);
-           itemp=nbitsgwidth*ngroups;
-           iofst=iofst+itemp;
-           //         Pad last octet with Zeros, if necessary,
-           if ( (itemp%8) != 0) {
-              left=8-(itemp%8);
-              sbit(cpack,&zero,iofst,left);
-              iofst=iofst+left;
-           }
+            temp=log((double)(iwmax-ngwidthref+1))/alog2;
+            nbitsgwidth=(g2int)ceil(temp);
+            for (i=0;i<ngroups;i++)
+                gwidth[i]=gwidth[i]-ngwidthref;
+            sbits(cpack,gwidth,iofst,nbitsgwidth,0,ngroups);
+            itemp=nbitsgwidth*ngroups;
+            iofst=iofst+itemp;
+            //         Pad last octet with Zeros, if necessary,
+            if ( (itemp%8) != 0) {
+                left=8-(itemp%8);
+                sbit(cpack,&zero,iofst,left);
+                iofst=iofst+left;
+            }
         }
         else {
-           nbitsgwidth=0;
-           for (i=0;i<ngroups;i++) gwidth[i]=0;
+            nbitsgwidth=0;
+            for (i=0;i<ngroups;i++) gwidth[i]=0;
         }
         //
         //  Find max/min of the group lengths and calc num of bits needed
@@ -313,47 +313,47 @@ void compack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
         ilmax=glen[0];
         nglenref=glen[0];
         for (j=1;j<ngroups-1;j++) {
-           if (glen[j] > ilmax) ilmax=glen[j];
-           if (glen[j] < nglenref) nglenref=glen[j];
+            if (glen[j] > ilmax) ilmax=glen[j];
+            if (glen[j] < nglenref) nglenref=glen[j];
         }
         nglenlast=glen[ngroups-1];
         if (ilmax != nglenref) {
-           temp=log((double)(ilmax-nglenref+1))/alog2;
-           nbitsglen=(g2int)ceil(temp);
-           for (i=0;i<ngroups-1;i++)  glen[i]=glen[i]-nglenref;
-           sbits(cpack,glen,iofst,nbitsglen,0,ngroups);
-           itemp=nbitsglen*ngroups;
-           iofst=iofst+itemp;
-           //         Pad last octet with Zeros, if necessary,
-           if ( (itemp%8) != 0) {
-              left=8-(itemp%8);
-              sbit(cpack,&zero,iofst,left);
-              iofst=iofst+left;
-           }
+            temp=log((double)(ilmax-nglenref+1))/alog2;
+            nbitsglen=(g2int)ceil(temp);
+            for (i=0;i<ngroups-1;i++)  glen[i]=glen[i]-nglenref;
+            sbits(cpack,glen,iofst,nbitsglen,0,ngroups);
+            itemp=nbitsglen*ngroups;
+            iofst=iofst+itemp;
+            //         Pad last octet with Zeros, if necessary,
+            if ( (itemp%8) != 0) {
+                left=8-(itemp%8);
+                sbit(cpack,&zero,iofst,left);
+                iofst=iofst+left;
+            }
         }
         else {
-           nbitsglen=0;
-           for (i=0;i<ngroups;i++) glen[i]=0;
+            nbitsglen=0;
+            for (i=0;i<ngroups;i++) glen[i]=0;
         }
         //
         //  For each group, pack data values
         //
         n=0;
         for (ng=0;ng<ngroups;ng++) {
-           glength=glen[ng]+nglenref;
-           if (ng == (ngroups-1) ) glength=nglenlast;
-           grpwidth=gwidth[ng]+ngwidthref;
-           if ( grpwidth != 0 ) {
-              sbits(cpack,ifld+n,iofst,grpwidth,0,glength);
-              iofst=iofst+(grpwidth*glength);
-           }
-           n=n+glength;
+            glength=glen[ng]+nglenref;
+            if (ng == (ngroups-1) ) glength=nglenlast;
+            grpwidth=gwidth[ng]+ngwidthref;
+            if ( grpwidth != 0 ) {
+                sbits(cpack,ifld+n,iofst,grpwidth,0,glength);
+                iofst=iofst+(grpwidth*glength);
+            }
+            n=n+glength;
         }
         //         Pad last octet with Zeros, if necessary,
         if ( (iofst%8) != 0) {
-           left=8-(iofst%8);
-           sbit(cpack,&zero,iofst,left);
-           iofst=iofst+left;
+            left=8-(iofst%8);
+            sbit(cpack,&zero,iofst,left);
+            iofst=iofst+left;
         }
         *lcpack=iofst/8;
         //
@@ -361,34 +361,34 @@ void compack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
         if ( gref!=0 ) free(gref);
         if ( gwidth!=0 ) free(gwidth);
         if ( glen!=0 ) free(glen);
-      }
-      else {          //   Constant field ( max = min )
+    }
+    else {          //   Constant field ( max = min )
         nbits=0;
         *lcpack=0;
         nbitsgref=0;
         ngroups=0;
-      }
+    }
 
 //
 //  Fill in ref value and number of bits in Template 5.2
 //
-      mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
-      idrstmpl[3]=nbitsgref;
-      idrstmpl[4]=0;         // original data were reals
-      idrstmpl[5]=1;         // general group splitting
-      idrstmpl[6]=0;         // No internal missing values
-      idrstmpl[7]=0;         // Primary missing value
-      idrstmpl[8]=0;         // secondary missing value
-      idrstmpl[9]=ngroups;          // Number of groups
-      idrstmpl[10]=ngwidthref;       // reference for group widths
-      idrstmpl[11]=nbitsgwidth;      // num bits used for group widths
-      idrstmpl[12]=nglenref;         // Reference for group lengths
-      idrstmpl[13]=1;                // length increment for group lengths
-      idrstmpl[14]=nglenlast;        // True length of last group
-      idrstmpl[15]=nbitsglen;        // num bits used for group lengths
-      if (idrsnum == 3) {
-         idrstmpl[17]=nbitsd/8;      // num bits used for extra spatial
-                                     // differencing values
-      }
+    mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
+    idrstmpl[3]=nbitsgref;
+    idrstmpl[4]=0;         // original data were reals
+    idrstmpl[5]=1;         // general group splitting
+    idrstmpl[6]=0;         // No internal missing values
+    idrstmpl[7]=0;         // Primary missing value
+    idrstmpl[8]=0;         // secondary missing value
+    idrstmpl[9]=ngroups;          // Number of groups
+    idrstmpl[10]=ngwidthref;       // reference for group widths
+    idrstmpl[11]=nbitsgwidth;      // num bits used for group widths
+    idrstmpl[12]=nglenref;         // Reference for group lengths
+    idrstmpl[13]=1;                // length increment for group lengths
+    idrstmpl[14]=nglenlast;        // True length of last group
+    idrstmpl[15]=nbitsglen;        // num bits used for group lengths
+    if (idrsnum == 3) {
+        idrstmpl[17]=nbitsd/8;      // num bits used for extra spatial
+        // differencing values
+    }
 
 }

--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -1,7 +1,7 @@
 /** @file
  */
 #ifndef USE_JPEG2000
- void dummy(void) {}
+void dummy(void) {}
 #else   /* USE_JPEG2000 */
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,44 +12,44 @@
 
 
 /*$$$  SUBPROGRAM DOCUMENTATION BLOCK
-*                .      .    .                                       .
-* SUBPROGRAM:    dec_jpeg2000      Decodes JPEG2000 code stream
-*   PRGMMR: Gilbert          ORG: W/NP11     DATE: 2002-12-02
-*
-* ABSTRACT: This Function decodes a JPEG2000 code stream specified in the
-*   JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using JasPer 
-*   Software version 1.500.4 (or 1.700.2) written by the University of British
-*   Columbia and Image Power Inc, and others.
-*   JasPer is available at http://www.ece.uvic.ca/~mdadams/jasper/.
-*
-* PROGRAM HISTORY LOG:
-* 2002-12-02  Gilbert
-*
-* USAGE:     int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
-*
-*   INPUT ARGUMENTS:
-*      injpc - Input JPEG2000 code stream.
-*    bufsize - Length (in bytes) of the input JPEG2000 code stream.
-*
-*   OUTPUT ARGUMENTS:
-*     outfld - Output matrix of grayscale image values.
-*
-*   RETURN VALUES :
-*          0 = Successful decode
-*         -3 = Error decode jpeg2000 code stream.
-*         -5 = decoded image had multiple color components.
-*              Only grayscale is expected.
-*
-* REMARKS:
-*
-*      Requires JasPer Software version 1.500.4 or 1.700.2
-*
-* ATTRIBUTES:
-*   LANGUAGE: C
-*   MACHINE:  IBM SP
-*
-*$$$*/
-   int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
+ *                .      .    .                                       .
+ * SUBPROGRAM:    dec_jpeg2000      Decodes JPEG2000 code stream
+ *   PRGMMR: Gilbert          ORG: W/NP11     DATE: 2002-12-02
+ *
+ * ABSTRACT: This Function decodes a JPEG2000 code stream specified in the
+ *   JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using JasPer
+ *   Software version 1.500.4 (or 1.700.2) written by the University of British
+ *   Columbia and Image Power Inc, and others.
+ *   JasPer is available at http://www.ece.uvic.ca/~mdadams/jasper/.
+ *
+ * PROGRAM HISTORY LOG:
+ * 2002-12-02  Gilbert
+ *
+ * USAGE:     int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
+ *
+ *   INPUT ARGUMENTS:
+ *      injpc - Input JPEG2000 code stream.
+ *    bufsize - Length (in bytes) of the input JPEG2000 code stream.
+ *
+ *   OUTPUT ARGUMENTS:
+ *     outfld - Output matrix of grayscale image values.
+ *
+ *   RETURN VALUES :
+ *          0 = Successful decode
+ *         -3 = Error decode jpeg2000 code stream.
+ *         -5 = decoded image had multiple color components.
+ *              Only grayscale is expected.
+ *
+ * REMARKS:
+ *
+ *      Requires JasPer Software version 1.500.4 or 1.700.2
+ *
+ * ATTRIBUTES:
+ *   LANGUAGE: C
+ *   MACHINE:  IBM SP
+ *
+ *$$$*/
+int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
 {
     int ier;
     g2int i,j,k;
@@ -62,61 +62,61 @@
 //    jas_init();
 
     ier=0;
-//   
+//
 //     Create jas_stream_t containing input JPEG200 codestream in memory.
-//       
+//
 
     jpcstream=jas_stream_memopen(injpc,bufsize);
 
-//   
+//
 //     Decode JPEG200 codestream into jas_image_t structure.
-//       
+//
     image=jpc_decode(jpcstream,opts);
     if ( image == 0 ) {
-       printf(" jpc_decode return\n");
-       return -3;
+        printf(" jpc_decode return\n");
+        return -3;
     }
-    
+
     pcmpt=image->cmpts_[0];
 /*
-    printf(" SAGOUT DECODE:\n");
-    printf(" tlx %d \n",image->tlx_);
-    printf(" tly %d \n",image->tly_);
-    printf(" brx %d \n",image->brx_);
-    printf(" bry %d \n",image->bry_);
-    printf(" numcmpts %d \n",image->numcmpts_);
-    printf(" maxcmpts %d \n",image->maxcmpts_);
-#ifdef JAS_1_500_4
-    printf(" colormodel %d \n",image->colormodel_);
-#endif
-#ifdef JAS_1_700_2
-    printf(" colorspace %d \n",image->clrspc_);
-#endif
-    printf(" inmem %d \n",image->inmem_);
-    printf(" COMPONENT:\n");
-    printf(" tlx %d \n",pcmpt->tlx_);
-    printf(" tly %d \n",pcmpt->tly_);
-    printf(" hstep %d \n",pcmpt->hstep_);
-    printf(" vstep %d \n",pcmpt->vstep_);
-    printf(" width %d \n",pcmpt->width_);
-    printf(" height %d \n",pcmpt->height_);
-    printf(" prec %d \n",pcmpt->prec_);
-    printf(" sgnd %d \n",pcmpt->sgnd_);
-    printf(" cps %d \n",pcmpt->cps_);
-#ifdef JAS_1_700_2
-    printf(" type %d \n",pcmpt->type_);
-#endif
+  printf(" SAGOUT DECODE:\n");
+  printf(" tlx %d \n",image->tlx_);
+  printf(" tly %d \n",image->tly_);
+  printf(" brx %d \n",image->brx_);
+  printf(" bry %d \n",image->bry_);
+  printf(" numcmpts %d \n",image->numcmpts_);
+  printf(" maxcmpts %d \n",image->maxcmpts_);
+  #ifdef JAS_1_500_4
+  printf(" colormodel %d \n",image->colormodel_);
+  #endif
+  #ifdef JAS_1_700_2
+  printf(" colorspace %d \n",image->clrspc_);
+  #endif
+  printf(" inmem %d \n",image->inmem_);
+  printf(" COMPONENT:\n");
+  printf(" tlx %d \n",pcmpt->tlx_);
+  printf(" tly %d \n",pcmpt->tly_);
+  printf(" hstep %d \n",pcmpt->hstep_);
+  printf(" vstep %d \n",pcmpt->vstep_);
+  printf(" width %d \n",pcmpt->width_);
+  printf(" height %d \n",pcmpt->height_);
+  printf(" prec %d \n",pcmpt->prec_);
+  printf(" sgnd %d \n",pcmpt->sgnd_);
+  printf(" cps %d \n",pcmpt->cps_);
+  #ifdef JAS_1_700_2
+  printf(" type %d \n",pcmpt->type_);
+  #endif
 */
 
 //   Expecting jpeg2000 image to be grayscale only.
 //   No color components.
 //
     if (image->numcmpts_ != 1 ) {
-       printf("dec_jpeg2000: Found color image.  Grayscale expected.\n");
-       return (-5);
+        printf("dec_jpeg2000: Found color image.  Grayscale expected.\n");
+        return (-5);
     }
 
-// 
+//
 //    Create a data matrix of grayscale image values decoded from
 //    the jpeg2000 codestream.
 //
@@ -127,9 +127,9 @@
 //    Copy data matrix to output integer array.
 //
     k=0;
-    for (i=0;i<pcmpt->height_;i++) 
-      for (j=0;j<pcmpt->width_;j++) 
-        outfld[k++]=data->rows_[i][j];
+    for (i=0;i<pcmpt->height_;i++)
+        for (j=0;j<pcmpt->width_;j++)
+            outfld[k++]=data->rows_[i][j];
 //
 //     Clean up JasPer work structures.
 //

--- a/src/dec_png.c
+++ b/src/dec_png.c
@@ -1,7 +1,7 @@
 /** @file
  */
 #ifndef USE_PNG
- void dummy(void) {}
+void dummy(void) {}
 #else   /* USE_PNG */
 
 #include <stdio.h>
@@ -12,8 +12,8 @@
 
 
 struct png_stream {
-   unsigned char *stream_ptr;     /*  location to write PNG stream  */
-   g2int stream_len;               /*  number of bytes written       */
+    unsigned char *stream_ptr;     /*  location to write PNG stream  */
+    g2int stream_len;               /*  number of bytes written       */
 };
 typedef struct png_stream png_stream;
 
@@ -21,20 +21,20 @@ void user_read_data(png_structp , png_bytep , png_uint_32 );
 
 void user_read_data(png_structp png_ptr,png_bytep data, png_uint_32 length)
 /*
-        Custom read function used so that libpng will read a PNG stream
-        from memory instead of a file on disk.
+  Custom read function used so that libpng will read a PNG stream
+  from memory instead of a file on disk.
 */
 {
-     char *ptr;
-     g2int offset;
-     png_stream *mem;
+    char *ptr;
+    g2int offset;
+    png_stream *mem;
 
-     mem=(png_stream *)png_get_io_ptr(png_ptr);
-     ptr=(void *)mem->stream_ptr;
-     offset=mem->stream_len;
+    mem=(png_stream *)png_get_io_ptr(png_ptr);
+    ptr=(void *)mem->stream_ptr;
+    offset=mem->stream_len;
 /*     printf("SAGrd %ld %ld %x\n",offset,length,ptr);  */
-     memcpy(data,ptr+offset,length);
-     mem->stream_len += length;
+    memcpy(data,ptr+offset,length);
+    mem->stream_len += length;
 }
 
 
@@ -51,36 +51,36 @@ int dec_png(unsigned char *pngbuf,g2int *width,g2int *height,char *cout)
 
 /*  check if stream is a valid PNG format   */
 
-    if ( png_sig_cmp(pngbuf,0,8) != 0) 
-       return (-3);
+    if ( png_sig_cmp(pngbuf,0,8) != 0)
+        return (-3);
 
 /* create and initialize png_structs  */
 
-    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, (png_voidp)NULL, 
-                                      NULL, NULL);
+    png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, (png_voidp)NULL,
+                                     NULL, NULL);
     if (!png_ptr)
-       return (-1);
+        return (-1);
 
     info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr)
     {
-       png_destroy_read_struct(&png_ptr,(png_infopp)NULL,(png_infopp)NULL);
-       return (-2);
+        png_destroy_read_struct(&png_ptr,(png_infopp)NULL,(png_infopp)NULL);
+        return (-2);
     }
 
     end_info = png_create_info_struct(png_ptr);
     if (!end_info)
     {
-       png_destroy_read_struct(&png_ptr,(png_infopp)info_ptr,(png_infopp)NULL);
-       return (-2);
+        png_destroy_read_struct(&png_ptr,(png_infopp)info_ptr,(png_infopp)NULL);
+        return (-2);
     }
 
 /*     Set Error callback   */
 
     if (setjmp(png_jmpbuf(png_ptr)))
     {
-       png_destroy_read_struct(&png_ptr, &info_ptr,&end_info);
-       return (-3);
+        png_destroy_read_struct(&png_ptr, &info_ptr,&end_info);
+        return (-3);
     }
 
 /*    Initialize info for reading PNG stream from memory   */
@@ -106,7 +106,7 @@ int dec_png(unsigned char *pngbuf,g2int *width,g2int *height,char *cout)
     /*printf("SAGT:png %d %d %d\n",info_ptr->width,info_ptr->height,info_ptr->bit_depth);*/
     // (void)png_get_IHDR(png_ptr, info_ptr, (png_uint_32 *)width, (png_uint_32 *)height,
     (void)png_get_IHDR(png_ptr, info_ptr, &w32, &h32,
-               &bit_depth, &color, &interlace, &compres, &filter);
+                       &bit_depth, &color, &interlace, &compres, &filter);
 
     *height = h32;
     *width = w32;
@@ -114,15 +114,15 @@ int dec_png(unsigned char *pngbuf,g2int *width,g2int *height,char *cout)
 /*     Check if image was grayscale      */
 
 /*
-    if (color != PNG_COLOR_TYPE_GRAY ) {
-       fprintf(stderr,"dec_png: Grayscale image was expected. \n");
-    }
+  if (color != PNG_COLOR_TYPE_GRAY ) {
+  fprintf(stderr,"dec_png: Grayscale image was expected. \n");
+  }
 */
     if ( color == PNG_COLOR_TYPE_RGB ) {
-       bit_depth=24;
+        bit_depth=24;
     }
     else if ( color == PNG_COLOR_TYPE_RGB_ALPHA ) {
-       bit_depth=32;
+        bit_depth=32;
     }
 /*     Copy image data to output string   */
 
@@ -130,10 +130,10 @@ int dec_png(unsigned char *pngbuf,g2int *width,g2int *height,char *cout)
     bytes=bit_depth/8;
     clen=(*width)*bytes;
     for (j=0;j<*height;j++) {
-      for (k=0;k<clen;k++) {
-        cout[n]=*(row_pointers[j]+k);
-        n++;
-      }
+        for (k=0;k<clen;k++) {
+            cout[n]=*(row_pointers[j]+k);
+            n++;
+        }
     }
 
 /*      Clean up   */

--- a/src/decenc_openjpeg.c
+++ b/src/decenc_openjpeg.c
@@ -131,60 +131,60 @@ static void opj_memory_stream_do_nothing(void * p_user_data)
 /* Create a stream to use memory as the input or output */
 static opj_stream_t* opj_stream_create_default_memory_stream(opj_memory_stream* memoryStream, OPJ_BOOL is_read_stream)
 {
-	opj_stream_t* stream;
+    opj_stream_t* stream;
 
-	if (!(stream = opj_stream_default_create(is_read_stream)))
-		return (NULL);
+    if (!(stream = opj_stream_default_create(is_read_stream)))
+        return (NULL);
     /* Set how to work with the frame buffer */
-	if (is_read_stream)
-		opj_stream_set_read_function(stream, opj_memory_stream_read);
-	else
-		opj_stream_set_write_function(stream, opj_memory_stream_write);
+    if (is_read_stream)
+        opj_stream_set_read_function(stream, opj_memory_stream_read);
+    else
+        opj_stream_set_write_function(stream, opj_memory_stream_write);
 
-	opj_stream_set_seek_function(stream, opj_memory_stream_seek);
-	opj_stream_set_skip_function(stream, opj_memory_stream_skip);
-	opj_stream_set_user_data(stream, memoryStream, opj_memory_stream_do_nothing);
-	opj_stream_set_user_data_length(stream, memoryStream->dataSize);
-	return stream;
+    opj_stream_set_seek_function(stream, opj_memory_stream_seek);
+    opj_stream_set_skip_function(stream, opj_memory_stream_skip);
+    opj_stream_set_user_data(stream, memoryStream, opj_memory_stream_do_nothing);
+    opj_stream_set_user_data_length(stream, memoryStream->dataSize);
+    return stream;
 }
 
 int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
 /*$$$  SUBPROGRAM DOCUMENTATION BLOCK
-*                .      .    .                                       .
-* SUBPROGRAM:    dec_jpeg2000      Decodes JPEG2000 code stream
-*   PRGMMR: Jovic            ORG: W/NP11     DATE: 2020-06-08
-*
-* ABSTRACT: This Function decodes a JPEG2000 code stream specified in the
-*   JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using OpenJPEG
-*
-* PROGRAM HISTORY LOG:
-* 2002-12-02  Gilbert
-* 2016-06-08  Jovic
-*
-* USAGE:     int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
-*
-*   INPUT ARGUMENTS:
-*      injpc - Input JPEG2000 code stream.
-*    bufsize - Length (in bytes) of the input JPEG2000 code stream.
-*
-*   OUTPUT ARGUMENTS:
-*     outfld - Output matrix of grayscale image values.
-*
-*   RETURN VALUES :
-*          0 = Successful decode
-*         -3 = Error decode jpeg2000 code stream.
-*         -5 = decoded image had multiple color components.
-*              Only grayscale is expected.
-*
-* REMARKS:
-*
-*      Requires OpenJPEG Version 2
-*
-* ATTRIBUTES:
-*   LANGUAGE: C
-*   MACHINE:  Linux
-*
-*$$$*/
+ *                .      .    .                                       .
+ * SUBPROGRAM:    dec_jpeg2000      Decodes JPEG2000 code stream
+ *   PRGMMR: Jovic            ORG: W/NP11     DATE: 2020-06-08
+ *
+ * ABSTRACT: This Function decodes a JPEG2000 code stream specified in the
+ *   JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using OpenJPEG
+ *
+ * PROGRAM HISTORY LOG:
+ * 2002-12-02  Gilbert
+ * 2016-06-08  Jovic
+ *
+ * USAGE:     int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
+ *
+ *   INPUT ARGUMENTS:
+ *      injpc - Input JPEG2000 code stream.
+ *    bufsize - Length (in bytes) of the input JPEG2000 code stream.
+ *
+ *   OUTPUT ARGUMENTS:
+ *     outfld - Output matrix of grayscale image values.
+ *
+ *   RETURN VALUES :
+ *          0 = Successful decode
+ *         -3 = Error decode jpeg2000 code stream.
+ *         -5 = decoded image had multiple color components.
+ *              Only grayscale is expected.
+ *
+ * REMARKS:
+ *
+ *      Requires OpenJPEG Version 2
+ *
+ * ATTRIBUTES:
+ *   LANGUAGE: C
+ *   MACHINE:  Linux
+ *
+ *$$$*/
 {
     int iret = 0;
     OPJ_INT32 mask;
@@ -194,7 +194,7 @@ int dec_jpeg2000(char *injpc,g2int bufsize,g2int *outfld)
     opj_codec_t *codec = NULL;
 
     /* set decoding parameters to default values */
-    opj_dparameters_t parameters = {0,};	/* decompression parameters */
+    opj_dparameters_t parameters = {0,};        /* decompression parameters */
     opj_set_default_decoder_parameters(&parameters);
     parameters.decod_format = 1; /* JP2_FMT */
 
@@ -270,57 +270,57 @@ int enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
                  g2int ltype, g2int ratio, g2int retry, char *outjpc,
                  g2int jpclen)
 /*$$$  SUBPROGRAM DOCUMENTATION BLOCK
-*                .      .    .                                       .
-* SUBPROGRAM:    enc_jpeg2000      Encodes JPEG2000 code stream
-*   PRGMMR: Jovic            ORG: W/NP11     DATE: 2020-06-08
-*
-* ABSTRACT: This Function encodes a grayscale image into a JPEG2000 code stream
-*   specified in the JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1)
-*   using OpenJPEG library
-*
-* PROGRAM HISTORY LOG:
-* 2002-12-02  Gilbert
-* 2016-06-08  Jovic
-*
-* USAGE:    int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,
-*                            g2int nbits, g2int ltype, g2int ratio,
-*                            g2int retry, char *outjpc, g2int jpclen)
-*
-*   INPUT ARGUMENTS:
-*      cin   - Packed matrix of Grayscale image values to encode.
-*     width  - width of image
-*     height - height of image
-*     nbits  - depth (in bits) of image.  i.e number of bits
-*              used to hold each data value
-*    ltype   - indicator of lossless or lossy compression
-*              = 1, for lossy compression
-*              != 1, for lossless compression
-*    ratio   - target compression ratio.  (ratio:1)
-*              Used only when ltype == 1.
-*    retry   - Pointer to option type.
-*              1 = try increasing number of guard bits
-*              otherwise, no additional options
-*    jpclen  - Number of bytes allocated for new JPEG2000 code stream in
-*              outjpc.
-*
-*   INPUT ARGUMENTS:
-*     outjpc - Output encoded JPEG2000 code stream
-*
-*   RETURN VALUES :
-*        > 0 = Length in bytes of encoded JPEG2000 code stream
-*         -3 = Error decode jpeg2000 code stream.
-*         -5 = decoded image had multiple color components.
-*              Only grayscale is expected.
-*
-* REMARKS:
-*
-*      Requires OpenJPEG Version 2.
-*
-* ATTRIBUTES:
-*   LANGUAGE: C
-*   MACHINE:  Linux
-*
-*$$$*/
+ *                .      .    .                                       .
+ * SUBPROGRAM:    enc_jpeg2000      Encodes JPEG2000 code stream
+ *   PRGMMR: Jovic            ORG: W/NP11     DATE: 2020-06-08
+ *
+ * ABSTRACT: This Function encodes a grayscale image into a JPEG2000 code stream
+ *   specified in the JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1)
+ *   using OpenJPEG library
+ *
+ * PROGRAM HISTORY LOG:
+ * 2002-12-02  Gilbert
+ * 2016-06-08  Jovic
+ *
+ * USAGE:    int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,
+ *                            g2int nbits, g2int ltype, g2int ratio,
+ *                            g2int retry, char *outjpc, g2int jpclen)
+ *
+ *   INPUT ARGUMENTS:
+ *      cin   - Packed matrix of Grayscale image values to encode.
+ *     width  - width of image
+ *     height - height of image
+ *     nbits  - depth (in bits) of image.  i.e number of bits
+ *              used to hold each data value
+ *    ltype   - indicator of lossless or lossy compression
+ *              = 1, for lossy compression
+ *              != 1, for lossless compression
+ *    ratio   - target compression ratio.  (ratio:1)
+ *              Used only when ltype == 1.
+ *    retry   - Pointer to option type.
+ *              1 = try increasing number of guard bits
+ *              otherwise, no additional options
+ *    jpclen  - Number of bytes allocated for new JPEG2000 code stream in
+ *              outjpc.
+ *
+ *   INPUT ARGUMENTS:
+ *     outjpc - Output encoded JPEG2000 code stream
+ *
+ *   RETURN VALUES :
+ *        > 0 = Length in bytes of encoded JPEG2000 code stream
+ *         -3 = Error decode jpeg2000 code stream.
+ *         -5 = decoded image had multiple color components.
+ *              Only grayscale is expected.
+ *
+ * REMARKS:
+ *
+ *      Requires OpenJPEG Version 2.
+ *
+ * ATTRIBUTES:
+ *   LANGUAGE: C
+ *   MACHINE:  Linux
+ *
+ *$$$*/
 {
     (void) retry;
     int iret = 0;
@@ -331,7 +331,7 @@ int enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
     opj_stream_t *stream = NULL;
 
     /* set encoding parameters to default values */
-    opj_cparameters_t parameters = {0,};	/* compression parameters */
+    opj_cparameters_t parameters = {0,};        /* compression parameters */
     opj_set_default_encoder_parameters(&parameters);
 
     parameters.tcp_numlayers  = 1;

--- a/src/drstemplates.c
+++ b/src/drstemplates.c
@@ -5,155 +5,154 @@
 #include "drstemplates.h"
 
 /*!$$$  SUBPROGRAM DOCUMENTATION BLOCK
-!                .      .    .                                       .
-! SUBPROGRAM:    getdrsindex 
-!   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2001-06-28
-!
-! ABSTRACT: This function returns the index of specified Data 
-!   Representation Template 5.NN (NN=number) in array templates.
-!
-! PROGRAM HISTORY LOG:
-! 2001-06-28  Gilbert
-! 2009-01-14  Vuong     Changed structure name template to gtemplate
-!
-! USAGE:    index=getdrsindex(number)
-!   INPUT ARGUMENT LIST:
-!     number   - NN, indicating the number of the Data Representation 
-!                Template 5.NN that is being requested.
-!
-! RETURNS:  Index of DRT 5.NN in array gtemplates, if gtemplate exists.
-!           = -1, otherwise.
-!
-! REMARKS: None
-!
-! ATTRIBUTES:
-!   LANGUAGE: C
-!   MACHINE:  IBM SP
-!
-!$$$*/
+  !                .      .    .                                       .
+  ! SUBPROGRAM:    getdrsindex
+  !   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2001-06-28
+  !
+  ! ABSTRACT: This function returns the index of specified Data
+  !   Representation Template 5.NN (NN=number) in array templates.
+  !
+  ! PROGRAM HISTORY LOG:
+  ! 2001-06-28  Gilbert
+  ! 2009-01-14  Vuong     Changed structure name template to gtemplate
+  !
+  ! USAGE:    index=getdrsindex(number)
+  !   INPUT ARGUMENT LIST:
+  !     number   - NN, indicating the number of the Data Representation
+  !                Template 5.NN that is being requested.
+  !
+  ! RETURNS:  Index of DRT 5.NN in array gtemplates, if gtemplate exists.
+  !           = -1, otherwise.
+  !
+  ! REMARKS: None
+  !
+  ! ATTRIBUTES:
+  !   LANGUAGE: C
+  !   MACHINE:  IBM SP
+  !
+  !$$$*/
 g2int getdrsindex(g2int number)
 {
-           g2int j,getdrsindex=-1;
+    g2int j,getdrsindex=-1;
 
-           for (j=0;j<MAXDRSTEMP;j++) {
-              if (number == templatesdrs[j].template_num) {
-                 getdrsindex=j;
-                 return(getdrsindex);
-              }
-           }
+    for (j=0;j<MAXDRSTEMP;j++) {
+        if (number == templatesdrs[j].template_num) {
+            getdrsindex=j;
+            return(getdrsindex);
+        }
+    }
 
-           return(getdrsindex);
+    return(getdrsindex);
 }
 
 
 /*!$$$  SUBPROGRAM DOCUMENTATION BLOCK
-!                .      .    .                                       .
-! SUBPROGRAM:    getdrstemplate 
-!   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2000-05-11
-!
-! ABSTRACT: This subroutine returns DRS template information for a 
-!   specified Data Representation Template 5.NN.
-!   The number of entries in the template is returned along with a map
-!   of the number of octets occupied by each entry.  Also, a flag is
-!   returned to indicate whether the template would need to be extended.
-!
-! PROGRAM HISTORY LOG:
-! 2000-05-11  Gilbert
-! 2009-01-14  Vuong     Changed structure name template to gtemplate
-!
-! USAGE:    new=getdrstemplate(number);
-!   INPUT ARGUMENT LIST:
-!     number   - NN, indicating the number of the Data Representation 
-!                Template 5.NN that is being requested.
-!
-!   RETURN VALUE:      
-!        - Pointer to the returned template struct. 
-!          Returns NULL pointer, if template not found.
-!
-! REMARKS: None
-!
-! ATTRIBUTES:
-!   LANGUAGE: C
-!   MACHINE:  IBM SP
-!
-!$$$*/
+  !                .      .    .                                       .
+  ! SUBPROGRAM:    getdrstemplate
+  !   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2000-05-11
+  !
+  ! ABSTRACT: This subroutine returns DRS template information for a
+  !   specified Data Representation Template 5.NN.
+  !   The number of entries in the template is returned along with a map
+  !   of the number of octets occupied by each entry.  Also, a flag is
+  !   returned to indicate whether the template would need to be extended.
+  !
+  ! PROGRAM HISTORY LOG:
+  ! 2000-05-11  Gilbert
+  ! 2009-01-14  Vuong     Changed structure name template to gtemplate
+  !
+  ! USAGE:    new=getdrstemplate(number);
+  !   INPUT ARGUMENT LIST:
+  !     number   - NN, indicating the number of the Data Representation
+  !                Template 5.NN that is being requested.
+  !
+  !   RETURN VALUE:
+  !        - Pointer to the returned template struct.
+  !          Returns NULL pointer, if template not found.
+  !
+  ! REMARKS: None
+  !
+  ! ATTRIBUTES:
+  !   LANGUAGE: C
+  !   MACHINE:  IBM SP
+  !
+  !$$$*/
 gtemplate *getdrstemplate(g2int number)
 {
-           g2int index;
-           gtemplate *new;
+    g2int index;
+    gtemplate *new;
 
-           index=getdrsindex(number);
+    index=getdrsindex(number);
 
-           if (index != -1) {
-              new=(gtemplate *)malloc(sizeof(gtemplate));
-              new->type=5;
-              new->num=templatesdrs[index].template_num;
-              new->maplen=templatesdrs[index].mapdrslen;
-              new->needext=templatesdrs[index].needext;
-              new->map=(g2int *)templatesdrs[index].mapdrs;
-              new->extlen=0;
-              new->ext=0;        //NULL
-              return(new);
-           }
-           else {
-             printf("getdrstemplate: DRS Template 5.%d not defined.\n",(int)number);
-             return(0);        //NULL
-           }
+    if (index != -1) {
+        new=(gtemplate *)malloc(sizeof(gtemplate));
+        new->type=5;
+        new->num=templatesdrs[index].template_num;
+        new->maplen=templatesdrs[index].mapdrslen;
+        new->needext=templatesdrs[index].needext;
+        new->map=(g2int *)templatesdrs[index].mapdrs;
+        new->extlen=0;
+        new->ext=0;        //NULL
+        return(new);
+    }
+    else {
+        printf("getdrstemplate: DRS Template 5.%d not defined.\n",(int)number);
+        return(0);        //NULL
+    }
 
-         return(0);        //NULL
+    return(0);        //NULL
 }
 
 /*!$$$  SUBPROGRAM DOCUMENTATION BLOCK
-!                .      .    .                                       .
-! SUBPROGRAM:    extdrstemplate 
-!   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2000-05-11
-!
-! ABSTRACT: This subroutine generates the remaining octet map for a
-!   given Data Representation Template, if required.  Some Templates can
-!   vary depending on data values given in an earlier part of the 
-!   Template, and it is necessary to know some of the earlier entry
-!   values to generate the full octet map of the Template.
-!
-! PROGRAM HISTORY LOG:
-! 2000-05-11  Gilbert
-! 2009-01-14  Vuong     Changed structure name template to gtemplate
-!
-! USAGE:    new=extdrstemplate(number,list);
-!   INPUT ARGUMENT LIST:
-!     number   - NN, indicating the number of the Data Representation 
-!                Template 5.NN that is being requested.
-!     list()   - The list of values for each entry in the 
-!                the Data Representation Template 5.NN.
-!
-!   RETURN VALUE:      
-!        - Pointer to the returned template struct. 
-!          Returns NULL pointer, if template not found.
-!
-! ATTRIBUTES:
-!   LANGUAGE: C
-!   MACHINE:  IBM SP
-!
-!$$$*/
+  !                .      .    .                                       .
+  ! SUBPROGRAM:    extdrstemplate
+  !   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2000-05-11
+  !
+  ! ABSTRACT: This subroutine generates the remaining octet map for a
+  !   given Data Representation Template, if required.  Some Templates can
+  !   vary depending on data values given in an earlier part of the
+  !   Template, and it is necessary to know some of the earlier entry
+  !   values to generate the full octet map of the Template.
+  !
+  ! PROGRAM HISTORY LOG:
+  ! 2000-05-11  Gilbert
+  ! 2009-01-14  Vuong     Changed structure name template to gtemplate
+  !
+  ! USAGE:    new=extdrstemplate(number,list);
+  !   INPUT ARGUMENT LIST:
+  !     number   - NN, indicating the number of the Data Representation
+  !                Template 5.NN that is being requested.
+  !     list()   - The list of values for each entry in the
+  !                the Data Representation Template 5.NN.
+  !
+  !   RETURN VALUE:
+  !        - Pointer to the returned template struct.
+  !          Returns NULL pointer, if template not found.
+  !
+  ! ATTRIBUTES:
+  !   LANGUAGE: C
+  !   MACHINE:  IBM SP
+  !
+  !$$$*/
 gtemplate *extdrstemplate(g2int number,g2int *list)
 {
-           gtemplate *new;
-           g2int index,i;
+    gtemplate *new;
+    g2int index,i;
 
-           index=getdrsindex(number);
-           if (index == -1) return(0);
+    index=getdrsindex(number);
+    if (index == -1) return(0);
 
-           new=getdrstemplate(number);
+    new=getdrstemplate(number);
 
-           if ( ! new->needext ) return(new);
+    if ( ! new->needext ) return(new);
 
-           if ( number == 1 ) {
-              new->extlen=list[10]+list[12];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<new->extlen;i++) {
-                new->ext[i]=4;
-              }
-           }
-           return(new);
+    if ( number == 1 ) {
+        new->extlen=list[10]+list[12];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=4;
+        }
+    }
+    return(new);
 
 }
-

--- a/src/drstemplates.h
+++ b/src/drstemplates.h
@@ -1,7 +1,7 @@
 /** @file
  *  @author Gilbert @date 2002-10-26
  *
- *  This Fortran Module contains info on all the available 
+ *  This Fortran Module contains info on all the available
  *   GRIB2 Data Representation Templates used in Section 5 (DRS).
  *   The information decribing each template is stored in the
  *   drstemplate structure defined below.
@@ -9,12 +9,12 @@
  *   Each Template has three parts: The number of entries in the template
  *   (mapdrslen);  A map of the template (mapdrs), which contains the
  *   number of octets in which to pack each of the template values; and
- *   a logical value (needext) that indicates whether the Template needs 
- *   to be extended.  In some cases the number of entries in a template 
- *   can vary depending upon values specified in the "static" part of 
+ *   a logical value (needext) that indicates whether the Template needs
+ *   to be extended.  In some cases the number of entries in a template
+ *   can vary depending upon values specified in the "static" part of
  *   the template.  ( See Template 5.1 as an example )
  *
- *   NOTE:  Array mapdrs contains the number of octets in which the 
+ *   NOTE:  Array mapdrs contains the number of octets in which the
  *   corresponding template values will be stored.  A negative value in
  *   mapdrs is used to indicate that the corresponding template entry can
  *   contain negative values.  This information is used later when packing
@@ -22,45 +22,45 @@
  *   are stored with the left most bit set to one, and a negative number
  *   of octets value in mapdrs[] indicates that this possibility should
  *   be considered.  The number of octets used to store the data value
- *   in this case would be the absolute value of the negative value in 
+ *   in this case would be the absolute value of the negative value in
  *   mapdrs[].
  */
 #ifndef _drstemplates_H
 #define _drstemplates_H
 #include "grib2.h"
-      #define MAXDRSTEMP 9              // maximum number of templates
-      #define MAXDRSMAPLEN 200          // maximum template map length
+#define MAXDRSTEMP 9              // maximum number of templates
+#define MAXDRSMAPLEN 200          // maximum template map length
 
-      struct drstemplate
-      {
-          g2int template_num;
-          g2int mapdrslen;
-          g2int needext;
-          g2int mapdrs[MAXDRSMAPLEN];
-      };
+struct drstemplate
+{
+    g2int template_num;
+    g2int mapdrslen;
+    g2int needext;
+    g2int mapdrs[MAXDRSMAPLEN];
+};
 
-      const struct drstemplate templatesdrs[MAXDRSTEMP] = {
-             // 5.0: Grid point data - Simple Packing
-         { 0, 5, 0, {4,-2,-2,1,1} },
-             // 5.2: Grid point data - Complex Packing
-         { 2, 16, 0, {4,-2,-2,1,1,1,1,4,4,4,1,1,4,1,4,1} },
-             // 5.3: Grid point data - Complex Packing and spatial differencing
-         { 3, 18, 0, {4,-2,-2,1,1,1,1,4,4,4,1,1,4,1,4,1,1,1} },
-             // 5.50: Spectral Data - Simple Packing
-         { 50, 5, 0, {4,-2,-2,1,4} },
-             // 5.51: Spherical Harmonics data - Complex packing 
-         { 51, 10, 0, {4,-2,-2,1,-4,2,2,2,4,1} },
+const struct drstemplate templatesdrs[MAXDRSTEMP] = {
+    // 5.0: Grid point data - Simple Packing
+    { 0, 5, 0, {4,-2,-2,1,1} },
+    // 5.2: Grid point data - Complex Packing
+    { 2, 16, 0, {4,-2,-2,1,1,1,1,4,4,4,1,1,4,1,4,1} },
+    // 5.3: Grid point data - Complex Packing and spatial differencing
+    { 3, 18, 0, {4,-2,-2,1,1,1,1,4,4,4,1,1,4,1,4,1,1,1} },
+    // 5.50: Spectral Data - Simple Packing
+    { 50, 5, 0, {4,-2,-2,1,4} },
+    // 5.51: Spherical Harmonics data - Complex packing
+    { 51, 10, 0, {4,-2,-2,1,-4,2,2,2,4,1} },
 //           // 5.1: Matrix values at gridpoint - Simple packing
 //         { 1, 15, 1, {4,-2,-2,1,1,1,4,2,2,1,1,1,1,1,1} },
-             // 5.40: Grid point data - JPEG2000 encoding
-         { 40, 7, 0, {4,-2,-2,1,1,1,1} },
-             // 5.41: Grid point data - PNG encoding
-         { 41, 5, 0, {4,-2,-2,1,1} },
-             // 5.40000: Grid point data - JPEG2000 encoding
-         { 40000, 7, 0, {4,-2,-2,1,1,1,1} },
-             // 5.40010: Grid point data - PNG encoding
-         { 40010, 5, 0, {4,-2,-2,1,1} }
-      } ;
+    // 5.40: Grid point data - JPEG2000 encoding
+    { 40, 7, 0, {4,-2,-2,1,1,1,1} },
+    // 5.41: Grid point data - PNG encoding
+    { 41, 5, 0, {4,-2,-2,1,1} },
+    // 5.40000: Grid point data - JPEG2000 encoding
+    { 40000, 7, 0, {4,-2,-2,1,1,1,1} },
+    // 5.40010: Grid point data - PNG encoding
+    { 40010, 5, 0, {4,-2,-2,1,1} }
+} ;
 
 
 #endif  /*  _drstemplates_H  */

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -1,7 +1,7 @@
 /** @file
  */
 #ifndef USE_JPEG2000
- void dummy(void) {}
+void dummy(void) {}
 #else   /* USE_JPEG2000 */
 
 #include <stdio.h>
@@ -12,63 +12,63 @@
 
 
 /*$$$  SUBPROGRAM DOCUMENTATION BLOCK
-*                .      .    .                                       .
-* SUBPROGRAM:    enc_jpeg2000      Encodes JPEG2000 code stream
-*   PRGMMR: Gilbert          ORG: W/NP11     DATE: 2002-12-02
-*
-* ABSTRACT: This Function encodes a grayscale image into a JPEG2000 code stream
-*   specified in the JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) 
-*   using JasPer Software version 1.500.4 (or 1.700.2 ) written by the 
-*   University of British Columbia, Image Power Inc, and others.
-*   JasPer is available at http://www.ece.uvic.ca/~mdadams/jasper/.
-*
-* PROGRAM HISTORY LOG:
-* 2002-12-02  Gilbert
-* 2004-12-16  Gilbert - Added retry argument/option to allow option of
-*                       increasing the maximum number of guard bits to the
-*                       JPEG2000 algorithm.
-*
-* USAGE:    int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,
-*                            g2int nbits, g2int ltype, g2int ratio, 
-*                            g2int retry, char *outjpc, g2int jpclen)
-*
-*   INPUT ARGUMENTS:
-*      cin   - Packed matrix of Grayscale image values to encode.
-*     width  - width of image
-*     height - height of image
-*     nbits  - depth (in bits) of image.  i.e number of bits
-*              used to hold each data value
-*    ltype   - indicator of lossless or lossy compression
-*              = 1, for lossy compression
-*              != 1, for lossless compression
-*    ratio   - target compression ratio.  (ratio:1)
-*              Used only when ltype == 1.
-*    retry   - Pointer to option type.
-*              1 = try increasing number of guard bits
-*              otherwise, no additional options
-*    jpclen  - Number of bytes allocated for new JPEG2000 code stream in
-*              outjpc.
-*
-*   INPUT ARGUMENTS:
-*     outjpc - Output encoded JPEG2000 code stream
-*
-*   RETURN VALUES :
-*        > 0 = Length in bytes of encoded JPEG2000 code stream
-*         -3 = Error decode jpeg2000 code stream.
-*         -5 = decoded image had multiple color components.
-*              Only grayscale is expected.
-*
-* REMARKS:
-*
-*      Requires JasPer Software version 1.500.4 or 1.700.2
-*
-* ATTRIBUTES:
-*   LANGUAGE: C
-*   MACHINE:  IBM SP
-*
-*$$$*/
+ *                .      .    .                                       .
+ * SUBPROGRAM:    enc_jpeg2000      Encodes JPEG2000 code stream
+ *   PRGMMR: Gilbert          ORG: W/NP11     DATE: 2002-12-02
+ *
+ * ABSTRACT: This Function encodes a grayscale image into a JPEG2000 code stream
+ *   specified in the JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1)
+ *   using JasPer Software version 1.500.4 (or 1.700.2 ) written by the
+ *   University of British Columbia, Image Power Inc, and others.
+ *   JasPer is available at http://www.ece.uvic.ca/~mdadams/jasper/.
+ *
+ * PROGRAM HISTORY LOG:
+ * 2002-12-02  Gilbert
+ * 2004-12-16  Gilbert - Added retry argument/option to allow option of
+ *                       increasing the maximum number of guard bits to the
+ *                       JPEG2000 algorithm.
+ *
+ * USAGE:    int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,
+ *                            g2int nbits, g2int ltype, g2int ratio,
+ *                            g2int retry, char *outjpc, g2int jpclen)
+ *
+ *   INPUT ARGUMENTS:
+ *      cin   - Packed matrix of Grayscale image values to encode.
+ *     width  - width of image
+ *     height - height of image
+ *     nbits  - depth (in bits) of image.  i.e number of bits
+ *              used to hold each data value
+ *    ltype   - indicator of lossless or lossy compression
+ *              = 1, for lossy compression
+ *              != 1, for lossless compression
+ *    ratio   - target compression ratio.  (ratio:1)
+ *              Used only when ltype == 1.
+ *    retry   - Pointer to option type.
+ *              1 = try increasing number of guard bits
+ *              otherwise, no additional options
+ *    jpclen  - Number of bytes allocated for new JPEG2000 code stream in
+ *              outjpc.
+ *
+ *   INPUT ARGUMENTS:
+ *     outjpc - Output encoded JPEG2000 code stream
+ *
+ *   RETURN VALUES :
+ *        > 0 = Length in bytes of encoded JPEG2000 code stream
+ *         -3 = Error decode jpeg2000 code stream.
+ *         -5 = decoded image had multiple color components.
+ *              Only grayscale is expected.
+ *
+ * REMARKS:
+ *
+ *      Requires JasPer Software version 1.500.4 or 1.700.2
+ *
+ * ATTRIBUTES:
+ *   LANGUAGE: C
+ *   MACHINE:  IBM SP
+ *
+ *$$$*/
 int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
-                 g2int ltype, g2int ratio, g2int retry, char *outjpc, 
+                 g2int ltype, g2int ratio, g2int retry, char *outjpc,
                  g2int jpclen)
 {
     int ier,rwcnt;
@@ -79,10 +79,10 @@ int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
     char opts[MAXOPTSSIZE];
 
 /*
-    printf(" enc_jpeg2000:width %ld\n",width);
-    printf(" enc_jpeg2000:height %ld\n",height);
-    printf(" enc_jpeg2000:nbits %ld\n",nbits);
-    printf(" enc_jpeg2000:jpclen %ld\n",jpclen);
+  printf(" enc_jpeg2000:width %ld\n",width);
+  printf(" enc_jpeg2000:height %ld\n",height);
+  printf(" enc_jpeg2000:nbits %ld\n",nbits);
+  printf(" enc_jpeg2000:jpclen %ld\n",jpclen);
 */
 //    jas_init();
 
@@ -90,26 +90,26 @@ int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
 //    Set lossy compression options, if requested.
 //
     if ( ltype != 1 ) {
-       opts[0]=(char)0;
+        opts[0]=(char)0;
     }
     else {
-       snprintf(opts,MAXOPTSSIZE,"mode=real\nrate=%f",1.0/(float)ratio);
+        snprintf(opts,MAXOPTSSIZE,"mode=real\nrate=%f",1.0/(float)ratio);
     }
     if ( retry == 1 ) {             // option to increase number of guard bits
-       strcat(opts,"\nnumgbits=4");
+        strcat(opts,"\nnumgbits=4");
     }
     //printf("SAGopts: %s\n",opts);
-    
+
 //
 //     Initialize the JasPer image structure describing the grayscale
 //     image to encode into the JPEG2000 code stream.
 //
     image.tlx_=0;
     image.tly_=0;
-#ifdef JAS_1_500_4 
+#ifdef JAS_1_500_4
     image.brx_=(uint_fast32_t)width;
     image.bry_=(uint_fast32_t)height;
-#endif 
+#endif
 #ifdef JAS_1_700_2
     image.brx_=(jas_image_coord_t)width;
     image.bry_=(jas_image_coord_t)height;
@@ -121,7 +121,7 @@ int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
 #endif
 #ifdef JAS_1_700_2
     image.clrspc_=JAS_CLRSPC_SGRAY;         /* grayscale Image */
-    image.cmprof_=0; 
+    image.cmprof_=0;
 #endif
 //    image.inmem_=1;
 
@@ -162,12 +162,12 @@ int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
 //
     ier=jpc_encode(&image,jpcstream,opts);
     if ( ier != 0 ) {
-       printf(" jpc_encode return = %d \n",ier);
-       return -3;
+        printf(" jpc_encode return = %d \n",ier);
+        return -3;
     }
 //
 //     Clean up JasPer work structures.
-//    
+//
     rwcnt=jpcstream->rwcnt_;
     ier=jas_stream_close(istream);
     ier=jas_stream_close(jpcstream);

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -1,7 +1,7 @@
 /** @file
  */
 #ifndef USE_PNG
- void dummy(void) {}
+void dummy(void) {}
 #else   /* USE_PNG */
 
 #include <stdio.h>
@@ -12,8 +12,8 @@
 
 
 struct png_stream {
-   unsigned char *stream_ptr;     /*  location to write PNG stream  */
-   g2int stream_len;               /*  number of bytes written       */
+    unsigned char *stream_ptr;     /*  location to write PNG stream  */
+    g2int stream_len;               /*  number of bytes written       */
 };
 typedef struct png_stream png_stream;
 
@@ -22,37 +22,37 @@ void user_flush_data(png_structp );
 
 void user_write_data(png_structp png_ptr,png_bytep data, png_uint_32 length)
 /*
-        Custom write function used to that libpng will write
-        to memory location instead of a file on disk
+  Custom write function used to that libpng will write
+  to memory location instead of a file on disk
 */
 {
-     unsigned char *ptr;
-     g2int offset;
-     png_stream *mem;
+    unsigned char *ptr;
+    g2int offset;
+    png_stream *mem;
 
-     mem=(png_stream *)png_get_io_ptr(png_ptr);
-     ptr=mem->stream_ptr;
-     offset=mem->stream_len;
+    mem=(png_stream *)png_get_io_ptr(png_ptr);
+    ptr=mem->stream_ptr;
+    offset=mem->stream_len;
 /*     printf("SAGwr %ld %ld %x\n",offset,length,ptr);    */
-     /*for (j=offset,k=0;k<length;j++,k++) ptr[j]=data[k];*/
-     memcpy(ptr+offset,data,length);
-     mem->stream_len += length;
+    /*for (j=offset,k=0;k<length;j++,k++) ptr[j]=data[k];*/
+    memcpy(ptr+offset,data,length);
+    mem->stream_len += length;
 }
 
 
 void user_flush_data(png_structp png_ptr)
 /*
-        Dummy Custom flush function
+  Dummy Custom flush function
 */
 {
-   int *do_nothing;
-   do_nothing=NULL;
+    int *do_nothing;
+    do_nothing=NULL;
 }
 
 
 int enc_png(char *data,g2int width,g2int height,g2int nbits,char *pngbuf)
 {
- 
+
     int color_type;
     g2int j,bytes,pnglen,bit_depth;
     png_structp png_ptr;
@@ -63,24 +63,24 @@ int enc_png(char *data,g2int width,g2int height,g2int nbits,char *pngbuf)
 
 /* create and initialize png_structs  */
 
-    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, (png_voidp)NULL, 
+    png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, (png_voidp)NULL,
                                       NULL, NULL);
     if (!png_ptr)
-       return (-1);
+        return (-1);
 
     info_ptr = png_create_info_struct(png_ptr);
     if (!info_ptr)
     {
-       png_destroy_write_struct(&png_ptr,(png_infopp)NULL);
-       return (-2);
+        png_destroy_write_struct(&png_ptr,(png_infopp)NULL);
+        return (-2);
     }
 
 /*     Set Error callback   */
 
     if (setjmp(png_jmpbuf(png_ptr)))
     {
-       png_destroy_write_struct(&png_ptr, &info_ptr);
-       return (-3);
+        png_destroy_write_struct(&png_ptr, &info_ptr);
+        return (-3);
     }
 
 /*    Initialize info for writing PNG stream to memory   */
@@ -91,7 +91,7 @@ int enc_png(char *data,g2int width,g2int height,g2int nbits,char *pngbuf)
 /*    Set new custom write functions    */
 
     png_set_write_fn(png_ptr,(png_voidp)&write_io_ptr,(png_rw_ptr)user_write_data,
-                    (png_flush_ptr)user_flush_data);
+                     (png_flush_ptr)user_flush_data);
 /*    png_init_io(png_ptr, fptr);   */
 /*    png_set_compression_level(png_ptr, Z_BEST_COMPRESSION);  */
 
@@ -109,8 +109,8 @@ int enc_png(char *data,g2int width,g2int height,g2int nbits,char *pngbuf)
         color_type=PNG_COLOR_TYPE_RGB_ALPHA;
     }
     png_set_IHDR(png_ptr, info_ptr, width, height,
-       bit_depth, color_type, PNG_INTERLACE_NONE,
-       PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
+                 bit_depth, color_type, PNG_INTERLACE_NONE,
+                 PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 
 /*     Put image data into the PNG info structure    */
 

--- a/src/g2_addfield.c
+++ b/src/g2_addfield.c
@@ -11,28 +11,28 @@ void cmplxpack(g2float *, g2int, g2int, g2int *, unsigned char *, g2int *);
 void specpack(g2float *,g2int,g2int,g2int,g2int,g2int *,unsigned char *,
               g2int *);
 #ifdef USE_PNG
-  void pngpack(g2float *,g2int,g2int,g2int *,unsigned char *,g2int *);
+void pngpack(g2float *,g2int,g2int,g2int *,unsigned char *,g2int *);
 #endif  /* USE_PNG */
 #if defined USE_JPEG2000 || defined USE_OPENJPEG
-  void jpcpack(g2float *,g2int,g2int,g2int *,unsigned char *,g2int *);
+void jpcpack(g2float *,g2int,g2int,g2int *,unsigned char *,g2int *);
 #endif  /* USE_JPEG2000 */
 
 
 //$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    g2_addfield 
+// SUBPROGRAM:    g2_addfield
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2002-11-05
 //
 // ABSTRACT: This routine packs up Sections 4 through 7 for a given field
 //   and adds them to a GRIB2 message.  They are Product Definition Section,
-//   Data Representation Section, Bit-Map Section and Data Section, 
+//   Data Representation Section, Bit-Map Section and Data Section,
 //   respectively.
-//   This routine is used with routines "g2_create", "g2_addlocal", 
-//   "g2_addgrid", and "g2_gribend" to create a complete GRIB2 message.  
+//   This routine is used with routines "g2_create", "g2_addlocal",
+//   "g2_addgrid", and "g2_gribend" to create a complete GRIB2 message.
 //   g2_create must be called first to initialize a new GRIB2 message.
 //   Also, routine g2_addgrid must be called after g2_create and
 //   before this routine to add the appropriate grid description to
-//   the GRIB2 message.   Also, a call to g2_gribend is required to complete 
+//   the GRIB2 message.   Also, a call to g2_gribend is required to complete
 //   GRIB2 message after all fields have been added.
 //
 // PROGRAM HISTORY LOG:
@@ -55,7 +55,7 @@ void specpack(g2float *,g2int,g2int,g2int,g2int,g2int *,unsigned char *,
 //                4 through 7 should be added.
 //     ipdsnum  - Product Definition Template Number ( see Code Table 4.0)
 //     ipdstmpl - Contains the data values for the specified Product Definition
-//                Template ( N=ipdsnum ).  Each element of this integer 
+//                Template ( N=ipdsnum ).  Each element of this integer
 //                array contains an entry (in the order specified) of Product
 //                Defintion Template 4.N
 //     coordlist- Array containg floating point values intended to document
@@ -64,7 +64,7 @@ void specpack(g2float *,g2int,g2int,g2int,g2int,g2int *,unsigned char *,
 //     numcoord - number of values in array coordlist.
 //     idrsnum  - Data Representation Template Number ( see Code Table 5.0 )
 //     idrstmpl - Contains the data values for the specified Data Representation
-//                Template ( N=idrsnum ).  Each element of this integer 
+//                Template ( N=idrsnum ).  Each element of this integer
 //                array contains an entry (in the order specified) of Data
 //                Representation Template 5.N
 //                Note that some values in this template (eg. reference
@@ -82,7 +82,7 @@ void specpack(g2float *,g2int,g2int,g2int,g2int,g2int *,unsigned char *,
 //                255 = Bit map does not apply to this product.
 //     bmap[]   - Integer array containing bitmap to be added. ( if ibmap=0 )
 //
-//   OUTPUT ARGUMENT LIST:      
+//   OUTPUT ARGUMENT LIST:
 //     cgrib    - Character array to contain the updated GRIB2 message.
 //                Must be allocated large enough to store the entire
 //                GRIB2 message.
@@ -109,99 +109,99 @@ void specpack(g2float *,g2int,g2int,g2int,g2int,g2int *,unsigned char *,
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$
 g2int g2_addfield(unsigned char *cgrib,g2int ipdsnum,g2int *ipdstmpl,
-                g2float *coordlist,g2int numcoord,g2int idrsnum,g2int *idrstmpl,
-                g2float *fld,g2int ngrdpts,g2int ibmap,g2int *bmap)
+                  g2float *coordlist,g2int numcoord,g2int idrsnum,g2int *idrstmpl,
+                  g2float *fld,g2int ngrdpts,g2int ibmap,g2int *bmap)
 {
-      g2int ierr;
-      static unsigned char G=0x47;       // 'G'
-      static unsigned char R=0x52;       // 'R'
-      static unsigned char I=0x49;       // 'I'
-      static unsigned char B=0x42;       // 'B'
-      static unsigned char s7=0x37;   // '7'
+    g2int ierr;
+    static unsigned char G=0x47;       // 'G'
+    static unsigned char R=0x52;       // 'R'
+    static unsigned char I=0x49;       // 'I'
+    static unsigned char B=0x42;       // 'B'
+    static unsigned char s7=0x37;   // '7'
 
-      unsigned char *cpack;
-      static g2int  zero=0,one=1,four=4,five=5,six=6,seven=7;
-      const g2int  minsize=50000;
-      g2int   iofst,ibeg,lencurr,len,nsize;
-      g2int   ilen,isecnum,i,nbits,temp,left;
-      g2int   ibmprev,j,lcpack,ioctet,newlen,ndpts;
-      g2int   lensec4,lensec5,lensec6,lensec7;
-      g2int   issec3,isprevbmap,lpos3=0,JJ,KK,MM;
-      g2int   *coordieee;
-      g2int   width,height,iscan,itemp;
-      g2float *pfld;
-      gtemplate  *mappds,*mapdrs;
-      unsigned int allones=4294967295u;
- 
-      ierr=0;
+    unsigned char *cpack;
+    static g2int  zero=0,one=1,four=4,five=5,six=6,seven=7;
+    const g2int  minsize=50000;
+    g2int   iofst,ibeg,lencurr,len,nsize;
+    g2int   ilen,isecnum,i,nbits,temp,left;
+    g2int   ibmprev,j,lcpack,ioctet,newlen,ndpts;
+    g2int   lensec4,lensec5,lensec6,lensec7;
+    g2int   issec3,isprevbmap,lpos3=0,JJ,KK,MM;
+    g2int   *coordieee;
+    g2int   width,height,iscan,itemp;
+    g2float *pfld;
+    gtemplate  *mappds,*mapdrs;
+    unsigned int allones=4294967295u;
+
+    ierr=0;
 //
 //  Check to see if beginning of GRIB message exists
 //
-      if ( cgrib[0]!=G || cgrib[1]!=R || cgrib[2]!=I || cgrib[3]!=B ) {
+    if ( cgrib[0]!=G || cgrib[1]!=R || cgrib[2]!=I || cgrib[3]!=B ) {
         printf("g2_addfield: GRIB not found in given message.\n");
         printf("g2_addfield: Call to routine g2_create required to initialize GRIB messge.\n");
         ierr=-1;
         return(ierr);
-      }
+    }
 //
 //  Get current length of GRIB message
-//  
-      gbit(cgrib,&lencurr,96,32);
+//
+    gbit(cgrib,&lencurr,96,32);
 //
 //  Check to see if GRIB message is already complete
-//  
-      if ( cgrib[lencurr-4]==s7 && cgrib[lencurr-3]==s7 &&
-           cgrib[lencurr-2]==s7 && cgrib[lencurr-1]==s7 ) {
+//
+    if ( cgrib[lencurr-4]==s7 && cgrib[lencurr-3]==s7 &&
+         cgrib[lencurr-2]==s7 && cgrib[lencurr-1]==s7 ) {
         printf("g2_addfield: GRIB message already complete.  Cannot add new section.\n");
         ierr=-2;
         return(ierr);
-      }
+    }
 //
 //  Loop through all current sections of the GRIB message to
 //  find the last section number.
 //
-      issec3=0;
-      isprevbmap=0;
-      len=16;    // length of Section 0
-      for (;;) { 
-      //    Get number and length of next section
+    issec3=0;
+    isprevbmap=0;
+    len=16;    // length of Section 0
+    for (;;) {
+        //    Get number and length of next section
         iofst=len*8;
         gbit(cgrib,&ilen,iofst,32);
         iofst=iofst+32;
         gbit(cgrib,&isecnum,iofst,8);
         iofst=iofst+8;
-      //  Check if previous Section 3 exists
+        //  Check if previous Section 3 exists
         if (isecnum == 3) {
             issec3=1;
             lpos3=len;
         }
-      //  Check if a previous defined bitmap exists
+        //  Check if a previous defined bitmap exists
         if (isecnum == 6) {
-          gbit(cgrib,&ibmprev,iofst,8);
-          iofst=iofst+8;
-          if ((ibmprev >= 0) && (ibmprev <= 253)) isprevbmap=1;
+            gbit(cgrib,&ibmprev,iofst,8);
+            iofst=iofst+8;
+            if ((ibmprev >= 0) && (ibmprev <= 253)) isprevbmap=1;
         }
         len=len+ilen;
-      //    Exit loop if last section reached
+        //    Exit loop if last section reached
         if ( len == lencurr ) break;
-      //    If byte count for each section doesn't match current
-      //    total length, then there is a problem.
+        //    If byte count for each section doesn't match current
+        //    total length, then there is a problem.
         if ( len > lencurr ) {
-          printf("g2_addfield: Section byte counts don''t add to total.\n");
-          printf("g2_addfield: Sum of section byte counts = %ld\n",len);
-          printf("g2_addfield: Total byte count in Section 0 = %ld\n",lencurr);
-          ierr=-3;
-          return(ierr);
+            printf("g2_addfield: Section byte counts don''t add to total.\n");
+            printf("g2_addfield: Sum of section byte counts = %ld\n",len);
+            printf("g2_addfield: Total byte count in Section 0 = %ld\n",lencurr);
+            ierr=-3;
+            return(ierr);
         }
-      }
+    }
 //
 //  Sections 4 through 7 can only be added after section 3 or 7.
 //
-      if ( (isecnum != 3) && (isecnum != 7) ) {
+    if ( (isecnum != 3) && (isecnum != 7) ) {
         printf("g2_addfield: Sections 4-7 can only be added after Section 3 or 7.\n");
         printf("g2_addfield: Section ',isecnum,' was the last found in given GRIB message.\n");
         ierr=-4;
@@ -209,305 +209,305 @@ g2int g2_addfield(unsigned char *cgrib,g2int ipdsnum,g2int *ipdstmpl,
 //
 //  Sections 4 through 7 can only be added if section 3 was previously defined.
 //
-      }
-      else if ( ! issec3) {
+    }
+    else if ( ! issec3) {
         printf("g2_addfield: Sections 4-7 can only be added if Section 3 was previously included.\n");
         printf("g2_addfield: Section 3 was not found in given GRIB message.\n");
         printf("g2_addfield: Call to routine addgrid required to specify Grid definition.\n");
         ierr=-6;
         return(ierr);
-      }
+    }
 //
 //  Add Section 4  - Product Definition Section
 //
-      ibeg=lencurr*8;        //   Calculate offset for beginning of section 4
-      iofst=ibeg+32;         //   leave space for length of section
-      sbit(cgrib,&four,iofst,8);     // Store section number ( 4 )
-      iofst=iofst+8;
-      sbit(cgrib,&numcoord,iofst,16);   // Store num of coordinate values
-      iofst=iofst+16;
-      sbit(cgrib,&ipdsnum,iofst,16);    // Store Prod Def Template num.
-      iofst=iofst+16;
-      //
-      //   Get Product Definition Template
-      //
-      mappds=getpdstemplate(ipdsnum);
-      if (mappds == 0) {          // undefined template
+    ibeg=lencurr*8;        //   Calculate offset for beginning of section 4
+    iofst=ibeg+32;         //   leave space for length of section
+    sbit(cgrib,&four,iofst,8);     // Store section number ( 4 )
+    iofst=iofst+8;
+    sbit(cgrib,&numcoord,iofst,16);   // Store num of coordinate values
+    iofst=iofst+16;
+    sbit(cgrib,&ipdsnum,iofst,16);    // Store Prod Def Template num.
+    iofst=iofst+16;
+    //
+    //   Get Product Definition Template
+    //
+    mappds=getpdstemplate(ipdsnum);
+    if (mappds == 0) {          // undefined template
         ierr=-5;
         return(ierr);
-      }
-      //
-      //   Extend the Product Definition Template, if necessary.
-      //   The number of values in a specific template may vary
-      //   depending on data specified in the "static" part of the
-      //   template.
-      //
-      if ( mappds->needext ) {
+    }
+    //
+    //   Extend the Product Definition Template, if necessary.
+    //   The number of values in a specific template may vary
+    //   depending on data specified in the "static" part of the
+    //   template.
+    //
+    if ( mappds->needext ) {
         free(mappds);
         mappds=extpdstemplate(ipdsnum,ipdstmpl);
-      }
-      //
-      //   Pack up each input value in array ipdstmpl into the
-      //   the appropriate number of octets, which are specified in
-      //   corresponding entries in array mappds.
-      //
-      for (i=0;i<mappds->maplen;i++) {
+    }
+    //
+    //   Pack up each input value in array ipdstmpl into the
+    //   the appropriate number of octets, which are specified in
+    //   corresponding entries in array mappds.
+    //
+    for (i=0;i<mappds->maplen;i++) {
         nbits=abs(mappds->map[i])*8;
         if ( (mappds->map[i] >= 0) || (ipdstmpl[i] >= 0) )
-          sbit(cgrib,ipdstmpl+i,iofst,nbits);
+            sbit(cgrib,ipdstmpl+i,iofst,nbits);
         else {
-          sbit(cgrib,&one,iofst,1);
-          temp=abs(ipdstmpl[i]);
-          sbit(cgrib,&temp,iofst+1,nbits-1);
+            sbit(cgrib,&one,iofst,1);
+            temp=abs(ipdstmpl[i]);
+            sbit(cgrib,&temp,iofst+1,nbits-1);
         }
         iofst=iofst+nbits;
-      }
-      //  Pack template extension, if appropriate
-      j=mappds->maplen;
-      if ( mappds->needext && (mappds->extlen > 0) ) {
-         for (i=0;i<mappds->extlen;i++) {
-           nbits=abs(mappds->ext[i])*8;
-           if ( (mappds->ext[i] >= 0) || (ipdstmpl[j] >= 0) )
-             sbit(cgrib,ipdstmpl+j,iofst,nbits);
-           else {
-             sbit(cgrib,&one,iofst,1);
-             temp=abs(ipdstmpl[j]);
-             sbit(cgrib,&temp,iofst+1,nbits-1);
-           }
-           iofst=iofst+nbits;
-           j++;
-         }
-      }
-      free(mappds);
-      //
-      //   Add Optional list of vertical coordinate values
-      //   after the Product Definition Template, if necessary.
-      //
-      if ( numcoord != 0 ) {
+    }
+    //  Pack template extension, if appropriate
+    j=mappds->maplen;
+    if ( mappds->needext && (mappds->extlen > 0) ) {
+        for (i=0;i<mappds->extlen;i++) {
+            nbits=abs(mappds->ext[i])*8;
+            if ( (mappds->ext[i] >= 0) || (ipdstmpl[j] >= 0) )
+                sbit(cgrib,ipdstmpl+j,iofst,nbits);
+            else {
+                sbit(cgrib,&one,iofst,1);
+                temp=abs(ipdstmpl[j]);
+                sbit(cgrib,&temp,iofst+1,nbits-1);
+            }
+            iofst=iofst+nbits;
+            j++;
+        }
+    }
+    free(mappds);
+    //
+    //   Add Optional list of vertical coordinate values
+    //   after the Product Definition Template, if necessary.
+    //
+    if ( numcoord != 0 ) {
         coordieee=(g2int *)calloc(numcoord,sizeof(g2int));
         mkieee(coordlist,coordieee,numcoord);
         sbits(cgrib,coordieee,iofst,32,0,numcoord);
         iofst=iofst+(32*numcoord);
         free(coordieee);
-      }
-      //
-      //   Calculate length of section 4 and store it in octets
-      //   1-4 of section 4.
-      //
-      lensec4=(iofst-ibeg)/8;
-      sbit(cgrib,&lensec4,ibeg,32);
+    }
+    //
+    //   Calculate length of section 4 and store it in octets
+    //   1-4 of section 4.
+    //
+    lensec4=(iofst-ibeg)/8;
+    sbit(cgrib,&lensec4,ibeg,32);
 //
 //  Pack Data using appropriate algorithm
 //
-      //
-      //   Get Data Representation Template
-      //
-      mapdrs=getdrstemplate(idrsnum);
-      if (mapdrs == 0) {
+    //
+    //   Get Data Representation Template
+    //
+    mapdrs=getdrstemplate(idrsnum);
+    if (mapdrs == 0) {
         ierr=-5;
         return(ierr);
-      }
-      //
-      //  contract data field, removing data at invalid grid points,
-      //  if bit-map is provided with field.
-      //
-      if ( ibmap == 0 || ibmap==254 ) {
-         pfld=(g2float *)malloc(ngrdpts*sizeof(g2float));
-         ndpts=0;
-         for (j=0;j<ngrdpts;j++) {
-             if ( bmap[j]==1 ) pfld[ndpts++]=fld[j];
-         }
-      }
-      else {
-         ndpts=ngrdpts;
-         pfld=fld;
-      }
-      nsize=ndpts*4;
-      if ( nsize < minsize ) nsize=minsize;
-      cpack=malloc(nsize);
-      if (idrsnum == 0)           //  Simple Packing
+    }
+    //
+    //  contract data field, removing data at invalid grid points,
+    //  if bit-map is provided with field.
+    //
+    if ( ibmap == 0 || ibmap==254 ) {
+        pfld=(g2float *)malloc(ngrdpts*sizeof(g2float));
+        ndpts=0;
+        for (j=0;j<ngrdpts;j++) {
+            if ( bmap[j]==1 ) pfld[ndpts++]=fld[j];
+        }
+    }
+    else {
+        ndpts=ngrdpts;
+        pfld=fld;
+    }
+    nsize=ndpts*4;
+    if ( nsize < minsize ) nsize=minsize;
+    cpack=malloc(nsize);
+    if (idrsnum == 0)           //  Simple Packing
         simpack(pfld,ndpts,idrstmpl,cpack,&lcpack);
-      else if (idrsnum==2 || idrsnum==3)           //  Complex Packing
+    else if (idrsnum==2 || idrsnum==3)           //  Complex Packing
         cmplxpack(pfld,ndpts,idrsnum,idrstmpl,cpack,&lcpack);
-      else if (idrsnum == 50) {         //  Sperical Harmonic Simple Packing 
+    else if (idrsnum == 50) {         //  Sperical Harmonic Simple Packing
         simpack(pfld+1,ndpts-1,idrstmpl,cpack,&lcpack);
         mkieee(pfld+0,idrstmpl+4,1);  // ensure RE(0,0) value is IEEE format
-      }
-      else if (idrsnum == 51) {         //  Sperical Harmonic Complex Packing 
+    }
+    else if (idrsnum == 51) {         //  Sperical Harmonic Complex Packing
         getpoly(cgrib+lpos3,&JJ,&KK,&MM);
         if ( JJ!=0 && KK!=0 && MM!=0 )
-           specpack(pfld,ndpts,JJ,KK,MM,idrstmpl,cpack,&lcpack);
+            specpack(pfld,ndpts,JJ,KK,MM,idrstmpl,cpack,&lcpack);
         else {
-           printf("g2_addfield: Cannot pack DRT 5.51.\n");
-           return (-9);
+            printf("g2_addfield: Cannot pack DRT 5.51.\n");
+            return (-9);
         }
-      }
+    }
 #if defined USE_JPEG2000 || defined USE_OPENJPEG
-      else if (idrsnum == 40 || idrsnum == 40000) {    /*  JPEG2000 encoding  */
+    else if (idrsnum == 40 || idrsnum == 40000) {    /*  JPEG2000 encoding  */
         if (ibmap == 255) {
-           getdim(cgrib+lpos3,&width,&height,&iscan);
-           if ( width==0 || height==0 ) {
-              width=ndpts;
-              height=1;
-           }
-           else if ( width==allones || height==allones ) {
-              width=ndpts;
-              height=1;
-           }
-           else if ( (iscan&32) == 32) {   /* Scanning mode: bit 3  */
-              itemp=width;
-              width=height;
-              height=itemp;
-           }
+            getdim(cgrib+lpos3,&width,&height,&iscan);
+            if ( width==0 || height==0 ) {
+                width=ndpts;
+                height=1;
+            }
+            else if ( width==allones || height==allones ) {
+                width=ndpts;
+                height=1;
+            }
+            else if ( (iscan&32) == 32) {   /* Scanning mode: bit 3  */
+                itemp=width;
+                width=height;
+                height=itemp;
+            }
         }
         else {
-           width=ndpts;
-           height=1;
+            width=ndpts;
+            height=1;
         }
         lcpack=nsize;
         jpcpack(pfld,width,height,idrstmpl,cpack,&lcpack);
-      }
+    }
 #endif  /* USE_JPEG2000 */
 #ifdef USE_PNG
-      else if (idrsnum == 41 || idrsnum == 40010) {      /*  PNG encoding   */
+    else if (idrsnum == 41 || idrsnum == 40010) {      /*  PNG encoding   */
         if (ibmap == 255) {
-           getdim(cgrib+lpos3,&width,&height,&iscan);
-           if ( width==0 || height==0 ) {
-              width=ndpts;
-              height=1;
-           }
-           else if ( width==allones || height==allones ) {
-              width=ndpts;
-              height=1;
-           }
-           else if ( (iscan&32) == 32) {   /* Scanning mode: bit 3  */
-              itemp=width;
-              width=height;
-              height=itemp;
-           }
+            getdim(cgrib+lpos3,&width,&height,&iscan);
+            if ( width==0 || height==0 ) {
+                width=ndpts;
+                height=1;
+            }
+            else if ( width==allones || height==allones ) {
+                width=ndpts;
+                height=1;
+            }
+            else if ( (iscan&32) == 32) {   /* Scanning mode: bit 3  */
+                itemp=width;
+                width=height;
+                height=itemp;
+            }
         }
         else {
-           width=ndpts;
-           height=1;
+            width=ndpts;
+            height=1;
         }
         pngpack(pfld,width,height,idrstmpl,cpack,&lcpack);
-      }
+    }
 #endif  /* USE_PNG */
-      else {
+    else {
         printf("g2_addfield: Data Representation Template 5.%ld not yet implemented.\n",idrsnum);
         ierr=-7;
         return(ierr);
-      }
-      if ( ibmap == 0 || ibmap==254 ) {      // free temp space
-         if (fld != pfld) free(pfld);
-      }
-      if ( lcpack < 0 ) {
+    }
+    if ( ibmap == 0 || ibmap==254 ) {      // free temp space
+        if (fld != pfld) free(pfld);
+    }
+    if ( lcpack < 0 ) {
         if( cpack != 0 ) free(cpack);
         ierr=-10;
         return(ierr);
-      }
+    }
 
 //
 //  Add Section 5  - Data Representation Section
 //
-      ibeg=iofst;            //   Calculate offset for beginning of section 5
-      iofst=ibeg+32;         //   leave space for length of section
-      sbit(cgrib,&five,iofst,8);     // Store section number ( 5 )
-      iofst=iofst+8;
-      sbit(cgrib,&ndpts,iofst,32);    // Store num of actual data points
-      iofst=iofst+32;
-      sbit(cgrib,&idrsnum,iofst,16);    // Store Data Repr. Template num.
-      iofst=iofst+16;
-      //
-      //   Pack up each input value in array idrstmpl into the
-      //   the appropriate number of octets, which are specified in
-      //   corresponding entries in array mapdrs.
-      //
-      for (i=0;i<mapdrs->maplen;i++) {
+    ibeg=iofst;            //   Calculate offset for beginning of section 5
+    iofst=ibeg+32;         //   leave space for length of section
+    sbit(cgrib,&five,iofst,8);     // Store section number ( 5 )
+    iofst=iofst+8;
+    sbit(cgrib,&ndpts,iofst,32);    // Store num of actual data points
+    iofst=iofst+32;
+    sbit(cgrib,&idrsnum,iofst,16);    // Store Data Repr. Template num.
+    iofst=iofst+16;
+    //
+    //   Pack up each input value in array idrstmpl into the
+    //   the appropriate number of octets, which are specified in
+    //   corresponding entries in array mapdrs.
+    //
+    for (i=0;i<mapdrs->maplen;i++) {
         nbits=abs(mapdrs->map[i])*8;
         if ( (mapdrs->map[i] >= 0) || (idrstmpl[i] >= 0) )
-          sbit(cgrib,idrstmpl+i,iofst,nbits);
+            sbit(cgrib,idrstmpl+i,iofst,nbits);
         else {
-          sbit(cgrib,&one,iofst,1);
-          temp=abs(idrstmpl[i]);
-          sbit(cgrib,&temp,iofst+1,nbits-1);
+            sbit(cgrib,&one,iofst,1);
+            temp=abs(idrstmpl[i]);
+            sbit(cgrib,&temp,iofst+1,nbits-1);
         }
         iofst=iofst+nbits;
-      }
-      free(mapdrs);
-      //
-      //   Calculate length of section 5 and store it in octets
-      //   1-4 of section 5.
-      //
-      lensec5=(iofst-ibeg)/8;
-      sbit(cgrib,&lensec5,ibeg,32);
+    }
+    free(mapdrs);
+    //
+    //   Calculate length of section 5 and store it in octets
+    //   1-4 of section 5.
+    //
+    lensec5=(iofst-ibeg)/8;
+    sbit(cgrib,&lensec5,ibeg,32);
 
 //
 //  Add Section 6  - Bit-Map Section
 //
-      ibeg=iofst;            //   Calculate offset for beginning of section 6
-      iofst=ibeg+32;         //   leave space for length of section
-      sbit(cgrib,&six,iofst,8);     // Store section number ( 6 )
-      iofst=iofst+8;
-      sbit(cgrib,&ibmap,iofst,8);    // Store Bit Map indicator
-      iofst=iofst+8;
-      //
-      //  Store bitmap, if supplied
-      //
-      if (ibmap == 0) {
+    ibeg=iofst;            //   Calculate offset for beginning of section 6
+    iofst=ibeg+32;         //   leave space for length of section
+    sbit(cgrib,&six,iofst,8);     // Store section number ( 6 )
+    iofst=iofst+8;
+    sbit(cgrib,&ibmap,iofst,8);    // Store Bit Map indicator
+    iofst=iofst+8;
+    //
+    //  Store bitmap, if supplied
+    //
+    if (ibmap == 0) {
         sbits(cgrib,bmap,iofst,1,0,ngrdpts);    // Store BitMap
         iofst=iofst+ngrdpts;
-      }
-      //
-      //  If specifying a previously defined bit-map, make sure
-      //  one already exists in the current GRIB message.
-      //
-      if ((ibmap==254) && ( ! isprevbmap)) {
+    }
+    //
+    //  If specifying a previously defined bit-map, make sure
+    //  one already exists in the current GRIB message.
+    //
+    if ((ibmap==254) && ( ! isprevbmap)) {
         printf("g2_addfield: Requested previously defined bitmap,");
         printf(" but one does not exist in the current GRIB message.\n");
         ierr=-8;
         return(ierr);
-      }
-      //
-      //   Calculate length of section 6 and store it in octets
-      //   1-4 of section 6.  Pad to end of octect, if necessary.
-      //
-      left=8-(iofst%8);
-      if (left != 8) {
+    }
+    //
+    //   Calculate length of section 6 and store it in octets
+    //   1-4 of section 6.  Pad to end of octect, if necessary.
+    //
+    left=8-(iofst%8);
+    if (left != 8) {
         sbit(cgrib,&zero,iofst,left);     // Pad with zeros to fill Octet
         iofst=iofst+left;
-      }
-      lensec6=(iofst-ibeg)/8;
-      sbit(cgrib,&lensec6,ibeg,32);
+    }
+    lensec6=(iofst-ibeg)/8;
+    sbit(cgrib,&lensec6,ibeg,32);
 
 //
 //  Add Section 7  - Data Section
 //
-      ibeg=iofst;            //   Calculate offset for beginning of section 7
-      iofst=ibeg+32;        //   leave space for length of section
-      sbit(cgrib,&seven,iofst,8);    // Store section number ( 7 )
-      iofst=iofst+8;
-      //      Store Packed Binary Data values, if non-constant field
-      if (lcpack != 0) {
+    ibeg=iofst;            //   Calculate offset for beginning of section 7
+    iofst=ibeg+32;        //   leave space for length of section
+    sbit(cgrib,&seven,iofst,8);    // Store section number ( 7 )
+    iofst=iofst+8;
+    //      Store Packed Binary Data values, if non-constant field
+    if (lcpack != 0) {
         ioctet=iofst/8;
         //cgrib(ioctet+1:ioctet+lcpack)=cpack(1:lcpack)
         for (j=0;j<lcpack;j++) cgrib[ioctet+j]=cpack[j];
         iofst=iofst+(8*lcpack);
-      }
-      //
-      //   Calculate length of section 7 and store it in octets
-      //   1-4 of section 7.  
-      //
-      lensec7=(iofst-ibeg)/8;
-      sbit(cgrib,&lensec7,ibeg,32);
+    }
+    //
+    //   Calculate length of section 7 and store it in octets
+    //   1-4 of section 7.
+    //
+    lensec7=(iofst-ibeg)/8;
+    sbit(cgrib,&lensec7,ibeg,32);
 
-      if( cpack != 0 ) free(cpack);
+    if( cpack != 0 ) free(cpack);
 //
 //  Update current byte total of message in Section 0
 //
-      newlen=lencurr+lensec4+lensec5+lensec6+lensec7;
-      sbit(cgrib,&newlen,96,32);
+    newlen=lencurr+lensec4+lensec5+lensec6+lensec7;
+    sbit(cgrib,&newlen,96,32);
 
-      return(newlen);
+    return(newlen);
 
 }

--- a/src/g2_addlocal.c
+++ b/src/g2_addlocal.c
@@ -85,9 +85,9 @@ g2_addlocal(unsigned char *cgrib, unsigned char *csec2, g2int lcsec2)
         /* Exit loop if last section reached. */
         if ( len == lencurr ) break;
         /* If byte count for each section doesn't match current total
-	 * length, then there is a problem. */
+         * length, then there is a problem. */
         if ( len > lencurr )
-	{
+        {
             printf("g2_addlocal: Section byte counts don't add to total.\n");
             printf("g2_addlocal: Sum of section byte counts = %ld\n",len);
             printf("g2_addlocal: Total byte count in Section 0 = %ld\n",lencurr);
@@ -95,7 +95,7 @@ g2_addlocal(unsigned char *cgrib, unsigned char *csec2, g2int lcsec2)
             return(ierr);
         }
     }
-    
+
     /* Section 2 can only be added after sections 1 and 7. */
     if ( (isecnum!=1) && (isecnum!=7) )
     {
@@ -116,7 +116,7 @@ g2_addlocal(unsigned char *cgrib, unsigned char *csec2, g2int lcsec2)
     {
         cgrib[j]=csec2[k++];
     }
-    
+
     /* Calculate length of section 2 and store it in octets 1-4 of section 2. */
     lensec2=lcsec2+5;      /* bytes */
     sbit(cgrib,&lensec2,ibeg,32);

--- a/src/g2_getfld.c
+++ b/src/g2_getfld.c
@@ -7,20 +7,20 @@
 g2int g2_unpack1(unsigned char *,g2int *,g2int **,g2int *);
 g2int g2_unpack2(unsigned char *,g2int *,g2int *,unsigned char **);
 g2int g2_unpack3(unsigned char *,g2int *,g2int **,g2int **,
-                         g2int *,g2int **,g2int *);
+                 g2int *,g2int **,g2int *);
 g2int g2_unpack4(unsigned char *,g2int *,g2int *,g2int **,
-                         g2int *,g2float **,g2int *);
+                 g2int *,g2float **,g2int *);
 g2int g2_unpack5(unsigned char *,g2int *,g2int *,g2int *, g2int **,g2int *);
 g2int g2_unpack6(unsigned char *,g2int *,g2int ,g2int *, g2int **);
 g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
-                         g2int ,g2int *,g2int ,g2float **);
+                 g2int ,g2int *,g2int ,g2float **);
 
 //$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    g2_getfld 
+// SUBPROGRAM:    g2_getfld
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2002-10-28
 //
-// ABSTRACT: This subroutine returns all the metadata, template values, 
+// ABSTRACT: This subroutine returns all the metadata, template values,
 //   Bit-map ( if applicable ), and the unpacked data for a given data
 //   field.  All of the information returned is stored in a gribfield
 //   structure, which is defined in file grib2.h.
@@ -45,20 +45,20 @@ g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
 //     unpack   - Boolean value indicating whether to unpack bitmap/data field
 //                1 = unpack bitmap (if present) and data values
 //                0 = do not unpack bitmap and data values
-//     expand   - Boolean value indicating whether the data points should be 
+//     expand   - Boolean value indicating whether the data points should be
 //                expanded to the correspond grid, if a bit-map is present.
-//                1 = if possible, expand data field to grid, inserting zero 
-//                    values at gridpoints that are bitmapped out. 
+//                1 = if possible, expand data field to grid, inserting zero
+//                    values at gridpoints that are bitmapped out.
 //                    (SEE REMARKS2)
 //                0 = do not expand data field, leaving it an array of
 //                    consecutive data points for each "1" in the bitmap.
 //                This argument is ignored if unpack == 0 OR if the
 //                returned field does not contain a bit-map.
 //
-//   OUTPUT ARGUMENT:      
+//   OUTPUT ARGUMENT:
 //     gribfield gfld; - pointer to structure gribfield containing
 //                       all decoded data for the data field.
-// 
+//
 //        gfld->version = GRIB edition number ( currently 2 )
 //        gfld->discipline = Message Discipline ( see Code Table 0.0 )
 //        gfld->idsect = Contains the entries in the Identification
@@ -136,7 +136,7 @@ g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
 //                          This element is a pointer to an array
 //                          that holds the data.  This pointer is nullified
 //                          if gfld->numoct_opt=0.
-//        gfld->num_opt = (Used if gfld->numoct_opt .ne. 0) 
+//        gfld->num_opt = (Used if gfld->numoct_opt .ne. 0)
 //                        The number of entries
 //                       in array ideflist.  i.e. number of rows ( or columns )
 //                       for which optional grid points are defined.  This value
@@ -174,10 +174,10 @@ g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
 //        gfld->unpacked = logical value indicating whether the bitmap and
 //                        data values were unpacked.  If false,
 //                        gfld->bmap and gfld->fld pointers are nullified.
-//        gfld->expanded = Logical value indicating whether the data field 
-//                         was expanded to the grid in the case where a 
+//        gfld->expanded = Logical value indicating whether the data field
+//                         was expanded to the grid in the case where a
 //                         bit-map is present.  If true, the data points in
-//                         gfld->fld match the grid points and zeros were 
+//                         gfld->fld match the grid points and zeros were
 //                         inserted at grid points where data was bit-mapped
 //                         out.  If false, the data values in gfld->fld were
 //                         not expanded to the grid and are just a consecutive
@@ -196,7 +196,7 @@ g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
 //                     This element is a pointer to an array
 //                     that holds the data.
 //
-// 
+//
 //   RETURN VALUES:
 //     ierr     - Error return code.
 //                0 = no error
@@ -220,7 +220,7 @@ g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
 //
 // REMARKS: Note that struct gribfield is allocated by this routine and it
 //          also contains pointers to many arrays of data that were allocated
-//          during decoding.  Users are encouraged to free up this memory, 
+//          during decoding.  Users are encouraged to free up this memory,
 //          when it is no longer needed, by an explicit call to routine g2_free.
 //          EXAMPLE:
 //              #include "grib2.h"
@@ -234,111 +234,111 @@ g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
 //
 // REMARKS2: It may not always be possible to expand a bit-mapped data field.
 //           If a pre-defined bit-map is used and not included in the GRIB2
-//           message itself, this routine would not have the necessary 
+//           message itself, this routine would not have the necessary
 //           information to expand the data.  In this case, gfld->expanded would
-//           would be set to 0 (false), regardless of the value of input 
+//           would be set to 0 (false), regardless of the value of input
 //           argument expand.
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$
 g2int g2_getfld(unsigned char *cgrib,g2int ifldnum,g2int unpack,g2int expand,
                 gribfield **gfld)
 {
-    
-      g2int have3,have4,have5,have6,have7,ierr,jerr;
-      g2int numfld,j,n,istart,iofst,ipos;
-      g2int disc,ver,lensec0,lengrib,lensec,isecnum;
-      g2int  *igds;
-      g2int *bmpsave;
-      g2float *newfld;
-      gribfield  *lgfld;
 
-      have3=0;
-      have4=0;
-      have5=0;
-      have6=0;
-      have7=0;
-      ierr=0;
-      numfld=0;
+    g2int have3,have4,have5,have6,have7,ierr,jerr;
+    g2int numfld,j,n,istart,iofst,ipos;
+    g2int disc,ver,lensec0,lengrib,lensec,isecnum;
+    g2int  *igds;
+    g2int *bmpsave;
+    g2float *newfld;
+    gribfield  *lgfld;
 
-      lgfld=(gribfield *)malloc(sizeof(gribfield));
-      *gfld=lgfld;
+    have3=0;
+    have4=0;
+    have5=0;
+    have6=0;
+    have7=0;
+    ierr=0;
+    numfld=0;
 
-      lgfld->locallen=0;
-      lgfld->idsect=0;
-      lgfld->local=0;
-      lgfld->list_opt=0;
-      lgfld->igdtmpl=0;
-      lgfld->ipdtmpl=0;
-      lgfld->idrtmpl=0;
-      lgfld->coord_list=0;
-      lgfld->bmap=0;
-      lgfld->fld=0;
+    lgfld=(gribfield *)malloc(sizeof(gribfield));
+    *gfld=lgfld;
+
+    lgfld->locallen=0;
+    lgfld->idsect=0;
+    lgfld->local=0;
+    lgfld->list_opt=0;
+    lgfld->igdtmpl=0;
+    lgfld->ipdtmpl=0;
+    lgfld->idrtmpl=0;
+    lgfld->coord_list=0;
+    lgfld->bmap=0;
+    lgfld->fld=0;
 //
 //  Check for valid request number
-//  
-      if (ifldnum <= 0) {
+//
+    if (ifldnum <= 0) {
         printf("g2_getfld: Request for field number must be positive.\n");
         ierr=3;
         return(ierr);
-      }
+    }
 //
 //  Check for beginning of GRIB message in the first 100 bytes
 //
-      istart=-1;
-      for (j=0;j<100;j++) {
-        if (cgrib[j]=='G' && cgrib[j+1]=='R' &&cgrib[j+2]=='I' && 
+    istart=-1;
+    for (j=0;j<100;j++) {
+        if (cgrib[j]=='G' && cgrib[j+1]=='R' &&cgrib[j+2]=='I' &&
             cgrib[j+3]=='B') {
-          istart=j;
-          break;
+            istart=j;
+            break;
         }
-      }
-      if (istart == -1) {
+    }
+    if (istart == -1) {
         printf("g2_getfld:  Beginning characters GRIB not found.\n");
         ierr=1;
         return(ierr);
-      }
+    }
 //
-//  Unpack Section 0 - Indicator Section 
+//  Unpack Section 0 - Indicator Section
 //
-      iofst=8*(istart+6);
-      gbit(cgrib,&disc,iofst,8);     // Discipline
-      iofst=iofst+8;
-      gbit(cgrib,&ver,iofst,8);     // GRIB edition number
-      iofst=iofst+8;
-      iofst=iofst+32;
-      gbit(cgrib,&lengrib,iofst,32);        // Length of GRIB message
-      iofst=iofst+32;
-      lensec0=16;
-      ipos=istart+lensec0;
+    iofst=8*(istart+6);
+    gbit(cgrib,&disc,iofst,8);     // Discipline
+    iofst=iofst+8;
+    gbit(cgrib,&ver,iofst,8);     // GRIB edition number
+    iofst=iofst+8;
+    iofst=iofst+32;
+    gbit(cgrib,&lengrib,iofst,32);        // Length of GRIB message
+    iofst=iofst+32;
+    lensec0=16;
+    ipos=istart+lensec0;
 //
 //  Currently handles only GRIB Edition 2.
-//  
-      if (ver != 2) {
+//
+    if (ver != 2) {
         printf("g2_getfld: can only decode GRIB edition 2.\n");
         ierr=2;
         return(ierr);
-      }
+    }
 //
-//  Loop through the remaining sections keeping track of the 
+//  Loop through the remaining sections keeping track of the
 //  length of each.  Also keep the latest Grid Definition Section info.
 //  Unpack the requested field number.
 //
-      for (;;) {
+    for (;;) {
         //    Check to see if we are at end of GRIB message
-        if (cgrib[ipos]=='7' && cgrib[ipos+1]=='7' && cgrib[ipos+2]=='7' && 
+        if (cgrib[ipos]=='7' && cgrib[ipos+1]=='7' && cgrib[ipos+2]=='7' &&
             cgrib[ipos+3]=='7') {
-          ipos=ipos+4;
-          //    If end of GRIB message not where expected, issue error
-          if (ipos != (istart+lengrib)) {
-            printf("g2_getfld: '7777' found, but not where expected.\n");
-            ierr=4;
-            return(ierr);
-          }
-          break;
+            ipos=ipos+4;
+            //    If end of GRIB message not where expected, issue error
+            if (ipos != (istart+lengrib)) {
+                printf("g2_getfld: '7777' found, but not where expected.\n");
+                ierr=4;
+                return(ierr);
+            }
+            break;
         }
         //     Get length of Section and Section number
         iofst=(ipos-1)*8;
@@ -352,97 +352,97 @@ g2int g2_getfld(unsigned char *cgrib,g2int ifldnum,g2int unpack,g2int expand,
         //  Check to see if section number is valid
         //
         if ( isecnum<1 || isecnum>7 ) {
-          printf("g2_getfld: Unrecognized Section Encountered=%ld\n",isecnum);
-          ierr=8;
-          return(ierr);
+            printf("g2_getfld: Unrecognized Section Encountered=%ld\n",isecnum);
+            ierr=8;
+            return(ierr);
         }
         //
         //   If found Section 1, decode elements in Identification Section
         //
         if (isecnum == 1) {
-          iofst=iofst-40;       // reset offset to beginning of section
-          jerr=g2_unpack1(cgrib,&iofst,&lgfld->idsect,&lgfld->idsectlen);
-          if (jerr !=0 ) {
-            ierr=15;
-            return(ierr);
-          }
+            iofst=iofst-40;       // reset offset to beginning of section
+            jerr=g2_unpack1(cgrib,&iofst,&lgfld->idsect,&lgfld->idsectlen);
+            if (jerr !=0 ) {
+                ierr=15;
+                return(ierr);
+            }
         }
         //
         //   If found Section 2, Grab local section
         //   Save in case this is the latest one before the requested field.
         //
         if (isecnum == 2) {
-          iofst=iofst-40;       // reset offset to beginning of section
-          if (lgfld->local!=0) free(lgfld->local);
-          jerr=g2_unpack2(cgrib,&iofst,&lgfld->locallen,&lgfld->local);
-          if (jerr != 0) {
-            ierr=16;
-            return(ierr);
-          }
+            iofst=iofst-40;       // reset offset to beginning of section
+            if (lgfld->local!=0) free(lgfld->local);
+            jerr=g2_unpack2(cgrib,&iofst,&lgfld->locallen,&lgfld->local);
+            if (jerr != 0) {
+                ierr=16;
+                return(ierr);
+            }
         }
         //
-        //   If found Section 3, unpack the GDS info using the 
+        //   If found Section 3, unpack the GDS info using the
         //   appropriate template.  Save in case this is the latest
         //   grid before the requested field.
         //
         if (isecnum == 3) {
-          iofst=iofst-40;       // reset offset to beginning of section
-          if (lgfld->igdtmpl!=0) free(lgfld->igdtmpl);
-          if (lgfld->list_opt!=0) free(lgfld->list_opt);
-          jerr=g2_unpack3(cgrib,&iofst,&igds,&lgfld->igdtmpl,
-                          &lgfld->igdtlen,&lgfld->list_opt,&lgfld->num_opt);
-          if (jerr == 0) {
-            have3=1;
-            lgfld->griddef=igds[0];
-            lgfld->ngrdpts=igds[1];
-            lgfld->numoct_opt=igds[2];
-            lgfld->interp_opt=igds[3];
-            lgfld->igdtnum=igds[4];
-            free(igds);
-          }
-          else {
-            ierr=10;
-            return(ierr);
-          }
+            iofst=iofst-40;       // reset offset to beginning of section
+            if (lgfld->igdtmpl!=0) free(lgfld->igdtmpl);
+            if (lgfld->list_opt!=0) free(lgfld->list_opt);
+            jerr=g2_unpack3(cgrib,&iofst,&igds,&lgfld->igdtmpl,
+                            &lgfld->igdtlen,&lgfld->list_opt,&lgfld->num_opt);
+            if (jerr == 0) {
+                have3=1;
+                lgfld->griddef=igds[0];
+                lgfld->ngrdpts=igds[1];
+                lgfld->numoct_opt=igds[2];
+                lgfld->interp_opt=igds[3];
+                lgfld->igdtnum=igds[4];
+                free(igds);
+            }
+            else {
+                ierr=10;
+                return(ierr);
+            }
         }
         //
         //   If found Section 4, check to see if this field is the
         //   one requested.
         //
         if (isecnum == 4) {
-          numfld=numfld+1;
-          if (numfld == ifldnum) {
-            lgfld->discipline=disc;
-            lgfld->version=ver;
-            lgfld->ifldnum=ifldnum;
-            lgfld->unpacked=unpack;
-            lgfld->expanded=0;
-            iofst=iofst-40;       // reset offset to beginning of section
-            jerr=g2_unpack4(cgrib,&iofst,&lgfld->ipdtnum,
-                            &lgfld->ipdtmpl,&lgfld->ipdtlen,&lgfld->coord_list,
-                            &lgfld->num_coord);
-            if (jerr == 0)
-              have4=1;
-            else {
-              ierr=11;
-              return(ierr);
+            numfld=numfld+1;
+            if (numfld == ifldnum) {
+                lgfld->discipline=disc;
+                lgfld->version=ver;
+                lgfld->ifldnum=ifldnum;
+                lgfld->unpacked=unpack;
+                lgfld->expanded=0;
+                iofst=iofst-40;       // reset offset to beginning of section
+                jerr=g2_unpack4(cgrib,&iofst,&lgfld->ipdtnum,
+                                &lgfld->ipdtmpl,&lgfld->ipdtlen,&lgfld->coord_list,
+                                &lgfld->num_coord);
+                if (jerr == 0)
+                    have4=1;
+                else {
+                    ierr=11;
+                    return(ierr);
+                }
             }
-          }
         }
         //
         //   If found Section 5, check to see if this field is the
         //   one requested.
         //
         if (isecnum == 5 && numfld == ifldnum) {
-          iofst=iofst-40;       // reset offset to beginning of section
-          jerr=g2_unpack5(cgrib,&iofst,&lgfld->ndpts,&lgfld->idrtnum,
-                          &lgfld->idrtmpl,&lgfld->idrtlen);
-          if (jerr == 0)
-            have5=1;
-          else {
-            ierr=12;
-            return(ierr);
-          }
+            iofst=iofst-40;       // reset offset to beginning of section
+            jerr=g2_unpack5(cgrib,&iofst,&lgfld->ndpts,&lgfld->idrtnum,
+                            &lgfld->idrtmpl,&lgfld->idrtlen);
+            if (jerr == 0)
+                have5=1;
+            else {
+                ierr=12;
+                return(ierr);
+            }
         }
         //
         //   If found Section 6, Unpack bitmap.
@@ -450,71 +450,71 @@ g2int g2_getfld(unsigned char *cgrib,g2int ifldnum,g2int unpack,g2int expand,
         //   bitmap before the requested field.
         //
         if (isecnum == 6) {
-          if (unpack) {   // unpack bitmap
-            iofst=iofst-40;           // reset offset to beginning of section
-            bmpsave=lgfld->bmap;      // save pointer to previous bitmap
-            jerr=g2_unpack6(cgrib,&iofst,lgfld->ngrdpts,&lgfld->ibmap,
-                         &lgfld->bmap);
-            if (jerr == 0) {
-              have6=1;
-              if (lgfld->ibmap == 254)     // use previously specified bitmap
-                 if( bmpsave!=0 ) 
-                    lgfld->bmap=bmpsave;
-                 else {
-                    printf("g2_getfld: Prev bit-map specified, but none exist.\n");
-                    ierr=17;
+            if (unpack) {   // unpack bitmap
+                iofst=iofst-40;           // reset offset to beginning of section
+                bmpsave=lgfld->bmap;      // save pointer to previous bitmap
+                jerr=g2_unpack6(cgrib,&iofst,lgfld->ngrdpts,&lgfld->ibmap,
+                                &lgfld->bmap);
+                if (jerr == 0) {
+                    have6=1;
+                    if (lgfld->ibmap == 254)     // use previously specified bitmap
+                        if( bmpsave!=0 )
+                            lgfld->bmap=bmpsave;
+                        else {
+                            printf("g2_getfld: Prev bit-map specified, but none exist.\n");
+                            ierr=17;
+                            return(ierr);
+                        }
+                    else                         // get rid of it
+                        if( bmpsave!=0 ) free(bmpsave);
+                }
+                else {
+                    ierr=13;
                     return(ierr);
-                 }
-              else                         // get rid of it
-                 if( bmpsave!=0 ) free(bmpsave);
+                }
             }
-            else {
-              ierr=13;
-              return(ierr);
+            else {    // do not unpack bitmap
+                gbit(cgrib,&lgfld->ibmap,iofst,8);      // Get BitMap Indicator
+                have6=1;
             }
-          }
-          else {    // do not unpack bitmap
-            gbit(cgrib,&lgfld->ibmap,iofst,8);      // Get BitMap Indicator
-            have6=1;
-          }
         }
         //
         //   If found Section 7, check to see if this field is the
         //   one requested.
         //
         if (isecnum==7 && numfld==ifldnum && unpack) {
-          iofst=iofst-40;       // reset offset to beginning of section
-          jerr=g2_unpack7(cgrib,&iofst,lgfld->igdtnum,lgfld->igdtmpl,
-                          lgfld->idrtnum,lgfld->idrtmpl,lgfld->ndpts,
-                          &lgfld->fld);
-          if (jerr == 0) {
-            have7=1;
-            //  If bitmap is used with this field, expand data field 
-            //  to grid, if possible.
-            if ( lgfld->ibmap != 255 && lgfld->bmap != 0 ) {
-               if ( expand == 1 ) {
-                  n=0;
-                  newfld=(g2float *)calloc(lgfld->ngrdpts,sizeof(g2float));
-                  for (j=0;j<lgfld->ngrdpts;j++) {
-                      if (lgfld->bmap[j]==1) newfld[j]=lgfld->fld[n++];
-                  }
-                  free(lgfld->fld);
-                  lgfld->fld=newfld;
-                  lgfld->expanded=1;
-               }
-               else {
-                  lgfld->expanded=0;
-               }
+            iofst=iofst-40;       // reset offset to beginning of section
+            jerr=g2_unpack7(cgrib,&iofst,lgfld->igdtnum,lgfld->igdtmpl,
+                            lgfld->idrtnum,lgfld->idrtmpl,lgfld->ndpts,
+                            &lgfld->fld);
+            if (jerr == 0) {
+                have7=1;
+                //  If bitmap is used with this field, expand data field
+                //  to grid, if possible.
+                if ( lgfld->ibmap != 255 && lgfld->bmap != 0 ) {
+                    if ( expand == 1 ) {
+                        n=0;
+                        newfld=(g2float *)calloc(lgfld->ngrdpts,sizeof(g2float));
+                        for (j=0;j<lgfld->ngrdpts;j++) {
+                            if (lgfld->bmap[j]==1) newfld[j]=lgfld->fld[n++];
+                        }
+                        free(lgfld->fld);
+                        lgfld->fld=newfld;
+                        lgfld->expanded=1;
+                    }
+                    else {
+                        lgfld->expanded=0;
+                    }
+                }
+                else {
+                    lgfld->expanded=1;
+                }
             }
             else {
-               lgfld->expanded=1;
+                printf("g2_getfld: return from g2_unpack7 = %d \n",(int)jerr);
+                ierr=14;
+                return(ierr);
             }
-          }
-          else {
-            printf("g2_getfld: return from g2_unpack7 = %d \n",(int)jerr);
-            ierr=14;
-            return(ierr);
-          }
         }
         //
         //   Check to see if we read pass the end of the GRIB
@@ -522,9 +522,9 @@ g2int g2_getfld(unsigned char *cgrib,g2int ifldnum,g2int unpack,g2int expand,
         //
         ipos=ipos+lensec;                // Update beginning of section pointer
         if (ipos > (istart+lengrib)) {
-          printf("g2_getfld: '7777'  not found at end of GRIB message.\n");
-          ierr=7;
-          return(ierr);
+            printf("g2_getfld: '7777'  not found at end of GRIB message.\n");
+            ierr=7;
+            return(ierr);
         }
         //
         //  If unpacking requested, return when all sections have been
@@ -533,22 +533,22 @@ g2int g2_getfld(unsigned char *cgrib,g2int ifldnum,g2int unpack,g2int expand,
         if (unpack && have3 && have4 && have5 && have6 && have7)
             return(ierr);
         //
-        //  If unpacking is not requested, return when sections 
+        //  If unpacking is not requested, return when sections
         //  3 through 6 have been processed
         //
         if ((! unpack) && have3 && have4 && have5 && have6)
             return(ierr);
-        
-      }
+
+    }
 
 //
 //  If exited from above loop, the end of the GRIB message was reached
 //  before the requested field was found.
 //
-      printf("g2_getfld: GRIB message contained %ld different fields.\n",numfld);
-      printf("g2_getfld: The request was for field %ld.\n",ifldnum);
-      ierr=6;
+    printf("g2_getfld: GRIB message contained %ld different fields.\n",numfld);
+    printf("g2_getfld: The request was for field %ld.\n",ifldnum);
+    ierr=6;
 
-      return(ierr);
+    return(ierr);
 
 }

--- a/src/g2_gribend.c
+++ b/src/g2_gribend.c
@@ -5,14 +5,14 @@
 
 //$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    g2_gribend 
+// SUBPROGRAM:    g2_gribend
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2002-10-31
 //
 // ABSTRACT: This routine finalizes a GRIB2 message after all grids
 //   and fields have been added.  It adds the End Section ( "7777" )
 //   to the end of the GRIB message and calculates the length and stores
 //   it in the appropriate place in Section 0.
-//   This routine is used with routines "g2_create", "g2_addlocal", 
+//   This routine is used with routines "g2_create", "g2_addlocal",
 //   "g2_addgrid", and "g2_addfield" to create a complete GRIB2 message.
 //   g2_create must be called first to initialize a new GRIB2 message.
 //
@@ -25,7 +25,7 @@
 //                be previous calls to g2_create, g2_addlocal, g2_addgrid,
 //                and g2_addfield.
 //
-//   OUTPUT ARGUMENTS:      
+//   OUTPUT ARGUMENTS:
 //     cgrib    - Char array containing the finalized GRIB2 message
 //
 //   RETURN VALUES:
@@ -33,12 +33,12 @@
 //              > 0 = Length of the final GRIB2 message in bytes.
 //               -1 = GRIB message was not initialized.  Need to call
 //                    routine g2_create first.
-//               -2 = GRIB message already complete.  
+//               -2 = GRIB message already complete.
 //               -3 = Sum of Section byte counts doesn't add to total byte count
 //               -4 = Previous Section was not 7.
 //
-// REMARKS: This routine is intended for use with routines "g2_create", 
-//          "g2_addlocal", "g2_addgrid", and "g2_addfield" to create a complete 
+// REMARKS: This routine is intended for use with routines "g2_create",
+//          "g2_addlocal", "g2_addgrid", and "g2_addfield" to create a complete
 //          GRIB2 message.
 //
 // ATTRIBUTES:
@@ -49,76 +49,75 @@
 g2int g2_gribend(unsigned char *cgrib)
 {
 
-      g2int iofst,lencurr,len,ilen,isecnum;
-      g2int   ierr,lengrib;
-      static unsigned char G=0x47;       // 'G'
-      static unsigned char R=0x52;       // 'R'
-      static unsigned char I=0x49;       // 'I'
-      static unsigned char B=0x42;       // 'B'
-      static unsigned char seven=0x37;   // '7'
- 
-      ierr=0;
+    g2int iofst,lencurr,len,ilen,isecnum;
+    g2int   ierr,lengrib;
+    static unsigned char G=0x47;       // 'G'
+    static unsigned char R=0x52;       // 'R'
+    static unsigned char I=0x49;       // 'I'
+    static unsigned char B=0x42;       // 'B'
+    static unsigned char seven=0x37;   // '7'
+
+    ierr=0;
 //
 //  Check to see if beginning of GRIB message exists
 //
-      if ( cgrib[0]!=G || cgrib[1]!=R || cgrib[2]!=I || cgrib[3]!=B ) {
+    if ( cgrib[0]!=G || cgrib[1]!=R || cgrib[2]!=I || cgrib[3]!=B ) {
         printf("g2_gribend: GRIB not found in given message.\n");
         ierr=-1;
         return (ierr);
-      }
+    }
 //
 //  Get current length of GRIB message
-//  
-      gbit(cgrib,&lencurr,96,32);
+//
+    gbit(cgrib,&lencurr,96,32);
 //
 //  Loop through all current sections of the GRIB message to
 //  find the last section number.
 //
-      len=16;    // Length of Section 0
-      for (;;) { 
-      //    Get number and length of next section
+    len=16;    // Length of Section 0
+    for (;;) {
+        //    Get number and length of next section
         iofst=len*8;
         gbit(cgrib,&ilen,iofst,32);
         iofst=iofst+32;
         gbit(cgrib,&isecnum,iofst,8);
         len=len+ilen;
-      //    Exit loop if last section reached
+        //    Exit loop if last section reached
         if ( len == lencurr ) break;
-      //    If byte count for each section doesn't match current
-      //    total length, then there is a problem.
+        //    If byte count for each section doesn't match current
+        //    total length, then there is a problem.
         if ( len > lencurr ) {
-          printf("g2_gribend: Section byte counts don''t add to total.\n");
-          printf("g2_gribend: Sum of section byte counts = %d\n",(int)len);
-          printf("g2_gribend: Total byte count in Section 0 = %d\n",(int)lencurr);
-          ierr=-3;
-          return (ierr);
+            printf("g2_gribend: Section byte counts don''t add to total.\n");
+            printf("g2_gribend: Sum of section byte counts = %d\n",(int)len);
+            printf("g2_gribend: Total byte count in Section 0 = %d\n",(int)lencurr);
+            ierr=-3;
+            return (ierr);
         }
-      }
+    }
 //
 //  Can only add End Section (Section 8) after Section 7.
 //
-      if ( isecnum != 7 ) {
+    if ( isecnum != 7 ) {
         printf("g2_gribend: Section 8 can only be added after Section 7.\n");
         printf("g2_gribend: Section %ld was the last found in given GRIB message.\n",isecnum);
         ierr=-4;
         return (ierr);
-      }
+    }
 //
 //  Add Section 8  - End Section
 //
-      //cgrib(lencurr+1:lencurr+4)=c7777
-      cgrib[lencurr]=seven;
-      cgrib[lencurr+1]=seven;
-      cgrib[lencurr+2]=seven;
-      cgrib[lencurr+3]=seven;
+    //cgrib(lencurr+1:lencurr+4)=c7777
+    cgrib[lencurr]=seven;
+    cgrib[lencurr+1]=seven;
+    cgrib[lencurr+2]=seven;
+    cgrib[lencurr+3]=seven;
 
 //
 //  Update current byte total of message in Section 0
 //
-      lengrib=lencurr+4;
-      sbit(cgrib,&lengrib,96,32);
+    lengrib=lencurr+4;
+    sbit(cgrib,&lengrib,96,32);
 
-      return (lengrib);
+    return (lengrib);
 
 }
-

--- a/src/g2_unpack2.c
+++ b/src/g2_unpack2.c
@@ -73,7 +73,7 @@ g2_unpack2(unsigned char *cgrib, g2int *iofst, g2int *lencsec2,
     /*printf(" SAGIPO %d \n",(int)ipos);*/
     for (j=0;j<*lencsec2;j++)
     {
-	*(*csec2+j)=cgrib[ipos+j];
+        *(*csec2+j)=cgrib[ipos+j];
     }
     *iofst=*iofst+(*lencsec2*8);
 

--- a/src/gbits.c
+++ b/src/gbits.c
@@ -71,21 +71,21 @@ gbits(unsigned char *in, g2int *iout, g2int iskip, g2int nbyte,
         ibit=nbit%8;
         nbit = nbit + nbyte + nskip;
 
-	/*        first byte */
+        /*        first byte */
         tbit= ( bitcnt < (8-ibit) ) ? bitcnt : 8-ibit;  // find min
         itmp = (int)*(in+index) & ones[7-ibit];
         if (tbit != 8-ibit) itmp >>= (8-ibit-tbit);
         index++;
         bitcnt = bitcnt - tbit;
 
-	/*        now transfer whole bytes */
+        /*        now transfer whole bytes */
         while (bitcnt >= 8) {
             itmp = itmp<<8 | (int)*(in+index);
             bitcnt = bitcnt - 8;
             index++;
         }
 
-	/* get data from last byte */
+        /* get data from last byte */
         if (bitcnt > 0) {
             itmp = ( itmp << bitcnt ) | ( ((int)*(in+index) >> (8-bitcnt)) & ones[bitcnt-1] );
         }
@@ -127,7 +127,7 @@ sbits(unsigned char *out, g2int *in, g2int iskip, g2int nbyte,
         ibit=nbit%8;
         nbit = nbit + nbyte + nskip;
 
-	/*        make byte aligned  */
+        /*        make byte aligned  */
         if (ibit != 7) {
             tbit= ( bitcnt < (ibit+1) ) ? bitcnt : ibit+1;  /* find min */
             imask = ones[tbit-1] << (7-ibit);
@@ -139,9 +139,9 @@ sbits(unsigned char *out, g2int *in, g2int iskip, g2int nbyte,
             index--;
         }
 
-	/*        now byte aligned */
+        /*        now byte aligned */
 
-	/*        do by bytes */
+        /*        do by bytes */
         while (bitcnt >= 8) {
             out[index] = (unsigned char)(itmp & 255);
             itmp = itmp >> 8;
@@ -149,7 +149,7 @@ sbits(unsigned char *out, g2int *in, g2int iskip, g2int nbyte,
             index--;
         }
 
-	/*        do last byte */
+        /*        do last byte */
 
         if (bitcnt > 0) {
             itmp2 = itmp & ones[bitcnt-1];

--- a/src/grib2.h
+++ b/src/grib2.h
@@ -123,10 +123,10 @@
  *        gfld->unpacked = logical value indicating whether the bitmap and
  *                        data values were unpacked.  If false,
  *                        gfld->bmap and gfld->fld pointers are nullified.
- *        gfld->expanded = Logical value indicating whether the data field 
- *                         was expanded to the grid in the case where a 
+ *        gfld->expanded = Logical value indicating whether the data field
+ *                         was expanded to the grid in the case where a
  *                         bit-map is present.  If true, the data points in
- *                         gfld->fld match the grid points and zeros were 
+ *                         gfld->fld match the grid points and zeros were
  *                         inserted at grid points where data was bit-mapped
  *                         out.  If false, the data values in gfld->fld were
  *                         not expanded to the grid and are just a consecutive
@@ -147,7 +147,7 @@
  *   </pre>
  *
  * @author Stephen Gilbert @date 2002-10-25
-*/
+ */
 #ifndef _grib2_H
 #define _grib2_H
 #include<stdio.h>
@@ -164,46 +164,46 @@ typedef unsigned long g2intu;
 typedef float g2float;
 
 struct gtemplate {
-   g2int type;           /* 3=Grid Defintion Template.                       */
-                         /* 4=Product Defintion Template.                    */
-                         /* 5=Data Representation Template.                  */
-   g2int num;            /* template number.                                 */
-   g2int maplen;         /* number of entries in the static part             */
-                         /*                    of the template.              */
-   g2int *map;           /* num of octets of each entry in the               */
-                         /*         static part of the template.             */
-   g2int needext;        /* indicates whether or not the template needs      */
-                         /*     to be extended.                              */
-   g2int extlen;         /* number of entries in the template extension.     */
-   g2int *ext;           /* num of octets of each entry in the extension     */
-                         /*                      part of the template.       */
+    g2int type;           /* 3=Grid Defintion Template.                       */
+    /* 4=Product Defintion Template.                    */
+    /* 5=Data Representation Template.                  */
+    g2int num;            /* template number.                                 */
+    g2int maplen;         /* number of entries in the static part             */
+    /*                    of the template.              */
+    g2int *map;           /* num of octets of each entry in the               */
+    /*         static part of the template.             */
+    g2int needext;        /* indicates whether or not the template needs      */
+    /*     to be extended.                              */
+    g2int extlen;         /* number of entries in the template extension.     */
+    g2int *ext;           /* num of octets of each entry in the extension     */
+    /*                      part of the template.       */
 };
 
 typedef struct gtemplate gtemplate;
 
 struct gribfield {
-   g2int   version,discipline;
-   g2int   *idsect;
-   g2int   idsectlen;
-   unsigned char *local;
-   g2int   locallen;
-   g2int   ifldnum;
-   g2int   griddef,ngrdpts;
-   g2int   numoct_opt,interp_opt,num_opt;
-   g2int   *list_opt;
-   g2int   igdtnum,igdtlen;
-   g2int   *igdtmpl;
-   g2int   ipdtnum,ipdtlen;
-   g2int   *ipdtmpl;
-   g2int   num_coord;
-   g2float *coord_list;
-   g2int   ndpts,idrtnum,idrtlen;
-   g2int   *idrtmpl;
-   g2int   unpacked;
-   g2int   expanded;
-   g2int   ibmap;
-   g2int   *bmap;
-   g2float *fld;
+    g2int   version,discipline;
+    g2int   *idsect;
+    g2int   idsectlen;
+    unsigned char *local;
+    g2int   locallen;
+    g2int   ifldnum;
+    g2int   griddef,ngrdpts;
+    g2int   numoct_opt,interp_opt,num_opt;
+    g2int   *list_opt;
+    g2int   igdtnum,igdtlen;
+    g2int   *igdtmpl;
+    g2int   ipdtnum,ipdtlen;
+    g2int   *ipdtmpl;
+    g2int   num_coord;
+    g2float *coord_list;
+    g2int   ndpts,idrtnum,idrtlen;
+    g2int   *idrtmpl;
+    g2int   unpacked;
+    g2int   expanded;
+    g2int   ibmap;
+    g2int   *bmap;
+    g2float *fld;
 };
 
 typedef struct gribfield gribfield;
@@ -225,10 +225,10 @@ void g2_free(gribfield *);
 /*  Prototypes for packing API  */
 g2int g2_create(unsigned char *,g2int *,g2int *);
 g2int g2_addlocal(unsigned char *,unsigned char *,g2int );
-g2int g2_addgrid(unsigned char *,g2int *,g2int *,g2int *,g2int ); 
+g2int g2_addgrid(unsigned char *,g2int *,g2int *,g2int *,g2int );
 g2int g2_addfield(unsigned char *,g2int ,g2int *,
-                       g2float *,g2int ,g2int ,g2int *,
-                       g2float *,g2int ,g2int ,g2int *);
+                  g2float *,g2int ,g2int ,g2int *,
+                  g2float *,g2int ,g2int ,g2int *);
 g2int g2_gribend(unsigned char *);
 
 /*  Prototypes for supporting routines  */
@@ -256,4 +256,3 @@ int pack_gp(g2int *, g2int *, g2int *,
             g2int *, g2int *, g2int *);
 
 #endif  /*  _grib2_H  */
-

--- a/src/gridtemplates.c
+++ b/src/gridtemplates.c
@@ -33,10 +33,10 @@ getgridindex(g2int number)
     g2int j,getgridindex=-1;
 
     for (j=0;j<MAXGRIDTEMP;j++) {
-	if (number == templatesgrid[j].template_num) {
-	    getgridindex=j;
-	    return(getgridindex);
-	}
+        if (number == templatesgrid[j].template_num) {
+            getgridindex=j;
+            return(getgridindex);
+        }
     }
 
     return(getgridindex);
@@ -73,19 +73,19 @@ getgridtemplate(g2int number)
     index=getgridindex(number);
 
     if (index != -1) {
-	new=(gtemplate *)malloc(sizeof(gtemplate));
-	new->type=3;
-	new->num=templatesgrid[index].template_num;
-	new->maplen=templatesgrid[index].mapgridlen;
-	new->needext=templatesgrid[index].needext;
-	new->map=(g2int *)templatesgrid[index].mapgrid;
-	new->extlen=0;
-	new->ext=0;        /*NULL */
-	return(new);
+        new=(gtemplate *)malloc(sizeof(gtemplate));
+        new->type=3;
+        new->num=templatesgrid[index].template_num;
+        new->maplen=templatesgrid[index].mapgridlen;
+        new->needext=templatesgrid[index].needext;
+        new->map=(g2int *)templatesgrid[index].mapgrid;
+        new->extlen=0;
+        new->ext=0;        /*NULL */
+        return(new);
     }
     else {
-	printf("getgridtemplate: GDT Template 3.%d not defined.\n",(int)number);
-	return(0);        /* NULL */
+        printf("getgridtemplate: GDT Template 3.%d not defined.\n",(int)number);
+        return(0);        /* NULL */
     }
 
     return(0);        /* NULL */
@@ -130,54 +130,54 @@ extgridtemplate(g2int number, g2int *list)
     if ( ! new->needext ) return(new);
 
     if ( number == 120 ) {
-	new->extlen=list[1]*2;
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    if ( i%2 == 0 ) {
-		new->ext[i]=2;
-	    }
-	    else {
-		new->ext[i]=-2;
-	    }
-	}
+        new->extlen=list[1]*2;
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            if ( i%2 == 0 ) {
+                new->ext[i]=2;
+            }
+            else {
+                new->ext[i]=-2;
+            }
+        }
     }
     else if ( number == 4 ) {
-	new->extlen=list[7];
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    new->ext[i]=4;
-	}
-	new->extlen=list[8];
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    new->ext[i]=-4;
-	}
+        new->extlen=list[7];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=4;
+        }
+        new->extlen=list[8];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=-4;
+        }
     }
     else if ( number == 5 ) {
-	new->extlen=list[7];
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    new->ext[i]=4;
-	}
-	new->extlen=list[8];
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    new->ext[i]=-4;
-	}
+        new->extlen=list[7];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=4;
+        }
+        new->extlen=list[8];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=-4;
+        }
     }
     else if ( number == 1000 ) {
-	new->extlen=list[19];
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    new->ext[i]=4;
-	}
+        new->extlen=list[19];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=4;
+        }
     }
     else if ( number == 1200 ) {
-	new->extlen=list[15];
-	new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-	for (i=0;i<new->extlen;i++) {
-	    new->ext[i]=4;
-	}
+        new->extlen=list[15];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=4;
+        }
     }
 
     return(new);

--- a/src/gridtemplates.h
+++ b/src/gridtemplates.h
@@ -1,7 +1,7 @@
 /** @file
  * @author Gilbert @date 2001-10-26
  *
- * This Fortran Module contains info on all the available 
+ * This Fortran Module contains info on all the available
  *   GRIB2 Grid Definition Templates used in Section 3 (GDS).
  *   The information decribing each template is stored in the
  *   gridtemplate structure defined below.
@@ -9,12 +9,12 @@
  *   Each Template has three parts: The number of entries in the template
  *   (mapgridlen);  A map of the template (mapgrid), which contains the
  *   number of octets in which to pack each of the template values; and
- *   a logical value (needext) that indicates whether the Template needs 
- *   to be extended.  In some cases the number of entries in a template 
- *   can vary depending upon values specified in the "static" part of 
+ *   a logical value (needext) that indicates whether the Template needs
+ *   to be extended.  In some cases the number of entries in a template
+ *   can vary depending upon values specified in the "static" part of
  *   the template.  ( See Template 3.120 as an example )
  *
- *   NOTE:  Array mapgrid contains the number of octets in which the 
+ *   NOTE:  Array mapgrid contains the number of octets in which the
  *   corresponding template values will be stored.  A negative value in
  *   mapgrid is used to indicate that the corresponding template entry can
  *   contain negative values.  This information is used later when packing
@@ -22,9 +22,9 @@
  *   are stored with the left most bit set to one, and a negative number
  *   of octets value in mapgrid[] indicates that this possibility should
  *   be considered.  The number of octets used to store the data value
- *   in this case would be the absolute value of the negative value in 
+ *   in this case would be the absolute value of the negative value in
  *   mapgrid[].
- *  
+ *
  * PROGRAM HISTORY LOG:
  *
  * -2001-10-26  Gilbert
@@ -38,84 +38,84 @@
 #define _gridtemplates_H
 #include "grib2.h"
 
-      #define MAXGRIDTEMP 31              // maximum number of templates
-      #define MAXGRIDMAPLEN 200           // maximum template map length
+#define MAXGRIDTEMP 31              // maximum number of templates
+#define MAXGRIDMAPLEN 200           // maximum template map length
 
-      struct gridtemplate
-      {
-          g2int template_num;
-          g2int mapgridlen;
-          g2int needext;
-          g2int mapgrid[MAXGRIDMAPLEN];
-      };
+struct gridtemplate
+{
+    g2int template_num;
+    g2int mapgridlen;
+    g2int needext;
+    g2int mapgrid[MAXGRIDMAPLEN];
+};
 
-      const struct gridtemplate templatesgrid[MAXGRIDTEMP] = {
-             // 3.0: Lat/Lon grid
-         { 0, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
-             // 3.1: Rotated Lat/Lon grid
-         { 1, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4} },
-             // 3.2: Stretched Lat/Lon grid
-         { 2, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,-4} },
-             // 3.3: Stretched & Rotated Lat/Lon grid
-         { 3, 25, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4,-4,4,-4} },
+const struct gridtemplate templatesgrid[MAXGRIDTEMP] = {
+    // 3.0: Lat/Lon grid
+    { 0, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
+    // 3.1: Rotated Lat/Lon grid
+    { 1, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4} },
+    // 3.2: Stretched Lat/Lon grid
+    { 2, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,-4} },
+    // 3.3: Stretched & Rotated Lat/Lon grid
+    { 3, 25, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4,-4,4,-4} },
 // Added GDT 3.4,3.5    (08/05/2013)
-             // 3.4: Variable resolution Latitude/Longitude
-         { 4, 13, 1, {1,1,4,1,4,1,4,4,4,4,4,1,1} },
-             // 3.5: Variable resolution rotate Latitude/Longitude
-         { 5, 16, 1, {1,1,4,1,4,1,4,4,4,4,4,1,1,-4,4,4} },
-             // 3.12: Transverse Mercator
-         {12, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,1,4,4,-4,-4,-4,-4} },
-             // 3.101: General unstructured grid
-         {101, 4, 0, {1,4,1,-4} },
-             // 3.140: Lambert Azimuthal Equal Area Projection
-         {140, 17, 0, {1,1,4,1,4,1,4,4,4,-4,4,4,4,1,4,4,1} },
+    // 3.4: Variable resolution Latitude/Longitude
+    { 4, 13, 1, {1,1,4,1,4,1,4,4,4,4,4,1,1} },
+    // 3.5: Variable resolution rotate Latitude/Longitude
+    { 5, 16, 1, {1,1,4,1,4,1,4,4,4,4,4,1,1,-4,4,4} },
+    // 3.12: Transverse Mercator
+    {12, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,1,4,4,-4,-4,-4,-4} },
+    // 3.101: General unstructured grid
+    {101, 4, 0, {1,4,1,-4} },
+    // 3.140: Lambert Azimuthal Equal Area Projection
+    {140, 17, 0, {1,1,4,1,4,1,4,4,4,-4,4,4,4,1,4,4,1} },
 //
-             // 3.10: Mercator
-         {10, 19, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,-4,4,1,4,4,4} },
-             // 3.20: Polar Stereographic Projection
-         {20, 18, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,4,1,1} },
-             // 3.30: Lambert Conformal
-         {30, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,4,1,1,-4,-4,-4,4} },
-             // 3.31: Albers equal area
-         {31, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,4,1,1,-4,-4,-4,4} },
-             // 3.40: Guassian Lat/Lon
-         {40, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
-             // 3.41: Rotated Gaussian Lat/Lon
-         {41, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4} },
-             // 3.42: Stretched Gaussian Lat/Lon
-         {42, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,-4} },
-             // 3.43: Stretched and Rotated Gaussian Lat/Lon
-         {43, 25, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4,-4,4,-4} },
-             // 3.50: Spherical Harmonic Coefficients
-         {50, 5, 0, {4,4,4,1,1} },
-             // 3.51: Rotated Spherical Harmonic Coefficients
-         {51, 8, 0, {4,4,4,1,1,-4,4,4} },
-             // 3.52: Stretched Spherical Harmonic Coefficients
-         {52, 8, 0, {4,4,4,1,1,-4,4,-4} },
-             // 3.53: Stretched and Rotated Spherical Harmonic Coefficients
-         {53, 11, 0, {4,4,4,1,1,-4,4,4,-4,4,-4} },
-             // 3.90: Space View Perspective or orthographic
-         {90, 21, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,4,4,4,4,1,4,4,4,4} },
-             // 3.100: Triangular grid based on an icosahedron
-         {100, 11, 0, {1,1,2,1,-4,4,4,1,1,1,4} },
-             // 3.110: Equatorial Azimuthal equidistant
-         {110, 16, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,4,4,1,1} },
-             // 3.120: Azimuth-range projection
-         {120, 7, 1, {4,4,-4,4,4,4,1} },
-             // 3.204: Curvilinear Orthogonal Grid
-         {204, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
-             // 3.32768: Rot Lat/Lon E-grid (Arakawa)
-         {32768, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
-             // 3.32769: Rot Lat/Lon Non-E Staggered grid (Arakawa)
-         {32769, 21, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,4,4} },
-             // 3.1000: Cross Section Grid
-         {1000, 20, 1, {1,1,4,1,4,1,4,4,4,4,-4,4,1,4,4,1,2,1,1,2} },
-             // 3.1100: Hovmoller Diagram Grid
-         {1100, 28, 0, {1,1,4,1,4,1,4,4,4,4,-4,4,1,-4,4,1,4,1,-4,1,1,-4,2,1,1,1,1,1} },
-             // 3.1200: Time Section Grid
-         {1200, 16, 1, {4,1,-4,1,1,-4,2,1,1,1,1,1,2,1,1,2} }
+    // 3.10: Mercator
+    {10, 19, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,-4,4,1,4,4,4} },
+    // 3.20: Polar Stereographic Projection
+    {20, 18, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,4,1,1} },
+    // 3.30: Lambert Conformal
+    {30, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,4,1,1,-4,-4,-4,4} },
+    // 3.31: Albers equal area
+    {31, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,4,1,1,-4,-4,-4,4} },
+    // 3.40: Guassian Lat/Lon
+    {40, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
+    // 3.41: Rotated Gaussian Lat/Lon
+    {41, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4} },
+    // 3.42: Stretched Gaussian Lat/Lon
+    {42, 22, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,-4} },
+    // 3.43: Stretched and Rotated Gaussian Lat/Lon
+    {43, 25, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,-4,4,4,-4,4,-4} },
+    // 3.50: Spherical Harmonic Coefficients
+    {50, 5, 0, {4,4,4,1,1} },
+    // 3.51: Rotated Spherical Harmonic Coefficients
+    {51, 8, 0, {4,4,4,1,1,-4,4,4} },
+    // 3.52: Stretched Spherical Harmonic Coefficients
+    {52, 8, 0, {4,4,4,1,1,-4,4,-4} },
+    // 3.53: Stretched and Rotated Spherical Harmonic Coefficients
+    {53, 11, 0, {4,4,4,1,1,-4,4,4,-4,4,-4} },
+    // 3.90: Space View Perspective or orthographic
+    {90, 21, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,4,4,4,4,1,4,4,4,4} },
+    // 3.100: Triangular grid based on an icosahedron
+    {100, 11, 0, {1,1,2,1,-4,4,4,1,1,1,4} },
+    // 3.110: Equatorial Azimuthal equidistant
+    {110, 16, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,4,4,1,1} },
+    // 3.120: Azimuth-range projection
+    {120, 7, 1, {4,4,-4,4,4,4,1} },
+    // 3.204: Curvilinear Orthogonal Grid
+    {204, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
+    // 3.32768: Rot Lat/Lon E-grid (Arakawa)
+    {32768, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },
+    // 3.32769: Rot Lat/Lon Non-E Staggered grid (Arakawa)
+    {32769, 21, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1,4,4} },
+    // 3.1000: Cross Section Grid
+    {1000, 20, 1, {1,1,4,1,4,1,4,4,4,4,-4,4,1,4,4,1,2,1,1,2} },
+    // 3.1100: Hovmoller Diagram Grid
+    {1100, 28, 0, {1,1,4,1,4,1,4,4,4,4,-4,4,1,-4,4,1,4,1,-4,1,1,-4,2,1,1,1,1,1} },
+    // 3.1200: Time Section Grid
+    {1200, 16, 1, {4,1,-4,1,1,-4,2,1,1,1,1,1,2,1,1,2} }
 
-      } ;
+} ;
 
 
 #endif  /*  _gridtemplates_H  */

--- a/src/int_power.c
+++ b/src/int_power.c
@@ -12,21 +12,20 @@
  */
 double int_power(double x, g2int y) {
 
-        double value;
+    double value;
 
-        if (y < 0) {
-                y = -y;
-                x = 1.0 / x;
-        }
-        value = 1.0;
+    if (y < 0) {
+        y = -y;
+        x = 1.0 / x;
+    }
+    value = 1.0;
 
-        while (y) {
-                if (y & 1) {
-                        value *= x;
-                }
-                x = x * x;
-                y >>= 1;
+    while (y) {
+        if (y & 1) {
+            value *= x;
         }
-        return value;
+        x = x * x;
+        y >>= 1;
+    }
+    return value;
 }
-

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -15,7 +15,7 @@ int enc_jpeg2000(unsigned char *,g2int ,g2int ,g2int ,
 // ABSTRACT: This subroutine packs up a data field into a JPEG2000 code stream.
 //   After the data field is scaled, and the reference value is subtracted out,
 //   it is treated as a grayscale image and passed to a JPEG2000 encoder.
-//   It also fills in GRIB2 Data Representation Template 5.40 or 5.40000 with 
+//   It also fills in GRIB2 Data Representation Template 5.40 or 5.40000 with
 //   the appropriate values.
 //
 // PROGRAM HISTORY LOG:
@@ -48,7 +48,7 @@ int enc_jpeg2000(unsigned char *,g2int ,g2int ,g2int ,
 //                      Set to 255, if idrstmpl[5]=0.
 //     lcpack   - size of array cpack[]
 //
-//   OUTPUT ARGUMENT LIST: 
+//   OUTPUT ARGUMENT LIST:
 //     idrstmpl - Contains the array of values for Data Representation
 //                Template 5.0
 //                [0] = Reference value - set by jpcpack routine.
@@ -60,7 +60,7 @@ int enc_jpeg2000(unsigned char *,g2int ,g2int ,g2int ,
 //                [5] = 0 - use lossless compression
 //                    = 1 - use lossy compression
 //                [6] = Desired compression ratio, if idrstmpl[5]=1
-//     cpack    - The packed data field 
+//     cpack    - The packed data field
 //     lcpack   - length of packed field in cpack.
 //
 // REMARKS: None
@@ -73,70 +73,70 @@ int enc_jpeg2000(unsigned char *,g2int ,g2int ,g2int ,
 void jpcpack(g2float *fld,g2int width,g2int height,g2int *idrstmpl,
              unsigned char *cpack,g2int *lcpack)
 {
-      g2int  *ifld;
-      static g2float alog2=0.69314718;       //  ln(2.0)
-      g2int  j,nbits,imin,imax,maxdif;
-      g2int  ndpts,nbytes,nsize,retry;
-      g2float  bscale,dscale,rmax,rmin,temp;
-      unsigned char *ctemp;
-      
-      ifld=0;
-      ndpts=width*height;
-      bscale=int_power(2.0,-idrstmpl[1]);
-      dscale=int_power(10.0,idrstmpl[2]);
+    g2int  *ifld;
+    static g2float alog2=0.69314718;       //  ln(2.0)
+    g2int  j,nbits,imin,imax,maxdif;
+    g2int  ndpts,nbytes,nsize,retry;
+    g2float  bscale,dscale,rmax,rmin,temp;
+    unsigned char *ctemp;
+
+    ifld=0;
+    ndpts=width*height;
+    bscale=int_power(2.0,-idrstmpl[1]);
+    dscale=int_power(10.0,idrstmpl[2]);
 //
 //  Find max and min values in the data
 //
-      rmax=fld[0];
-      rmin=fld[0];
-      for (j=1;j<ndpts;j++) {
+    rmax=fld[0];
+    rmin=fld[0];
+    for (j=1;j<ndpts;j++) {
         if (fld[j] > rmax) rmax=fld[j];
         if (fld[j] < rmin) rmin=fld[j];
-      }
-      if (idrstmpl[1] == 0) 
-         maxdif = (g2int) (rint(rmax*dscale) - rint(rmin*dscale));
-      else
-         maxdif = (g2int)rint( (rmax-rmin)*dscale*bscale );
+    }
+    if (idrstmpl[1] == 0)
+        maxdif = (g2int) (rint(rmax*dscale) - rint(rmin*dscale));
+    else
+        maxdif = (g2int)rint( (rmax-rmin)*dscale*bscale );
 //
 //  If max and min values are not equal, pack up field.
 //  If they are equal, we have a constant field, and the reference
 //  value (rmin) is the value for each point in the field and
 //  set nbits to 0.
 //
-      if ( rmin != rmax  &&  maxdif != 0 ) {
+    if ( rmin != rmax  &&  maxdif != 0 ) {
         ifld=(g2int *)malloc(ndpts*sizeof(g2int));
         //
-        //  Determine which algorithm to use based on user-supplied 
+        //  Determine which algorithm to use based on user-supplied
         //  binary scale factor and number of bits.
         //
         if (idrstmpl[1] == 0) {
-           //
-           //  No binary scaling and calculate minumum number of 
-           //  bits in which the data will fit.
-           //
-           imin=(g2int)rint(rmin*dscale);
-           imax=(g2int)rint(rmax*dscale);
-           maxdif=imax-imin;
-           temp=log((double)(maxdif+1))/alog2;
-           nbits=(g2int)ceil(temp);
-           rmin=(g2float)imin;
-           //   scale data
-           for(j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
+            //
+            //  No binary scaling and calculate minumum number of
+            //  bits in which the data will fit.
+            //
+            imin=(g2int)rint(rmin*dscale);
+            imax=(g2int)rint(rmax*dscale);
+            maxdif=imax-imin;
+            temp=log((double)(maxdif+1))/alog2;
+            nbits=(g2int)ceil(temp);
+            rmin=(g2float)imin;
+            //   scale data
+            for(j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
         }
         else {
-           //
-           //  Use binary scaling factor and calculate minumum number of 
-           //  bits in which the data will fit.
-           //
-           rmin=rmin*dscale;
-           rmax=rmax*dscale;
-           maxdif=(g2int)rint((rmax-rmin)*bscale);
-           temp=log((double)(maxdif+1))/alog2;
-           nbits=(g2int)ceil(temp);
-           //   scale data
-           for (j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
+            //
+            //  Use binary scaling factor and calculate minumum number of
+            //  bits in which the data will fit.
+            //
+            rmin=rmin*dscale;
+            rmax=rmax*dscale;
+            maxdif=(g2int)rint((rmax-rmin)*bscale);
+            temp=log((double)(maxdif+1))/alog2;
+            nbits=(g2int)ceil(temp);
+            //   scale data
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
         }
         //
         //  Pack data into full octets, then do JPEG 2000 encode.
@@ -149,29 +149,29 @@ void jpcpack(g2float *fld,g2int width,g2int height,g2int *idrstmpl,
         sbits(ctemp,ifld,0,nbytes*8,0,ndpts);
         *lcpack=(g2int)enc_jpeg2000(ctemp,width,height,nbits,idrstmpl[5],idrstmpl[6],retry,(char *)cpack,nsize);
         if (*lcpack <= 0) {
-           printf("jpcpack: ERROR Packing JPC = %d\n",(int)*lcpack);
-           if ( *lcpack == -3 ) {
-              retry=1;
-              *lcpack=(g2int)enc_jpeg2000(ctemp,width,height,nbits,idrstmpl[5],idrstmpl[6],retry,(char *)cpack,nsize);
-              if ( *lcpack <= 0 ) printf("jpcpack: Retry Failed.\n");
-              else printf("jpcpack: Retry Successful.\n");
-           }
+            printf("jpcpack: ERROR Packing JPC = %d\n",(int)*lcpack);
+            if ( *lcpack == -3 ) {
+                retry=1;
+                *lcpack=(g2int)enc_jpeg2000(ctemp,width,height,nbits,idrstmpl[5],idrstmpl[6],retry,(char *)cpack,nsize);
+                if ( *lcpack <= 0 ) printf("jpcpack: Retry Failed.\n");
+                else printf("jpcpack: Retry Successful.\n");
+            }
         }
         free(ctemp);
 
-      }
-      else {
+    }
+    else {
         nbits=0;
         *lcpack=0;
-      }
+    }
 
 //
 //  Fill in ref value and number of bits in Template 5.0
 //
-      mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
-      idrstmpl[3]=nbits;
-      idrstmpl[4]=0;         // original data were reals
-      if (idrstmpl[5] == 0) idrstmpl[6]=255;       // lossy not used
-      if (ifld != 0) free(ifld);
+    mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
+    idrstmpl[3]=nbits;
+    idrstmpl[4]=0;         // original data were reals
+    if (idrstmpl[5] == 0) idrstmpl[6]=255;       // lossy not used
+    if (ifld != 0) free(ifld);
 
 }

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -4,14 +4,14 @@
 #include <stdlib.h>
 #include "grib2.h"
 
-   int dec_jpeg2000(char *,g2int ,g2int *);
+int dec_jpeg2000(char *,g2int ,g2int *);
 
 //$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
 // SUBPROGRAM:    jpcunpack
 //   PRGMMR: Gilbert          ORG: W/NP11    DATE: 2003-08-27
 //
-// ABSTRACT: This subroutine unpacks a data field that was packed into a 
+// ABSTRACT: This subroutine unpacks a data field that was packed into a
 //   JPEG2000 code stream
 //   using info from the GRIB2 Data Representation Template 5.40 or 5.40000.
 //
@@ -41,34 +41,34 @@ g2int jpcunpack(unsigned char *cpack,g2int len,g2int *idrstmpl,g2int ndpts,
                 g2float *fld)
 {
 
-      g2int  *ifld;
-      g2int  j,nbits,iret;
-      g2float  ref,bscale,dscale;
+    g2int  *ifld;
+    g2int  j,nbits,iret;
+    g2float  ref,bscale,dscale;
 
-      rdieee(idrstmpl+0,&ref,1);
-      bscale = int_power(2.0,idrstmpl[1]);
-      dscale = int_power(10.0,-idrstmpl[2]);
-      nbits = idrstmpl[3];
+    rdieee(idrstmpl+0,&ref,1);
+    bscale = int_power(2.0,idrstmpl[1]);
+    dscale = int_power(10.0,-idrstmpl[2]);
+    nbits = idrstmpl[3];
 //
 //  if nbits equals 0, we have a constant field where the reference value
 //  is the data value at each gridpoint
 //
-      if (nbits != 0) {
+    if (nbits != 0) {
 
-         ifld=(g2int *)calloc(ndpts,sizeof(g2int));
-         if ( ifld == 0 ) {
+        ifld=(g2int *)calloc(ndpts,sizeof(g2int));
+        if ( ifld == 0 ) {
             fprintf(stderr,"Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
             return(1);
-         }
-         iret=(g2int)dec_jpeg2000(cpack,len,ifld);
-         for (j=0;j<ndpts;j++) {
-           fld[j]=(((g2float)ifld[j]*bscale)+ref)*dscale;
-         }
-         free(ifld);
-      }
-      else {
-         for (j=0;j<ndpts;j++) fld[j]=ref;
-      }
+        }
+        iret=(g2int)dec_jpeg2000(cpack,len,ifld);
+        for (j=0;j<ndpts;j++) {
+            fld[j]=(((g2float)ifld[j]*bscale)+ref)*dscale;
+        }
+        free(ifld);
+    }
+    else {
+        for (j=0;j<ndpts;j++) fld[j]=ref;
+    }
 
-      return(0);
+    return(0);
 }

--- a/src/misspack.c
+++ b/src/misspack.c
@@ -13,7 +13,7 @@
 //   packing algorithm as defined in the GRIB2 documention.  It
 //   supports GRIB2 complex packing templates with or without
 //   spatial differences (i.e. DRTs 5.2 and 5.3).
-//   It also fills in GRIB2 Data Representation Template 5.2 or 5.3 
+//   It also fills in GRIB2 Data Representation Template 5.2 or 5.3
 //   with the appropriate values.
 //   This version assumes that Missing Value Management is being used and that
 //   1 or 2 missing values appear in the data.
@@ -44,7 +44,7 @@
 //                    .
 //                    .
 //
-//   OUTPUT ARGUMENT LIST: 
+//   OUTPUT ARGUMENT LIST:
 //     idrstmpl - Contains the array of values for Data Representation
 //                Template 5.3
 //                [0] = Reference value - set by misspack routine.
@@ -59,476 +59,476 @@
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$
 void misspack(g2float *fld,g2int ndpts,g2int idrsnum,g2int *idrstmpl,
               unsigned char *cpack, g2int *lcpack)
 {
 
-      g2int  *ifld, *ifldmiss, *jfld;
-      g2int  *jmin, *jmax, *lbit;
-      static g2int zero=0;
-      g2int  *gref, *gwidth, *glen;
-      g2int  glength, grpwidth;
-      g2int  i, n, iofst, imin, ival1, ival2, isd, minsd, nbitsd;
-      g2int  nbitsgref, left, iwmax, ngwidthref, nbitsgwidth, ilmax;
-      g2int  nglenref, nglenlast, nbitsglen, ij;
-      g2int  j, missopt, nonmiss, itemp, maxorig, nbitorig, miss1, miss2;
-      g2int  ngroups, ng, num0, num1, num2;
-      g2int  imax, lg, mtemp, ier, igmax;
-      g2int  kfildo, minpk, inc, maxgrps, ibit, jbit, kbit, novref, lbitref;
-      g2float  rmissp, rmisss, bscale, dscale, rmin, temp;
-      static g2int simple_alg = 0;
-      static g2float alog2=0.69314718;       //  ln(2.0)
-      static g2int one=1;
-      
-      bscale=int_power(2.0,-idrstmpl[1]);
-      dscale=int_power(10.0,idrstmpl[2]);
-      missopt=idrstmpl[6];
-      if ( missopt != 1 && missopt != 2 ) {
-         printf("misspack: Unrecognized option.\n");
-         *lcpack=-1;
-         return;
-      }
-      else {    //  Get missing values
-         rdieee(idrstmpl+7,&rmissp,1);
-         if (missopt == 2) rdieee(idrstmpl+8,&rmisss,1);
-      }
+    g2int  *ifld, *ifldmiss, *jfld;
+    g2int  *jmin, *jmax, *lbit;
+    static g2int zero=0;
+    g2int  *gref, *gwidth, *glen;
+    g2int  glength, grpwidth;
+    g2int  i, n, iofst, imin, ival1, ival2, isd, minsd, nbitsd;
+    g2int  nbitsgref, left, iwmax, ngwidthref, nbitsgwidth, ilmax;
+    g2int  nglenref, nglenlast, nbitsglen, ij;
+    g2int  j, missopt, nonmiss, itemp, maxorig, nbitorig, miss1, miss2;
+    g2int  ngroups, ng, num0, num1, num2;
+    g2int  imax, lg, mtemp, ier, igmax;
+    g2int  kfildo, minpk, inc, maxgrps, ibit, jbit, kbit, novref, lbitref;
+    g2float  rmissp, rmisss, bscale, dscale, rmin, temp;
+    static g2int simple_alg = 0;
+    static g2float alog2=0.69314718;       //  ln(2.0)
+    static g2int one=1;
+
+    bscale=int_power(2.0,-idrstmpl[1]);
+    dscale=int_power(10.0,idrstmpl[2]);
+    missopt=idrstmpl[6];
+    if ( missopt != 1 && missopt != 2 ) {
+        printf("misspack: Unrecognized option.\n");
+        *lcpack=-1;
+        return;
+    }
+    else {    //  Get missing values
+        rdieee(idrstmpl+7,&rmissp,1);
+        if (missopt == 2) rdieee(idrstmpl+8,&rmisss,1);
+    }
 //
 //  Find min value of non-missing values in the data,
 //  AND set up missing value mapping of the field.
 //
-      ifldmiss = calloc(ndpts,sizeof(g2int));
-      rmin=1E+37;
-      if ( missopt ==  1 ) {        // Primary missing value only
-         for ( j=0; j<ndpts; j++) {
-           if (fld[j] == rmissp) {
-              ifldmiss[j]=1;
-           }
-           else {
-              ifldmiss[j]=0;
-              if (fld[j] < rmin) rmin=fld[j];
-           }
-         }
-      }
-      if ( missopt ==  2 ) {        // Primary and secondary missing values
-         for ( j=0; j<ndpts; j++ ) {
-           if (fld[j] == rmissp) {
-              ifldmiss[j]=1;
-           }
-           else if (fld[j] == rmisss) {
-              ifldmiss[j]=2;
-           }
-           else {
-              ifldmiss[j]=0;
-              if (fld[j] < rmin) rmin=fld[j];
-           }
-         }
-      }
+    ifldmiss = calloc(ndpts,sizeof(g2int));
+    rmin=1E+37;
+    if ( missopt ==  1 ) {        // Primary missing value only
+        for ( j=0; j<ndpts; j++) {
+            if (fld[j] == rmissp) {
+                ifldmiss[j]=1;
+            }
+            else {
+                ifldmiss[j]=0;
+                if (fld[j] < rmin) rmin=fld[j];
+            }
+        }
+    }
+    if ( missopt ==  2 ) {        // Primary and secondary missing values
+        for ( j=0; j<ndpts; j++ ) {
+            if (fld[j] == rmissp) {
+                ifldmiss[j]=1;
+            }
+            else if (fld[j] == rmisss) {
+                ifldmiss[j]=2;
+            }
+            else {
+                ifldmiss[j]=0;
+                if (fld[j] < rmin) rmin=fld[j];
+            }
+        }
+    }
 //
 //  Allocate work arrays:
-//  Note: -ifldmiss[j],j=0,ndpts-1 is a map of original field indicating 
+//  Note: -ifldmiss[j],j=0,ndpts-1 is a map of original field indicating
 //         which of the original data values
 //         are primary missing (1), sencondary missing (2) or non-missing (0).
-//        -jfld[j],j=0,nonmiss-1 is a subarray of just the non-missing values 
+//        -jfld[j],j=0,nonmiss-1 is a subarray of just the non-missing values
 //         from the original field.
 //
-      //if (rmin != rmax) {
-        iofst=0;
-        ifld = calloc(ndpts,sizeof(g2int));
-        jfld = calloc(ndpts,sizeof(g2int));
-        gref = calloc(ndpts,sizeof(g2int));
-        gwidth = calloc(ndpts,sizeof(g2int));
-        glen = calloc(ndpts,sizeof(g2int));
-        //
-        //  Scale original data
-        //
-        nonmiss=0;
-        if (idrstmpl[1] == 0) {        //  No binary scaling
-           imin=(g2int)rint(rmin*dscale);
-           //imax=(g2int)rint(rmax*dscale);
-           rmin=(g2float)imin;
-           for ( j=0; j<ndpts; j++) {
-              if (ifldmiss[j] == 0) {
+    //if (rmin != rmax) {
+    iofst=0;
+    ifld = calloc(ndpts,sizeof(g2int));
+    jfld = calloc(ndpts,sizeof(g2int));
+    gref = calloc(ndpts,sizeof(g2int));
+    gwidth = calloc(ndpts,sizeof(g2int));
+    glen = calloc(ndpts,sizeof(g2int));
+    //
+    //  Scale original data
+    //
+    nonmiss=0;
+    if (idrstmpl[1] == 0) {        //  No binary scaling
+        imin=(g2int)rint(rmin*dscale);
+        //imax=(g2int)rint(rmax*dscale);
+        rmin=(g2float)imin;
+        for ( j=0; j<ndpts; j++) {
+            if (ifldmiss[j] == 0) {
                 jfld[nonmiss]=(g2int)rint(fld[j]*dscale)-imin;
                 nonmiss++;
-              }
-           }
+            }
         }
-        else {                             //  Use binary scaling factor
-           rmin=rmin*dscale;
-           //rmax=rmax*dscale;
-           for ( j=0; j<ndpts; j++ ) {
-              if (ifldmiss[j] == 0) {
+    }
+    else {                             //  Use binary scaling factor
+        rmin=rmin*dscale;
+        //rmax=rmax*dscale;
+        for ( j=0; j<ndpts; j++ ) {
+            if (ifldmiss[j] == 0) {
                 jfld[nonmiss]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
                 nonmiss++;
-              }
-           }
+            }
+        }
+    }
+    //
+    //  Calculate Spatial differences, if using DRS Template 5.3
+    //
+    if (idrsnum == 3) {        // spatial differences
+        if (idrstmpl[16]!=1 && idrstmpl[16]!=2) idrstmpl[16]=2;
+        if (idrstmpl[16] == 1) {      // first order
+            ival1=jfld[0];
+            for ( j=nonmiss-1; j>0; j--)
+                jfld[j]=jfld[j]-jfld[j-1];
+            jfld[0]=0;
+        }
+        else if (idrstmpl[16] == 2) {      // second order
+            ival1=jfld[0];
+            ival2=jfld[1];
+            for ( j=nonmiss-1; j>1; j--)
+                jfld[j]=jfld[j]-(2*jfld[j-1])+jfld[j-2];
+            jfld[0]=0;
+            jfld[1]=0;
         }
         //
-        //  Calculate Spatial differences, if using DRS Template 5.3
+        //  subtract min value from spatial diff field
         //
-        if (idrsnum == 3) {        // spatial differences
-           if (idrstmpl[16]!=1 && idrstmpl[16]!=2) idrstmpl[16]=2;
-           if (idrstmpl[16] == 1) {      // first order
-              ival1=jfld[0];
-              for ( j=nonmiss-1; j>0; j--)
-                 jfld[j]=jfld[j]-jfld[j-1];
-              jfld[0]=0;
-           }
-           else if (idrstmpl[16] == 2) {      // second order
-              ival1=jfld[0];
-              ival2=jfld[1];
-              for ( j=nonmiss-1; j>1; j--)
-                 jfld[j]=jfld[j]-(2*jfld[j-1])+jfld[j-2];
-              jfld[0]=0;
-              jfld[1]=0;
-           }
-           //
-           //  subtract min value from spatial diff field
-           //
-           isd=idrstmpl[16];
-           minsd=jfld[isd];
-           for ( j=isd; j<nonmiss; j++ ) if ( jfld[j] < minsd ) minsd=jfld[j];
-           for ( j=isd; j<nonmiss; j++ ) jfld[j]=jfld[j]-minsd;
-           //
-           //   find num of bits need to store minsd and add 1 extra bit
-           //   to indicate sign
-           //
-           temp=log((double)(abs(minsd)+1))/alog2;
-           nbitsd=(g2int)ceil(temp)+1;
-           //
-           //   find num of bits need to store ifld[0] ( and ifld[1]
-           //   if using 2nd order differencing )
-           //
-           maxorig=ival1;
-           if (idrstmpl[16]==2 && ival2>ival1) maxorig=ival2;
-           temp=log((double)(maxorig+1))/alog2;
-           nbitorig=(g2int)ceil(temp)+1;
-           if (nbitorig > nbitsd) nbitsd=nbitorig;
-           //   increase number of bits to even multiple of 8 ( octet )
-           if ( (nbitsd%8) != 0) nbitsd=nbitsd+(8-(nbitsd%8));
-           //
-           //  Store extra spatial differencing info into the packed
-           //  data section.
-           //
-           if (nbitsd != 0) {
-              //   pack first original value
-              if (ival1 >= 0) {
-                 sbit(cpack,&ival1,iofst,nbitsd);
-                 iofst=iofst+nbitsd;
-              }
-              else {
-                 sbit(cpack,&one,iofst,1);
-                 iofst=iofst+1;
-                 itemp=abs(ival1);
-                 sbit(cpack,&itemp,iofst,nbitsd-1);
-                 iofst=iofst+nbitsd-1;
-              }
-              if (idrstmpl[16] == 2) {
-               //  pack second original value
-                 if (ival2 >= 0) {
+        isd=idrstmpl[16];
+        minsd=jfld[isd];
+        for ( j=isd; j<nonmiss; j++ ) if ( jfld[j] < minsd ) minsd=jfld[j];
+        for ( j=isd; j<nonmiss; j++ ) jfld[j]=jfld[j]-minsd;
+        //
+        //   find num of bits need to store minsd and add 1 extra bit
+        //   to indicate sign
+        //
+        temp=log((double)(abs(minsd)+1))/alog2;
+        nbitsd=(g2int)ceil(temp)+1;
+        //
+        //   find num of bits need to store ifld[0] ( and ifld[1]
+        //   if using 2nd order differencing )
+        //
+        maxorig=ival1;
+        if (idrstmpl[16]==2 && ival2>ival1) maxorig=ival2;
+        temp=log((double)(maxorig+1))/alog2;
+        nbitorig=(g2int)ceil(temp)+1;
+        if (nbitorig > nbitsd) nbitsd=nbitorig;
+        //   increase number of bits to even multiple of 8 ( octet )
+        if ( (nbitsd%8) != 0) nbitsd=nbitsd+(8-(nbitsd%8));
+        //
+        //  Store extra spatial differencing info into the packed
+        //  data section.
+        //
+        if (nbitsd != 0) {
+            //   pack first original value
+            if (ival1 >= 0) {
+                sbit(cpack,&ival1,iofst,nbitsd);
+                iofst=iofst+nbitsd;
+            }
+            else {
+                sbit(cpack,&one,iofst,1);
+                iofst=iofst+1;
+                itemp=abs(ival1);
+                sbit(cpack,&itemp,iofst,nbitsd-1);
+                iofst=iofst+nbitsd-1;
+            }
+            if (idrstmpl[16] == 2) {
+                //  pack second original value
+                if (ival2 >= 0) {
                     sbit(cpack,&ival2,iofst,nbitsd);
                     iofst=iofst+nbitsd;
-                 }
-                 else {
+                }
+                else {
                     sbit(cpack,&one,iofst,1);
                     iofst=iofst+1;
                     itemp=abs(ival2);
                     sbit(cpack,&itemp,iofst,nbitsd-1);
                     iofst=iofst+nbitsd-1;
-                 }
-              }
-              //  pack overall min of spatial differences
-              if (minsd >= 0) {
-                 sbit(cpack,&minsd,iofst,nbitsd);
-                 iofst=iofst+nbitsd;
-              }
-              else {
-                 sbit(cpack,&one,iofst,1);
-                 iofst=iofst+1;
-                 itemp=abs(minsd);
-                 sbit(cpack,&itemp,iofst,nbitsd-1);
-                 iofst=iofst+nbitsd-1;
-              }
-           }
-         //print *,'SDp ',ival1,ival2,minsd,nbitsd
-        }       //  end of spatial diff section
-        //
-        //  Expand non-missing data values to original grid.
-        //
-        miss1=jfld[0];
-        for ( j=0; j<nonmiss; j++) if (jfld[j] < miss1) miss1 = jfld[j];
-        miss1--;
-        miss2=miss1-1;
-        n=0;
-        for ( j=0; j<ndpts; j++) {
-           if ( ifldmiss[j] == 0 ) {
-              ifld[j]=jfld[n];
-              n++;
-           }
-           else if ( ifldmiss[j] == 1 ) {
-              ifld[j]=miss1;
-           }
-           else if ( ifldmiss[j] == 2 ) {
-              ifld[j]=miss2;
-           }
+                }
+            }
+            //  pack overall min of spatial differences
+            if (minsd >= 0) {
+                sbit(cpack,&minsd,iofst,nbitsd);
+                iofst=iofst+nbitsd;
+            }
+            else {
+                sbit(cpack,&one,iofst,1);
+                iofst=iofst+1;
+                itemp=abs(minsd);
+                sbit(cpack,&itemp,iofst,nbitsd-1);
+                iofst=iofst+nbitsd-1;
+            }
         }
-        //
-        //   Determine Groups to be used.
-        //
-        if ( simple_alg == 1 ) {
-           //  set group length to 10 :  calculate number of groups
-           //  and length of last group
-           ngroups=ndpts/10;
-           for (j=0;j<ngroups;j++) glen[j]=10;
-           itemp=ndpts%10;
-           if (itemp != 0) {
-              ngroups++;
-              glen[ngroups-1]=itemp;
-           }
+        //print *,'SDp ',ival1,ival2,minsd,nbitsd
+    }       //  end of spatial diff section
+    //
+    //  Expand non-missing data values to original grid.
+    //
+    miss1=jfld[0];
+    for ( j=0; j<nonmiss; j++) if (jfld[j] < miss1) miss1 = jfld[j];
+    miss1--;
+    miss2=miss1-1;
+    n=0;
+    for ( j=0; j<ndpts; j++) {
+        if ( ifldmiss[j] == 0 ) {
+            ifld[j]=jfld[n];
+            n++;
         }
-        else {
-           // Use Dr. Glahn's algorithm for determining grouping.
-           //
-           kfildo=6;
-           minpk=10;
-           inc=1;
-           maxgrps=(ndpts/minpk)+1;
-           jmin = calloc(maxgrps,sizeof(g2int));
-           jmax = calloc(maxgrps,sizeof(g2int));
-           lbit = calloc(maxgrps,sizeof(g2int));
-           pack_gp(&kfildo,ifld,&ndpts,&missopt,&minpk,&inc,&miss1,&miss2,
-                        jmin,jmax,lbit,glen,&maxgrps,&ngroups,&ibit,&jbit,
-                        &kbit,&novref,&lbitref,&ier);
-           //printf("SAGier = %d %d %d %d %d %d\n",ier,ibit,jbit,kbit,novref,lbitref);
-           for ( ng=0; ng<ngroups; ng++) glen[ng]=glen[ng]+novref;
-           free(jmin);
-           free(jmax);
-           free(lbit);
+        else if ( ifldmiss[j] == 1 ) {
+            ifld[j]=miss1;
         }
-        //  
-        //  For each group, find the group's reference value (min)
-        //  and the number of bits needed to hold the remaining values
+        else if ( ifldmiss[j] == 2 ) {
+            ifld[j]=miss2;
+        }
+    }
+    //
+    //   Determine Groups to be used.
+    //
+    if ( simple_alg == 1 ) {
+        //  set group length to 10 :  calculate number of groups
+        //  and length of last group
+        ngroups=ndpts/10;
+        for (j=0;j<ngroups;j++) glen[j]=10;
+        itemp=ndpts%10;
+        if (itemp != 0) {
+            ngroups++;
+            glen[ngroups-1]=itemp;
+        }
+    }
+    else {
+        // Use Dr. Glahn's algorithm for determining grouping.
         //
-        n=0;
-        for ( ng=0; ng<ngroups; ng++) {
-           //  how many of each type?
-           num0=num1=num2=0;
-           for (j=n; j<n+glen[ng]; j++) {
-               if (ifldmiss[j] == 0 ) num0++;
-               if (ifldmiss[j] == 1 ) num1++;
-               if (ifldmiss[j] == 2 ) num2++;
-           }
-           if ( num0 == 0 ) {      // all missing values
-              if ( num1 == 0 ) {       // all secondary missing
+        kfildo=6;
+        minpk=10;
+        inc=1;
+        maxgrps=(ndpts/minpk)+1;
+        jmin = calloc(maxgrps,sizeof(g2int));
+        jmax = calloc(maxgrps,sizeof(g2int));
+        lbit = calloc(maxgrps,sizeof(g2int));
+        pack_gp(&kfildo,ifld,&ndpts,&missopt,&minpk,&inc,&miss1,&miss2,
+                jmin,jmax,lbit,glen,&maxgrps,&ngroups,&ibit,&jbit,
+                &kbit,&novref,&lbitref,&ier);
+        //printf("SAGier = %d %d %d %d %d %d\n",ier,ibit,jbit,kbit,novref,lbitref);
+        for ( ng=0; ng<ngroups; ng++) glen[ng]=glen[ng]+novref;
+        free(jmin);
+        free(jmax);
+        free(lbit);
+    }
+    //
+    //  For each group, find the group's reference value (min)
+    //  and the number of bits needed to hold the remaining values
+    //
+    n=0;
+    for ( ng=0; ng<ngroups; ng++) {
+        //  how many of each type?
+        num0=num1=num2=0;
+        for (j=n; j<n+glen[ng]; j++) {
+            if (ifldmiss[j] == 0 ) num0++;
+            if (ifldmiss[j] == 1 ) num1++;
+            if (ifldmiss[j] == 2 ) num2++;
+        }
+        if ( num0 == 0 ) {      // all missing values
+            if ( num1 == 0 ) {       // all secondary missing
                 gref[ng]=-2;
                 gwidth[ng]=0;
-              }
-              else if ( num2 == 0 ) {       // all primary missing
+            }
+            else if ( num2 == 0 ) {       // all primary missing
                 gref[ng]=-1;
                 gwidth[ng]=0;
-              }
-              else {                          // both primary and secondary
+            }
+            else {                          // both primary and secondary
                 gref[ng]=0;
                 gwidth[ng]=1;
-              }
-           }
-           else {                      // contains some non-missing data
-             //    find max and min values of group
-             gref[ng]=2147483647;
-             imax=-2147483647;
-             j=n;
-             for ( lg=0; lg<glen[ng]; lg++ ) {
+            }
+        }
+        else {                      // contains some non-missing data
+            //    find max and min values of group
+            gref[ng]=2147483647;
+            imax=-2147483647;
+            j=n;
+            for ( lg=0; lg<glen[ng]; lg++ ) {
                 if ( ifldmiss[j] == 0 ) {
-                  if (ifld[j] < gref[ng]) gref[ng]=ifld[j];
-                  if (ifld[j] > imax) imax=ifld[j]; 
+                    if (ifld[j] < gref[ng]) gref[ng]=ifld[j];
+                    if (ifld[j] > imax) imax=ifld[j];
                 }
                 j++;
-             }
-             if (missopt == 1) imax=imax+1;
-             if (missopt == 2) imax=imax+2;
-             //   calc num of bits needed to hold data
-             if ( gref[ng] != imax ) {
+            }
+            if (missopt == 1) imax=imax+1;
+            if (missopt == 2) imax=imax+2;
+            //   calc num of bits needed to hold data
+            if ( gref[ng] != imax ) {
                 temp=log((double)(imax-gref[ng]+1))/alog2;
                 gwidth[ng]=(g2int)ceil(temp);
-             }
-             else {
+            }
+            else {
                 gwidth[ng]=0;
-             }
-           }
-           //   Subtract min from data
-           j=n;
-           mtemp=(g2int)int_power(2.,gwidth[ng]);
-           for ( lg=0; lg<glen[ng]; lg++ ) {
-              if (ifldmiss[j] == 0)            // non-missing
-                 ifld[j]=ifld[j]-gref[ng];
-              else if (ifldmiss[j] == 1)         // primary missing
-                 ifld[j]=mtemp-1;
-              else if (ifldmiss[j] == 2)         // secondary missing
-                 ifld[j]=mtemp-2;
-              
-              j++;
-           }
-           //   increment fld array counter
-           n=n+glen[ng];
+            }
         }
-        //  
-        //  Find max of the group references and calc num of bits needed 
-        //  to pack each groups reference value, then
-        //  pack up group reference values
-        //
-        //printf(" GREFS: ");
-        //for (j=0;j<ngroups;j++) printf(" %d",gref[j]); printf("\n");
-        igmax=gref[0];
-        for (j=1;j<ngroups;j++) if (gref[j] > igmax) igmax=gref[j];
-        if (missopt == 1) igmax=igmax+1;
-        if (missopt == 2) igmax=igmax+2;
-        if (igmax != 0) {
-           temp=log((double)(igmax+1))/alog2;
-           nbitsgref=(g2int)ceil(temp);
-           // reset the ref values of any "missing only" groups.
-           mtemp=(g2int)int_power(2.,nbitsgref);
-           for ( j=0; j<ngroups; j++ ) {
-               if (gref[j] == -1) gref[j]=mtemp-1;
-               if (gref[j] == -2) gref[j]=mtemp-2;
-           }
-           sbits(cpack,gref,iofst,nbitsgref,0,ngroups);
-           itemp=nbitsgref*ngroups;
-           iofst=iofst+itemp;
-           //         Pad last octet with Zeros, if necessary,
-           if ( (itemp%8) != 0) {
-              left=8-(itemp%8);
-              sbit(cpack,&zero,iofst,left);
-              iofst=iofst+left;
-           }
+        //   Subtract min from data
+        j=n;
+        mtemp=(g2int)int_power(2.,gwidth[ng]);
+        for ( lg=0; lg<glen[ng]; lg++ ) {
+            if (ifldmiss[j] == 0)            // non-missing
+                ifld[j]=ifld[j]-gref[ng];
+            else if (ifldmiss[j] == 1)         // primary missing
+                ifld[j]=mtemp-1;
+            else if (ifldmiss[j] == 2)         // secondary missing
+                ifld[j]=mtemp-2;
+
+            j++;
         }
-        else {
-           nbitsgref=0;
+        //   increment fld array counter
+        n=n+glen[ng];
+    }
+    //
+    //  Find max of the group references and calc num of bits needed
+    //  to pack each groups reference value, then
+    //  pack up group reference values
+    //
+    //printf(" GREFS: ");
+    //for (j=0;j<ngroups;j++) printf(" %d",gref[j]); printf("\n");
+    igmax=gref[0];
+    for (j=1;j<ngroups;j++) if (gref[j] > igmax) igmax=gref[j];
+    if (missopt == 1) igmax=igmax+1;
+    if (missopt == 2) igmax=igmax+2;
+    if (igmax != 0) {
+        temp=log((double)(igmax+1))/alog2;
+        nbitsgref=(g2int)ceil(temp);
+        // reset the ref values of any "missing only" groups.
+        mtemp=(g2int)int_power(2.,nbitsgref);
+        for ( j=0; j<ngroups; j++ ) {
+            if (gref[j] == -1) gref[j]=mtemp-1;
+            if (gref[j] == -2) gref[j]=mtemp-2;
         }
-        //
-        //  Find max/min of the group widths and calc num of bits needed
-        //  to pack each groups width value, then
-        //  pack up group width values
-        //
-        //write(77,*)'GWIDTHS: ',(gwidth(j),j=1,ngroups)
-        iwmax=gwidth[0];
-        ngwidthref=gwidth[0];
-        for (j=1;j<ngroups;j++) {
-           if (gwidth[j] > iwmax) iwmax=gwidth[j];
-           if (gwidth[j] < ngwidthref) ngwidthref=gwidth[j];
-        }
-        if (iwmax != ngwidthref) {
-           temp=log((double)(iwmax-ngwidthref+1))/alog2;
-           nbitsgwidth=(g2int)ceil(temp);
-           for ( i=0; i<ngroups; i++) gwidth[i]=gwidth[i]-ngwidthref;
-           sbits(cpack,gwidth,iofst,nbitsgwidth,0,ngroups);
-           itemp=nbitsgwidth*ngroups;
-           iofst=iofst+itemp;
-           //         Pad last octet with Zeros, if necessary,
-           if ( (itemp%8) != 0) {
-              left=8-(itemp%8);
-              sbit(cpack,&zero,iofst,left);
-              iofst=iofst+left;
-           }
-        }
-        else {
-           nbitsgwidth=0;
-           for (i=0;i<ngroups;i++) gwidth[i]=0;
-        }
-        //
-        //  Find max/min of the group lengths and calc num of bits needed
-        //  to pack each groups length value, then
-        //  pack up group length values
-        //
-        //printf(" GLENS: ");
-        //for (j=0;j<ngroups;j++) printf(" %d",glen[j]); printf("\n");
-        ilmax=glen[0];
-        nglenref=glen[0];
-        for (j=1;j<ngroups-1;j++) {
-           if (glen[j] > ilmax) ilmax=glen[j];
-           if (glen[j] < nglenref) nglenref=glen[j];
-        }
-        nglenlast=glen[ngroups-1];
-        if (ilmax != nglenref) {
-           temp=log((double)(ilmax-nglenref+1))/alog2;
-           nbitsglen=(g2int)ceil(temp);
-           for ( i=0; i<ngroups-1; i++) glen[i]=glen[i]-nglenref;
-           sbits(cpack,glen,iofst,nbitsglen,0,ngroups);
-           itemp=nbitsglen*ngroups;
-           iofst=iofst+itemp;
-           //         Pad last octet with Zeros, if necessary,
-           if ( (itemp%8) != 0) {
-              left=8-(itemp%8);
-              sbit(cpack,&zero,iofst,left);
-              iofst=iofst+left;
-           }
-        }
-        else {
-           nbitsglen=0;
-           for (i=0;i<ngroups;i++) glen[i]=0;
-        }
-        //
-        //  For each group, pack data values
-        //
-        //write(77,*)'IFLDS: ',(ifld(j),j=1,ndpts)
-        n=0;
-        ij=0;
-        for ( ng=0; ng<ngroups; ng++) {
-           glength=glen[ng]+nglenref;
-           if (ng == (ngroups-1) ) glength=nglenlast;
-           grpwidth=gwidth[ng]+ngwidthref;
-       //write(77,*)'NGP ',ng,grpwidth,glength,gref(ng)
-           if ( grpwidth != 0 ) {
-              sbits(cpack,ifld+n,iofst,grpwidth,0,glength);
-              iofst=iofst+(grpwidth*glength);
-           }
-       //  do kk=1,glength
-       //     ij=ij+1
-       //write(77,*)'SAG ',ij,fld(ij),ifld(ij),gref(ng),bscale,rmin,dscale
-       //  enddo
-           n=n+glength;
-        }
+        sbits(cpack,gref,iofst,nbitsgref,0,ngroups);
+        itemp=nbitsgref*ngroups;
+        iofst=iofst+itemp;
         //         Pad last octet with Zeros, if necessary,
-        if ( (iofst%8) != 0) {
-           left=8-(iofst%8);
-           sbit(cpack,&zero,iofst,left);
-           iofst=iofst+left;
+        if ( (itemp%8) != 0) {
+            left=8-(itemp%8);
+            sbit(cpack,&zero,iofst,left);
+            iofst=iofst+left;
         }
-        *lcpack=iofst/8;
-        //
-        if ( ifld != 0 ) free(ifld);
-        if ( jfld != 0 ) free(jfld);
-        if ( ifldmiss != 0 ) free(ifldmiss);
-        if ( gref != 0 ) free(gref);
-        if ( gwidth != 0 ) free(gwidth);
-        if ( glen != 0 ) free(glen);
-      //}
-      //else {          //   Constant field ( max = min )
-      //  nbits=0;
-      //  *lcpack=0;
-      //  nbitsgref=0;
-      //  ngroups=0;
-      //}
+    }
+    else {
+        nbitsgref=0;
+    }
+    //
+    //  Find max/min of the group widths and calc num of bits needed
+    //  to pack each groups width value, then
+    //  pack up group width values
+    //
+    //write(77,*)'GWIDTHS: ',(gwidth(j),j=1,ngroups)
+    iwmax=gwidth[0];
+    ngwidthref=gwidth[0];
+    for (j=1;j<ngroups;j++) {
+        if (gwidth[j] > iwmax) iwmax=gwidth[j];
+        if (gwidth[j] < ngwidthref) ngwidthref=gwidth[j];
+    }
+    if (iwmax != ngwidthref) {
+        temp=log((double)(iwmax-ngwidthref+1))/alog2;
+        nbitsgwidth=(g2int)ceil(temp);
+        for ( i=0; i<ngroups; i++) gwidth[i]=gwidth[i]-ngwidthref;
+        sbits(cpack,gwidth,iofst,nbitsgwidth,0,ngroups);
+        itemp=nbitsgwidth*ngroups;
+        iofst=iofst+itemp;
+        //         Pad last octet with Zeros, if necessary,
+        if ( (itemp%8) != 0) {
+            left=8-(itemp%8);
+            sbit(cpack,&zero,iofst,left);
+            iofst=iofst+left;
+        }
+    }
+    else {
+        nbitsgwidth=0;
+        for (i=0;i<ngroups;i++) gwidth[i]=0;
+    }
+    //
+    //  Find max/min of the group lengths and calc num of bits needed
+    //  to pack each groups length value, then
+    //  pack up group length values
+    //
+    //printf(" GLENS: ");
+    //for (j=0;j<ngroups;j++) printf(" %d",glen[j]); printf("\n");
+    ilmax=glen[0];
+    nglenref=glen[0];
+    for (j=1;j<ngroups-1;j++) {
+        if (glen[j] > ilmax) ilmax=glen[j];
+        if (glen[j] < nglenref) nglenref=glen[j];
+    }
+    nglenlast=glen[ngroups-1];
+    if (ilmax != nglenref) {
+        temp=log((double)(ilmax-nglenref+1))/alog2;
+        nbitsglen=(g2int)ceil(temp);
+        for ( i=0; i<ngroups-1; i++) glen[i]=glen[i]-nglenref;
+        sbits(cpack,glen,iofst,nbitsglen,0,ngroups);
+        itemp=nbitsglen*ngroups;
+        iofst=iofst+itemp;
+        //         Pad last octet with Zeros, if necessary,
+        if ( (itemp%8) != 0) {
+            left=8-(itemp%8);
+            sbit(cpack,&zero,iofst,left);
+            iofst=iofst+left;
+        }
+    }
+    else {
+        nbitsglen=0;
+        for (i=0;i<ngroups;i++) glen[i]=0;
+    }
+    //
+    //  For each group, pack data values
+    //
+    //write(77,*)'IFLDS: ',(ifld(j),j=1,ndpts)
+    n=0;
+    ij=0;
+    for ( ng=0; ng<ngroups; ng++) {
+        glength=glen[ng]+nglenref;
+        if (ng == (ngroups-1) ) glength=nglenlast;
+        grpwidth=gwidth[ng]+ngwidthref;
+        //write(77,*)'NGP ',ng,grpwidth,glength,gref(ng)
+        if ( grpwidth != 0 ) {
+            sbits(cpack,ifld+n,iofst,grpwidth,0,glength);
+            iofst=iofst+(grpwidth*glength);
+        }
+        //  do kk=1,glength
+        //     ij=ij+1
+        //write(77,*)'SAG ',ij,fld(ij),ifld(ij),gref(ng),bscale,rmin,dscale
+        //  enddo
+        n=n+glength;
+    }
+    //         Pad last octet with Zeros, if necessary,
+    if ( (iofst%8) != 0) {
+        left=8-(iofst%8);
+        sbit(cpack,&zero,iofst,left);
+        iofst=iofst+left;
+    }
+    *lcpack=iofst/8;
+    //
+    if ( ifld != 0 ) free(ifld);
+    if ( jfld != 0 ) free(jfld);
+    if ( ifldmiss != 0 ) free(ifldmiss);
+    if ( gref != 0 ) free(gref);
+    if ( gwidth != 0 ) free(gwidth);
+    if ( glen != 0 ) free(glen);
+    //}
+    //else {          //   Constant field ( max = min )
+    //  nbits=0;
+    //  *lcpack=0;
+    //  nbitsgref=0;
+    //  ngroups=0;
+    //}
 
 //
 //  Fill in ref value and number of bits in Template 5.2
 //
-      mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
-      idrstmpl[3]=nbitsgref;
-      idrstmpl[4]=0;         // original data were reals
-      idrstmpl[5]=1;         // general group splitting
-      idrstmpl[9]=ngroups;          // Number of groups
-      idrstmpl[10]=ngwidthref;       // reference for group widths
-      idrstmpl[11]=nbitsgwidth;      // num bits used for group widths
-      idrstmpl[12]=nglenref;         // Reference for group lengths
-      idrstmpl[13]=1;                // length increment for group lengths
-      idrstmpl[14]=nglenlast;        // True length of last group
-      idrstmpl[15]=nbitsglen;        // num bits used for group lengths
-      if (idrsnum == 3) {
-         idrstmpl[17]=nbitsd/8;      // num bits used for extra spatial
-                                     // differencing values
-      }
+    mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
+    idrstmpl[3]=nbitsgref;
+    idrstmpl[4]=0;         // original data were reals
+    idrstmpl[5]=1;         // general group splitting
+    idrstmpl[9]=ngroups;          // Number of groups
+    idrstmpl[10]=ngwidthref;       // reference for group widths
+    idrstmpl[11]=nbitsgwidth;      // num bits used for group widths
+    idrstmpl[12]=nglenref;         // Reference for group lengths
+    idrstmpl[13]=1;                // length increment for group lengths
+    idrstmpl[14]=nglenlast;        // True length of last group
+    idrstmpl[15]=nbitsglen;        // num bits used for group lengths
+    if (idrsnum == 3) {
+        idrstmpl[17]=nbitsd/8;      // num bits used for extra spatial
+        // differencing values
+    }
 
 }

--- a/src/mkieee.c
+++ b/src/mkieee.c
@@ -7,10 +7,10 @@
 
 //$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    mkieee 
+// SUBPROGRAM:    mkieee
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2002-10-29
 //
-// ABSTRACT: This subroutine stores a list of real values in 
+// ABSTRACT: This subroutine stores a list of real values in
 //   32-bit IEEE floating point format.
 //
 // PROGRAM HISTORY LOG:
@@ -21,7 +21,7 @@
 //     a        - Input array of floating point values.
 //     num      - Number of floating point values to convert.
 //
-//   OUTPUT ARGUMENT LIST:      
+//   OUTPUT ARGUMENT LIST:
 //     rieee    - Output array of data values in 32-bit IEEE format
 //                stored in g2int integer array.  rieee must be allocated
 //                with at least 4*num bytes of memory before calling this
@@ -31,64 +31,64 @@
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$
 void mkieee(g2float *a,g2int *rieee,g2int num)
 {
 
-      g2int  j,n,ieee,iexp,imant;
-      double  alog2,atemp;
+    g2int  j,n,ieee,iexp,imant;
+    double  alog2,atemp;
 
-      static double  two23,two126;
-      static g2int test=0;
+    static double  two23,two126;
+    static g2int test=0;
     //g2intu msk1=0x80000000;        // 10000000000000000000000000000000 binary
     //g2int msk2=0x7F800000;         // 01111111100000000000000000000000 binary
     //g2int msk3=0x007FFFFF;         // 00000000011111111111111111111111 binary
 
-      if ( test == 0 ) {
-         two23=(double)int_power(2.0,23);
-         two126=(double)int_power(2.0,126);
-         test=1;
-      }
+    if ( test == 0 ) {
+        two23=(double)int_power(2.0,23);
+        two126=(double)int_power(2.0,126);
+        test=1;
+    }
 
-      alog2=0.69314718;       //  ln(2.0)
+    alog2=0.69314718;       //  ln(2.0)
 
-      for (j=0;j<num;j++) {
-      
+    for (j=0;j<num;j++) {
+
         ieee=0;
 
         if (a[j] == 0.0) {
-          rieee[j]=ieee;
-          continue;
+            rieee[j]=ieee;
+            continue;
         }
-        
+
 //
 //  Set Sign bit (bit 31 - leftmost bit)
 //
         if (a[j] < 0.0) {
-          ieee= 1 << 31;
-          atemp=-1.0*a[j];
+            ieee= 1 << 31;
+            atemp=-1.0*a[j];
         }
         else {
-          ieee= 0 << 31;
-          atemp=a[j];
+            ieee= 0 << 31;
+            atemp=a[j];
         }
         //printf("sign %ld %x \n",ieee,ieee);
 //
 //  Determine exponent n with base 2
 //
         if ( atemp >= 1.0 ) {
-           n = 0;
-           while ( int_power(2.0,n+1) <= atemp ) {
-              n++;
-           }
+            n = 0;
+            while ( int_power(2.0,n+1) <= atemp ) {
+                n++;
+            }
         }
         else {
-           n = -1;
-           while ( int_power(2.0,n) > atemp ) {
-              n--;
-           }
+            n = -1;
+            while ( int_power(2.0,n) > atemp ) {
+                n--;
+            }
         }
         //n=(g2int)floor(log(atemp)/alog2);
         iexp=n+127;
@@ -99,16 +99,16 @@ void mkieee(g2float *a,g2int *rieee,g2int num)
         ieee = ieee | ( iexp << 23 );
 //
 //  Determine Mantissa
-// 
+//
         if (iexp != 255) {
-          if (iexp != 0) 
-            atemp=(atemp/int_power(2.0,n))-1.0;
-          else
-            atemp=atemp*two126;
-          imant=(g2int)rint(atemp*two23);
+            if (iexp != 0)
+                atemp=(atemp/int_power(2.0,n))-1.0;
+            else
+                atemp=atemp*two126;
+            imant=(g2int)rint(atemp*two23);
         }
         else {
-          imant=0;
+            imant=0;
         }
         //printf("mant %ld %x \n",imant,imant);
         //      set mantissa bits ( bits 22-0 )
@@ -118,8 +118,8 @@ void mkieee(g2float *a,g2int *rieee,g2int num)
 //
         rieee[j]=ieee;
 
-      }
+    }
 
-      return;
+    return;
 
 }

--- a/src/pack_gp.c
+++ b/src/pack_gp.c
@@ -1,15 +1,15 @@
 /** @file
     pack_gp.f -- translated by f2c (version 20031025).
     You must link the resulting object file with libf2c:
-	on Microsoft Windows system, link with libf2c.lib;
-	on Linux or Unix systems, link with .../path/to/libf2c.a -lm
-	or, if you install libf2c.a in a standard place, with -lf2c -lm
-	-- in that order, at the end of the command line, as in
-<pre>
-		cc *.o -lf2c -lm
-</pre>
-	Source for libf2c is in /netlib/f2c/libf2c.zip, e.g.,
-		http://www.netlib.org/f2c/libf2c.zip
+    on Microsoft Windows system, link with libf2c.lib;
+    on Linux or Unix systems, link with .../path/to/libf2c.a -lm
+    or, if you install libf2c.a in a standard place, with -lf2c -lm
+    -- in that order, at the end of the command line, as in
+    <pre>
+    cc *.o -lf2c -lm
+    </pre>
+    Source for libf2c is in /netlib/f2c/libf2c.zip, e.g.,
+    http://www.netlib.org/f2c/libf2c.zip
 */
 
 /*#include "f2c.h"*/
@@ -20,11 +20,11 @@ typedef g2int logical;
 #define TRUE_ (1)
 #define FALSE_ (0)
 
-/* Subroutine */ int pack_gp(integer *kfildo, integer *ic, integer *nxy, 
-	integer *is523, integer *minpk, integer *inc, integer *missp, integer 
-	*misss, integer *jmin, integer *jmax, integer *lbit, integer *nov, 
-	integer *ndg, integer *lx, integer *ibit, integer *jbit, integer *
-	kbit, integer *novref, integer *lbitref, integer *ier)
+/* Subroutine */ int pack_gp(integer *kfildo, integer *ic, integer *nxy,
+                             integer *is523, integer *minpk, integer *inc, integer *missp, integer
+                             *misss, integer *jmin, integer *jmax, integer *lbit, integer *nov,
+                             integer *ndg, integer *lx, integer *ibit, integer *jbit, integer *
+                             kbit, integer *novref, integer *lbitref, integer *ier)
 {
     /* Initialized data */
 
@@ -40,14 +40,14 @@ typedef g2int logical;
     static logical adda;
     static integer ired, kinc, mina, maxa, minb, maxb, minc, maxc, ibxx2[31];
     static char cfeed[1];
-    static integer nenda, nendb, ibita, ibitb, minak, minbk, maxak, maxbk, 
-	    minck, maxck, nouta, lmiss, itest, nount;
-    extern /* Subroutine */ int reduce(integer *, integer *, integer *, 
-	    integer *, integer *, integer *, integer *, integer *, integer *, 
-	    integer *, integer *, integer *, integer *);
-    static integer ibitbs, mislla, misllb, misllc, iersav, lminpk, ktotal, 
-	    kounta, kountb, kstart, mstart, mintst, maxtst, 
-	    kounts, mintstk, maxtstk;
+    static integer nenda, nendb, ibita, ibitb, minak, minbk, maxak, maxbk,
+        minck, maxck, nouta, lmiss, itest, nount;
+    extern /* Subroutine */ int reduce(integer *, integer *, integer *,
+                                       integer *, integer *, integer *, integer *, integer *, integer *,
+                                       integer *, integer *, integer *, integer *);
+    static integer ibitbs, mislla, misllb, misllc, iersav, lminpk, ktotal,
+        kounta, kountb, kstart, mstart, mintst, maxtst,
+        kounts, mintstk, maxtstk;
     integer *misslx;
 
 
@@ -359,7 +359,7 @@ typedef g2int logical;
 /*        THIS CASE PACK_GP EXECUTES AGAIN EXCEPT FOR REDUCE. */
 
     if (*inc <= 0) {
-	iersav = 717;
+        iersav = 717;
 /*        WRITE(KFILDO,101)INC */
 /* 101     FORMAT(/' ****INC ='I8,' NOT CORRECT IN PACK_GP.  1 IS USED.') */
     }
@@ -377,13 +377,13 @@ L102:
 /*         CALCULATE THE POWERS OF 2 THE FIRST TIME ENTERED. */
 
     if (ifirst == 0) {
-	ifirst = 1;
-	ibxx2[0] = 1;
+        ifirst = 1;
+        ibxx2[0] = 1;
 
-	for (j = 1; j <= 30; ++j) {
-	    ibxx2[j] = ibxx2[j - 1] << 1;
+        for (j = 1; j <= 30; ++j) {
+            ibxx2[j] = ibxx2[j - 1] << 1;
 /* L104: */
-	}
+        }
 
     }
 
@@ -397,10 +397,10 @@ L105:
     adda = FALSE_;
     lmiss = 0;
     if (*is523 == 1) {
-	lmiss = 1;
+        lmiss = 1;
     }
     if (*is523 == 2) {
-	lmiss = 2;
+        lmiss = 2;
     }
 
 /*        ************************************* */
@@ -431,7 +431,7 @@ L105:
     /*nenda = min(i__1,*nxy);*/
     nenda = (i__1 < *nxy) ? i__1 : *nxy;
     if (*nxy - nenda <= lminpk / 2) {
-	nenda = *nxy;
+        nenda = *nxy;
     }
 /*        ABOVE STATEMENT GUARANTEES THE LAST GROUP IS GT LMINPK/2 BY */
 /*        MAKING THE ACTUAL GROUP LARGER.  IF A PROVISION LIKE THIS IS */
@@ -450,130 +450,130 @@ L105:
     if (nenda != *nxy && ic[kstart] == ic[kstart + 1]) {
 /*           NO NEED TO EXECUTE IF FIRST TWO VALUES ARE NOT EQUAL. */
 
-	if (*is523 == 0) {
+        if (*is523 == 0) {
 /*              THIS LOOP IS FOR NO MISSING VALUES. */
 
-	    i__1 = *nxy;
-	    for (k = kstart + 1; k <= i__1; ++k) {
+            i__1 = *nxy;
+            for (k = kstart + 1; k <= i__1; ++k) {
 
-		if (ic[k] != ic[kstart]) {
+                if (ic[k] != ic[kstart]) {
 /* Computing MAX */
-		    i__2 = nenda, i__3 = k - 1;
-		    /*nenda = max(i__2,i__3);*/
-		    nenda = (i__2 > i__3) ? i__2 : i__3;
-		    goto L114;
-		}
+                    i__2 = nenda, i__3 = k - 1;
+                    /*nenda = max(i__2,i__3);*/
+                    nenda = (i__2 > i__3) ? i__2 : i__3;
+                    goto L114;
+                }
 
 /* L111: */
-	    }
+            }
 
-	    nenda = *nxy;
+            nenda = *nxy;
 /*              FALL THROUGH THE LOOP MEANS ALL VALUES ARE THE SAME. */
 
-	} else if (*is523 == 1) {
+        } else if (*is523 == 1) {
 /*              THIS LOOP IS FOR PRIMARY MISSING VALUES ONLY. */
 
-	    i__1 = *nxy;
-	    for (k = kstart + 1; k <= i__1; ++k) {
+            i__1 = *nxy;
+            for (k = kstart + 1; k <= i__1; ++k) {
 
-		if (ic[k] != *missp) {
+                if (ic[k] != *missp) {
 
-		    if (ic[k] != ic[kstart]) {
+                    if (ic[k] != ic[kstart]) {
 /* Computing MAX */
-			i__2 = nenda, i__3 = k - 1;
-			/*nenda = max(i__2,i__3);*/
-			nenda = (i__2 > i__3) ? i__2 : i__3;
-			goto L114;
-		    }
+                        i__2 = nenda, i__3 = k - 1;
+                        /*nenda = max(i__2,i__3);*/
+                        nenda = (i__2 > i__3) ? i__2 : i__3;
+                        goto L114;
+                    }
 
-		}
+                }
 
 /* L112: */
-	    }
+            }
 
-	    nenda = *nxy;
+            nenda = *nxy;
 /*              FALL THROUGH THE LOOP MEANS ALL VALUES ARE THE SAME. */
 
-	} else {
+        } else {
 /*              THIS LOOP IS FOR PRIMARY AND SECONDARY MISSING VALUES. */
 
-	    i__1 = *nxy;
-	    for (k = kstart + 1; k <= i__1; ++k) {
+            i__1 = *nxy;
+            for (k = kstart + 1; k <= i__1; ++k) {
 
-		if (ic[k] != *missp && ic[k] != *misss) {
+                if (ic[k] != *missp && ic[k] != *misss) {
 
-		    if (ic[k] != ic[kstart]) {
+                    if (ic[k] != ic[kstart]) {
 /* Computing MAX */
-			i__2 = nenda, i__3 = k - 1;
-			/*nenda = max(i__2,i__3);*/
-			nenda = (i__2 > i__3) ? i__2 : i__3;
-			goto L114;
-		    }
+                        i__2 = nenda, i__3 = k - 1;
+                        /*nenda = max(i__2,i__3);*/
+                        nenda = (i__2 > i__3) ? i__2 : i__3;
+                        goto L114;
+                    }
 
-		}
+                }
 
 /* L113: */
-	    }
+            }
 
-	    nenda = *nxy;
+            nenda = *nxy;
 /*              FALL THROUGH THE LOOP MEANS ALL VALUES ARE THE SAME. */
-	}
+        }
 
     }
 
 L114:
     if (*is523 == 0) {
 
-	i__1 = nenda;
-	for (k = kstart; k <= i__1; ++k) {
-	    if (ic[k] < mina) {
-		mina = ic[k];
-		minak = k;
-	    }
-	    if (ic[k] > maxa) {
-		maxa = ic[k];
-		maxak = k;
-	    }
+        i__1 = nenda;
+        for (k = kstart; k <= i__1; ++k) {
+            if (ic[k] < mina) {
+                mina = ic[k];
+                minak = k;
+            }
+            if (ic[k] > maxa) {
+                maxa = ic[k];
+                maxak = k;
+            }
 /* L115: */
-	}
+        }
 
     } else if (*is523 == 1) {
 
-	i__1 = nenda;
-	for (k = kstart; k <= i__1; ++k) {
-	    if (ic[k] == *missp) {
-		goto L117;
-	    }
-	    if (ic[k] < mina) {
-		mina = ic[k];
-		minak = k;
-	    }
-	    if (ic[k] > maxa) {
-		maxa = ic[k];
-		maxak = k;
-	    }
-L117:
-	    ;
-	}
+        i__1 = nenda;
+        for (k = kstart; k <= i__1; ++k) {
+            if (ic[k] == *missp) {
+                goto L117;
+            }
+            if (ic[k] < mina) {
+                mina = ic[k];
+                minak = k;
+            }
+            if (ic[k] > maxa) {
+                maxa = ic[k];
+                maxak = k;
+            }
+        L117:
+            ;
+        }
 
     } else {
 
-	i__1 = nenda;
-	for (k = kstart; k <= i__1; ++k) {
-	    if (ic[k] == *missp || ic[k] == *misss) {
-		goto L120;
-	    }
-	    if (ic[k] < mina) {
-		mina = ic[k];
-		minak = k;
-	    }
-	    if (ic[k] > maxa) {
-		maxa = ic[k];
-		maxak = k;
-	    }
-L120:
-	    ;
-	}
+        i__1 = nenda;
+        for (k = kstart; k <= i__1; ++k) {
+            if (ic[k] == *missp || ic[k] == *misss) {
+                goto L120;
+            }
+            if (ic[k] < mina) {
+                mina = ic[k];
+                minak = k;
+            }
+            if (ic[k] > maxa) {
+                maxa = ic[k];
+                maxak = k;
+            }
+        L120:
+            ;
+        }
 
     }
 
@@ -584,7 +584,7 @@ L120:
     ktotal += kounta;
     mislla = 0;
     if (mina != mallow) {
-	goto L125;
+        goto L125;
     }
 /*        ALL MISSING VALUES MUST BE ACCOMMODATED. */
     mina = 0;
@@ -592,7 +592,7 @@ L120:
     mislla = 1;
     ibitb = 0;
     if (*is523 != 2) {
-	goto L130;
+        goto L130;
     }
 /*        WHEN ALL VALUES ARE MISSING AND THERE ARE NO */
 /*        SECONDARY MISSING VALUES, IBITA = 0. */
@@ -602,9 +602,9 @@ L125:
     itest = maxa - mina + lmiss;
 
     for (ibita = 0; ibita <= 30; ++ibita) {
-	if (itest < ibxx2[ibita]) {
-	    goto L130;
-	}
+        if (itest < ibxx2[ibita]) {
+            goto L130;
+        }
 /* ***        THIS TEST IS THE SAME AS: */
 /* ***     IF(MAXA-MINA.LT.IBXX2(IBITA)-LMISS)GO TO 130 */
 /* L126: */
@@ -624,7 +624,7 @@ L130:
 
 L133:
     if (ktotal >= *nxy) {
-	goto L200;
+        goto L200;
     }
 
 /*        ************************************* */
@@ -649,24 +649,24 @@ L140:
 
     if (mstart < *nxy) {
 
-	if (*is523 == 0) {
+        if (*is523 == 0) {
 /*              THIS LOOP IS FOR NO MISSING VALUES. */
 
-	    i__1 = *nxy;
-	    for (k = mstart + 1; k <= i__1; ++k) {
+            i__1 = *nxy;
+            for (k = mstart + 1; k <= i__1; ++k) {
 
-		if (ic[k] != ic[mstart]) {
-		    nendb = k - 1;
-		    goto L150;
-		}
+                if (ic[k] != ic[mstart]) {
+                    nendb = k - 1;
+                    goto L150;
+                }
 
 /* L145: */
-	    }
+            }
 
-	    nendb = *nxy;
+            nendb = *nxy;
 /*              FALL THROUGH THE LOOP MEANS ALL REMAINING VALUES */
 /*              ARE THE SAME. */
-	}
+        }
 
     }
 
@@ -681,7 +681,7 @@ L150:
 /* **** 150  NENDB=MIN(KTOTAL+LMINPK,NXY) */
 
     if (*nxy - nendb <= lminpk / 2) {
-	nendb = *nxy;
+        nendb = *nxy;
     }
 /*        ABOVE STATEMENT GUARANTEES THE LAST GROUP IS GT LMINPK/2 BY */
 /*        MAKING THE ACTUAL GROUP LARGER.  IF A PROVISION LIKE THIS IS */
@@ -693,67 +693,67 @@ L150:
 
     if (*is523 == 0) {
 
-	i__1 = nendb;
-	for (k = mstart; k <= i__1; ++k) {
-	    if (ic[k] <= minb) {
-		minb = ic[k];
+        i__1 = nendb;
+        for (k = mstart; k <= i__1; ++k) {
+            if (ic[k] <= minb) {
+                minb = ic[k];
 /*              NOTE LE, NOT LT.  LT COULD BE USED BUT THEN A */
 /*              RECOMPUTE OVER THE WHOLE GROUP WOULD BE NEEDED */
 /*              MORE OFTEN.  SAME REASONING FOR GE AND OTHER */
 /*              LOOPS BELOW. */
-		minbk = k;
-	    }
-	    if (ic[k] >= maxb) {
-		maxb = ic[k];
-		maxbk = k;
-	    }
+                minbk = k;
+            }
+            if (ic[k] >= maxb) {
+                maxb = ic[k];
+                maxbk = k;
+            }
 /* L155: */
-	}
+        }
 
     } else if (*is523 == 1) {
 
-	i__1 = nendb;
-	for (k = mstart; k <= i__1; ++k) {
-	    if (ic[k] == *missp) {
-		goto L157;
-	    }
-	    if (ic[k] <= minb) {
-		minb = ic[k];
-		minbk = k;
-	    }
-	    if (ic[k] >= maxb) {
-		maxb = ic[k];
-		maxbk = k;
-	    }
-L157:
-	    ;
-	}
+        i__1 = nendb;
+        for (k = mstart; k <= i__1; ++k) {
+            if (ic[k] == *missp) {
+                goto L157;
+            }
+            if (ic[k] <= minb) {
+                minb = ic[k];
+                minbk = k;
+            }
+            if (ic[k] >= maxb) {
+                maxb = ic[k];
+                maxbk = k;
+            }
+        L157:
+            ;
+        }
 
     } else {
 
-	i__1 = nendb;
-	for (k = mstart; k <= i__1; ++k) {
-	    if (ic[k] == *missp || ic[k] == *misss) {
-		goto L160;
-	    }
-	    if (ic[k] <= minb) {
-		minb = ic[k];
-		minbk = k;
-	    }
-	    if (ic[k] >= maxb) {
-		maxb = ic[k];
-		maxbk = k;
-	    }
-L160:
-	    ;
-	}
+        i__1 = nendb;
+        for (k = mstart; k <= i__1; ++k) {
+            if (ic[k] == *missp || ic[k] == *misss) {
+                goto L160;
+            }
+            if (ic[k] <= minb) {
+                minb = ic[k];
+                minbk = k;
+            }
+            if (ic[k] >= maxb) {
+                maxb = ic[k];
+                maxbk = k;
+            }
+        L160:
+            ;
+        }
 
     }
 
     kountb = nendb - ktotal;
     misllb = 0;
     if (minb != mallow) {
-	goto L165;
+        goto L165;
     }
 /*        ALL MISSING VALUES MUST BE ACCOMMODATED. */
     minb = 0;
@@ -762,7 +762,7 @@ L160:
     ibitb = 0;
 
     if (*is523 != 2) {
-	goto L170;
+        goto L170;
     }
 /*        WHEN ALL VALUES ARE MISSING AND THERE ARE NO SECONDARY */
 /*        MISSING VALUES, IBITB = 0.  OTHERWISE, IBITB MUST BE */
@@ -770,9 +770,9 @@ L160:
 
 L165:
     for (ibitb = ibitbs; ibitb <= 30; ++ibitb) {
-	if (maxb - minb < ibxx2[ibitb] - lmiss) {
-	    goto L170;
-	}
+        if (maxb - minb < ibxx2[ibitb] - lmiss) {
+            goto L170;
+        }
 /* L166: */
     }
 
@@ -796,10 +796,10 @@ L170:
 /* ***D    2       '  MINB ='I8,'  MAXB ='I8,'  IBITB ='I3,'  MISLLB ='I3) */
 
     if (ibitb >= ibita) {
-	goto L180;
+        goto L180;
     }
     if (adda) {
-	goto L200;
+        goto L200;
     }
 
 /*        ************************************* */
@@ -822,90 +822,90 @@ L170:
 
     if (*is523 == 0) {
 
-	i__1 = kstart;
-	for (k = ktotal; k >= i__1; --k) {
+        i__1 = kstart;
+        for (k = ktotal; k >= i__1; --k) {
 /*           START WITH THE END OF THE GROUP AND WORK BACKWARDS. */
-	    if (ic[k] < minb) {
-		mintst = ic[k];
-		mintstk = k;
-	    } else if (ic[k] > maxb) {
-		maxtst = ic[k];
-		maxtstk = k;
-	    }
-	    if (maxtst - mintst >= ibxx2[ibitb]) {
-		goto L174;
-	    }
+            if (ic[k] < minb) {
+                mintst = ic[k];
+                mintstk = k;
+            } else if (ic[k] > maxb) {
+                maxtst = ic[k];
+                maxtstk = k;
+            }
+            if (maxtst - mintst >= ibxx2[ibitb]) {
+                goto L174;
+            }
 /*           NOTE THAT FOR THIS LOOP, LMISS = 0. */
-	    minb = mintst;
-	    maxb = maxtst;
-	    minbk = mintstk;
-	    maxbk = maxtstk;
-	    --kounta;
+            minb = mintst;
+            maxb = maxtst;
+            minbk = mintstk;
+            maxbk = maxtstk;
+            --kounta;
 /*           THERE IS ONE LESS POINT NOW IN A. */
 /* L1715: */
-	}
+        }
 
     } else if (*is523 == 1) {
 
-	i__1 = kstart;
-	for (k = ktotal; k >= i__1; --k) {
+        i__1 = kstart;
+        for (k = ktotal; k >= i__1; --k) {
 /*           START WITH THE END OF THE GROUP AND WORK BACKWARDS. */
-	    if (ic[k] == *missp) {
-		goto L1718;
-	    }
-	    if (ic[k] < minb) {
-		mintst = ic[k];
-		mintstk = k;
-	    } else if (ic[k] > maxb) {
-		maxtst = ic[k];
-		maxtstk = k;
-	    }
-	    if (maxtst - mintst >= ibxx2[ibitb] - lmiss) {
-		goto L174;
-	    }
+            if (ic[k] == *missp) {
+                goto L1718;
+            }
+            if (ic[k] < minb) {
+                mintst = ic[k];
+                mintstk = k;
+            } else if (ic[k] > maxb) {
+                maxtst = ic[k];
+                maxtstk = k;
+            }
+            if (maxtst - mintst >= ibxx2[ibitb] - lmiss) {
+                goto L174;
+            }
 /*           FOR THIS LOOP, LMISS = 1. */
-	    minb = mintst;
-	    maxb = maxtst;
-	    minbk = mintstk;
-	    maxbk = maxtstk;
-	    misllb = 0;
+            minb = mintst;
+            maxb = maxtst;
+            minbk = mintstk;
+            maxbk = maxtstk;
+            misllb = 0;
 /*           WHEN THE POINT IS NON MISSING, MISLLB SET = 0. */
-L1718:
-	    --kounta;
+        L1718:
+            --kounta;
 /*           THERE IS ONE LESS POINT NOW IN A. */
 /* L1719: */
-	}
+        }
 
     } else {
 
-	i__1 = kstart;
-	for (k = ktotal; k >= i__1; --k) {
+        i__1 = kstart;
+        for (k = ktotal; k >= i__1; --k) {
 /*           START WITH THE END OF THE GROUP AND WORK BACKWARDS. */
-	    if (ic[k] == *missp || ic[k] == *misss) {
-		goto L1729;
-	    }
-	    if (ic[k] < minb) {
-		mintst = ic[k];
-		mintstk = k;
-	    } else if (ic[k] > maxb) {
-		maxtst = ic[k];
-		maxtstk = k;
-	    }
-	    if (maxtst - mintst >= ibxx2[ibitb] - lmiss) {
-		goto L174;
-	    }
+            if (ic[k] == *missp || ic[k] == *misss) {
+                goto L1729;
+            }
+            if (ic[k] < minb) {
+                mintst = ic[k];
+                mintstk = k;
+            } else if (ic[k] > maxb) {
+                maxtst = ic[k];
+                maxtstk = k;
+            }
+            if (maxtst - mintst >= ibxx2[ibitb] - lmiss) {
+                goto L174;
+            }
 /*           FOR THIS LOOP, LMISS = 2. */
-	    minb = mintst;
-	    maxb = maxtst;
-	    minbk = mintstk;
-	    maxbk = maxtstk;
-	    misllb = 0;
+            minb = mintst;
+            maxb = maxtst;
+            minbk = mintstk;
+            maxbk = maxtstk;
+            misllb = 0;
 /*           WHEN THE POINT IS NON MISSING, MISLLB SET = 0. */
-L1729:
-	    --kounta;
+        L1729:
+            --kounta;
 /*           THERE IS ONE LESS POINT NOW IN A. */
 /* L173: */
-	}
+        }
 
     }
 
@@ -918,7 +918,7 @@ L1729:
 
 L174:
     if (kounta == kounts) {
-	goto L200;
+        goto L200;
     }
 /*        ON TRANSFER, GROUP A WAS NOT CHANGED.  CLOSE IT OUT. */
 
@@ -932,7 +932,7 @@ L174:
     ktotal -= nouta;
     kountb += nouta;
     if (nenda - nouta > minak && nenda - nouta > maxak) {
-	goto L200;
+        goto L200;
     }
 /*        WHEN THE ABOVE TEST IS MET, THE MIN AND MAX OF THE */
 /*        CURRENT GROUP A WERE WITHIN THE OLD GROUP A, SO THE */
@@ -947,63 +947,63 @@ L174:
 
     if (*is523 == 0) {
 
-	i__1 = nenda - nouta;
-	for (k = kstart; k <= i__1; ++k) {
-	    if (ic[k] < mina) {
-		mina = ic[k];
-	    }
-	    if (ic[k] > maxa) {
-		maxa = ic[k];
-	    }
+        i__1 = nenda - nouta;
+        for (k = kstart; k <= i__1; ++k) {
+            if (ic[k] < mina) {
+                mina = ic[k];
+            }
+            if (ic[k] > maxa) {
+                maxa = ic[k];
+            }
 /* L1742: */
-	}
+        }
 
     } else if (*is523 == 1) {
 
-	i__1 = nenda - nouta;
-	for (k = kstart; k <= i__1; ++k) {
-	    if (ic[k] == *missp) {
-		goto L1744;
-	    }
-	    if (ic[k] < mina) {
-		mina = ic[k];
-	    }
-	    if (ic[k] > maxa) {
-		maxa = ic[k];
-	    }
-L1744:
-	    ;
-	}
+        i__1 = nenda - nouta;
+        for (k = kstart; k <= i__1; ++k) {
+            if (ic[k] == *missp) {
+                goto L1744;
+            }
+            if (ic[k] < mina) {
+                mina = ic[k];
+            }
+            if (ic[k] > maxa) {
+                maxa = ic[k];
+            }
+        L1744:
+            ;
+        }
 
     } else {
 
-	i__1 = nenda - nouta;
-	for (k = kstart; k <= i__1; ++k) {
-	    if (ic[k] == *missp || ic[k] == *misss) {
-		goto L175;
-	    }
-	    if (ic[k] < mina) {
-		mina = ic[k];
-	    }
-	    if (ic[k] > maxa) {
-		maxa = ic[k];
-	    }
-L175:
-	    ;
-	}
+        i__1 = nenda - nouta;
+        for (k = kstart; k <= i__1; ++k) {
+            if (ic[k] == *missp || ic[k] == *misss) {
+                goto L175;
+            }
+            if (ic[k] < mina) {
+                mina = ic[k];
+            }
+            if (ic[k] > maxa) {
+                maxa = ic[k];
+            }
+        L175:
+            ;
+        }
 
     }
 
     mislla = 0;
     if (mina != mallow) {
-	goto L1750;
+        goto L1750;
     }
 /*        ALL MISSING VALUES MUST BE ACCOMMODATED. */
     mina = 0;
     maxa = 0;
     mislla = 1;
     if (*is523 != 2) {
-	goto L177;
+        goto L177;
     }
 /*        WHEN ALL VALUES ARE MISSING AND THERE ARE NO SECONDARY */
 /*        MISSING VALUES IBITA = 0 AS ORIGINALLY SET.  OTHERWISE, */
@@ -1013,9 +1013,9 @@ L1750:
     itest = maxa - mina + lmiss;
 
     for (ibita = 0; ibita <= 30; ++ibita) {
-	if (itest < ibxx2[ibita]) {
-	    goto L177;
-	}
+        if (itest < ibxx2[ibita]) {
+            goto L177;
+        }
 /* ***        THIS TEST IS THE SAME AS: */
 /* ***         IF(MAXA-MINA.LT.IBXX2(IBITA)-LMISS)GO TO 177 */
 /* L176: */
@@ -1040,20 +1040,20 @@ L177:
 
 L180:
     if (mislla == 1) {
-	minc = mallow;
-	minck = mallow;
-	maxc = -mallow;
-	maxck = -mallow;
+        minc = mallow;
+        minck = mallow;
+        maxc = -mallow;
+        maxck = -mallow;
     } else {
-	minc = mina;
-	maxc = maxa;
-	minck = minak;
-	maxck = minak;
+        minc = mina;
+        maxc = maxa;
+        minck = minak;
+        maxck = minak;
     }
 
     nount = 0;
     if (*nxy - (ktotal + kinc) <= lminpk / 2) {
-	kinc = *nxy - ktotal;
+        kinc = *nxy - ktotal;
     }
 /*        ABOVE STATEMENT CONSTRAINS THE LAST GROUP TO BE NOT LESS THAN */
 /*        LMINPK/2 IN SIZE.  IF A PROVISION LIKE THIS IS NOT INCLUDED, */
@@ -1067,67 +1067,67 @@ L180:
     if (*is523 == 0) {
 
 /* Computing MIN */
-	i__2 = ktotal + kinc;
-	/*i__1 = min(i__2,*nxy);*/
-	i__1 = (i__2 < *nxy) ? i__2 : *nxy;
-	for (k = ktotal + 1; k <= i__1; ++k) {
-	    if (ic[k] < minc) {
-		minc = ic[k];
-		minck = k;
-	    }
-	    if (ic[k] > maxc) {
-		maxc = ic[k];
-		maxck = k;
-	    }
-	    ++nount;
+        i__2 = ktotal + kinc;
+        /*i__1 = min(i__2,*nxy);*/
+        i__1 = (i__2 < *nxy) ? i__2 : *nxy;
+        for (k = ktotal + 1; k <= i__1; ++k) {
+            if (ic[k] < minc) {
+                minc = ic[k];
+                minck = k;
+            }
+            if (ic[k] > maxc) {
+                maxc = ic[k];
+                maxck = k;
+            }
+            ++nount;
 /* L185: */
-	}
+        }
 
     } else if (*is523 == 1) {
 
 /* Computing MIN */
-	i__2 = ktotal + kinc;
-	/*i__1 = min(i__2,*nxy);*/
-	i__1 = (i__2 < *nxy) ? i__2 : *nxy;
-	for (k = ktotal + 1; k <= i__1; ++k) {
-	    if (ic[k] == *missp) {
-		goto L186;
-	    }
-	    if (ic[k] < minc) {
-		minc = ic[k];
-		minck = k;
-	    }
-	    if (ic[k] > maxc) {
-		maxc = ic[k];
-		maxck = k;
-	    }
-L186:
-	    ++nount;
+        i__2 = ktotal + kinc;
+        /*i__1 = min(i__2,*nxy);*/
+        i__1 = (i__2 < *nxy) ? i__2 : *nxy;
+        for (k = ktotal + 1; k <= i__1; ++k) {
+            if (ic[k] == *missp) {
+                goto L186;
+            }
+            if (ic[k] < minc) {
+                minc = ic[k];
+                minck = k;
+            }
+            if (ic[k] > maxc) {
+                maxc = ic[k];
+                maxck = k;
+            }
+        L186:
+            ++nount;
 /* L187: */
-	}
+        }
 
     } else {
 
 /* Computing MIN */
-	i__2 = ktotal + kinc;
-	/*i__1 = min(i__2,*nxy);*/
-	i__1 = (i__2 < *nxy) ? i__2 : *nxy;
-	for (k = ktotal + 1; k <= i__1; ++k) {
-	    if (ic[k] == *missp || ic[k] == *misss) {
-		goto L189;
-	    }
-	    if (ic[k] < minc) {
-		minc = ic[k];
-		minck = k;
-	    }
-	    if (ic[k] > maxc) {
-		maxc = ic[k];
-		maxck = k;
-	    }
-L189:
-	    ++nount;
+        i__2 = ktotal + kinc;
+        /*i__1 = min(i__2,*nxy);*/
+        i__1 = (i__2 < *nxy) ? i__2 : *nxy;
+        for (k = ktotal + 1; k <= i__1; ++k) {
+            if (ic[k] == *missp || ic[k] == *misss) {
+                goto L189;
+            }
+            if (ic[k] < minc) {
+                minc = ic[k];
+                minck = k;
+            }
+            if (ic[k] > maxc) {
+                maxc = ic[k];
+                maxck = k;
+            }
+        L189:
+            ++nount;
 /* L190: */
-	}
+        }
 
     }
 
@@ -1142,21 +1142,21 @@ L189:
 /*        THEN THIS GROUP A IS A GROUP TO PACK. */
 
     if (minc == mallow) {
-	minc = mina;
-	maxc = maxa;
-	minck = minak;
-	maxck = maxak;
-	misllc = 1;
-	goto L195;
+        minc = mina;
+        maxc = maxa;
+        minck = minak;
+        maxck = maxak;
+        misllc = 1;
+        goto L195;
 /*           WHEN THE NEW VALUE(S) ARE MISSING, THEY CAN ALWAYS */
 /*           BE ADDED. */
 
     } else {
-	misllc = 0;
+        misllc = 0;
     }
 
     if (maxc - minc >= ibxx2[ibita] - lmiss) {
-	goto L200;
+        goto L200;
     }
 
 /*        THE BITS NECESSARY FOR GROUP C HAS NOT INCREASED FROM THE */
@@ -1174,20 +1174,20 @@ L195:
     mislla = misllc;
     adda = TRUE_;
     if (ktotal >= *nxy) {
-	goto L200;
+        goto L200;
     }
 
     if (minbk > ktotal && maxbk > ktotal) {
-	mstart = nendb + 1;
+        mstart = nendb + 1;
 /*           THE MAX AND MIN OF GROUP B WERE NOT FROM THE POINTS */
 /*           REMOVED, SO THE WHOLE GROUP DOES NOT HAVE TO BE LOOKED */
 /*           AT TO DETERMINE THE NEW MAX AND MIN.  RATHER START */
 /*           JUST BEYOND THE OLD NENDB. */
-	ibitbs = ibitb;
-	nendb = 1;
-	goto L150;
+        ibitbs = ibitb;
+        nendb = 1;
+        goto L150;
     } else {
-	goto L140;
+        goto L140;
     }
 
 /*        ************************************* */
@@ -1200,7 +1200,7 @@ L195:
 L200:
     ++(*lx);
     if (*lx <= *ndg) {
-	goto L205;
+        goto L205;
     }
     lminpk += lminpk / 2;
 /*     WRITE(KFILDO,201)NDG,LMINPK,LX */
@@ -1218,9 +1218,9 @@ L205:
     kstart = ktotal + 1;
 
     if (mislla == 0) {
-	misslx[*lx - 1] = mallow;
+        misslx[*lx - 1] = mallow;
     } else {
-	misslx[*lx - 1] = ic[ktotal];
+        misslx[*lx - 1] = ic[ktotal];
 /*           IC(KTOTAL) WAS THE LAST VALUE PROCESSED.  IF MISLLA NE 0, */
 /*           THIS MUST BE THE MISSING VALUE FOR THIS GROUP. */
     }
@@ -1232,7 +1232,7 @@ L205:
 /* ***D    2       '  LBIT(LX) ='I5,'  NOV(LX) ='I8,'  MISSLX(LX) =',I7) */
 
     if (ktotal >= *nxy) {
-	goto L209;
+        goto L209;
     }
 
 /*        THE NEW GROUP A WILL BE THE PREVIOUS GROUP B.  SET LIMITS, ETC. */
@@ -1261,14 +1261,14 @@ L209:
 
     i__1 = *lx;
     for (l = 1; l <= i__1; ++l) {
-L210:
-	if (jmin[l] < ibxx2[*ibit]) {
-	    goto L220;
-	}
-	++(*ibit);
-	goto L210;
-L220:
-	;
+    L210:
+        if (jmin[l] < ibxx2[*ibit]) {
+            goto L220;
+        }
+        ++(*ibit);
+        goto L210;
+    L220:
+        ;
     }
 
 /*        INSERT THE VALUE IN JMIN( ) TO BE USED FOR ALL MISSING */
@@ -1277,19 +1277,19 @@ L220:
 
     if (*is523 == 1) {
 
-	i__1 = *lx;
-	for (l = 1; l <= i__1; ++l) {
+        i__1 = *lx;
+        for (l = 1; l <= i__1; ++l) {
 
-	    if (lbit[l] == 0) {
+            if (lbit[l] == 0) {
 
-		if (misslx[l - 1] == *missp) {
-		    jmin[l] = ibxx2[*ibit] - 1;
-		}
+                if (misslx[l - 1] == *missp) {
+                    jmin[l] = ibxx2[*ibit] - 1;
+                }
 
-	    }
+            }
 
 /* L226: */
-	}
+        }
 
     }
 
@@ -1312,19 +1312,19 @@ L220:
 
     i__1 = *lx;
     for (k = 1; k <= i__1; ++k) {
-	if (lbit[k] < *lbitref) {
-	    *lbitref = lbit[k];
-	}
+        if (lbit[k] < *lbitref) {
+            *lbitref = lbit[k];
+        }
 /* L230: */
     }
 
     if (*lbitref != 0) {
 
-	i__1 = *lx;
-	for (k = 1; k <= i__1; ++k) {
-	    lbit[k] -= *lbitref;
+        i__1 = *lx;
+        for (k = 1; k <= i__1; ++k) {
+            lbit[k] -= *lbitref;
 /* L240: */
-	}
+        }
 
     }
 
@@ -1340,14 +1340,14 @@ L220:
 
     i__1 = *lx;
     for (k = 1; k <= i__1; ++k) {
-L310:
-	if (lbit[k] < ibxx2[*jbit]) {
-	    goto L320;
-	}
-	++(*jbit);
-	goto L310;
-L320:
-	;
+    L310:
+        if (lbit[k] < ibxx2[*jbit]) {
+            goto L320;
+        }
+        ++(*jbit);
+        goto L310;
+    L320:
+        ;
     }
 
 /*        ************************************* */
@@ -1369,19 +1369,19 @@ L320:
 
     i__1 = *lx;
     for (k = 1; k <= i__1; ++k) {
-	if (nov[k] < *novref) {
-	    *novref = nov[k];
-	}
+        if (nov[k] < *novref) {
+            *novref = nov[k];
+        }
 /* L400: */
     }
 
     if (*novref > 0) {
 
-	i__1 = *lx;
-	for (k = 1; k <= i__1; ++k) {
-	    nov[k] -= *novref;
+        i__1 = *lx;
+        for (k = 1; k <= i__1; ++k) {
+            nov[k] -= *novref;
 /* L405: */
-	}
+        }
 
     }
 
@@ -1402,42 +1402,42 @@ L320:
 
     i__1 = *lx;
     for (k = 1; k <= i__1; ++k) {
-L410:
-	if (nov[k] < ibxx2[*kbit]) {
-	    goto L420;
-	}
-	++(*kbit);
-	goto L410;
-L420:
-	;
+    L410:
+        if (nov[k] < ibxx2[*kbit]) {
+            goto L420;
+        }
+        ++(*kbit);
+        goto L410;
+    L420:
+        ;
     }
 
 /*        DETERMINE WHETHER THE GROUP SIZES SHOULD BE REDUCED */
 /*        FOR SPACE EFFICIENCY. */
 
     if (ired == 0) {
-	reduce(kfildo, &jmin[1], &jmax[1], &lbit[1], &nov[1], lx, ndg, ibit, 
-		jbit, kbit, novref, ibxx2, ier);
+        reduce(kfildo, &jmin[1], &jmax[1], &lbit[1], &nov[1], lx, ndg, ibit,
+               jbit, kbit, novref, ibxx2, ier);
 
-	if (*ier == 714 || *ier == 715) {
+        if (*ier == 714 || *ier == 715) {
 /*              REDUCE HAS ABORTED.  REEXECUTE PACK_GP WITHOUT REDUCE. */
 /*              PROVIDE FOR A NON FATAL RETURN FROM REDUCE. */
-	    iersav = *ier;
-	    ired = 1;
-	    *ier = 0;
-	    goto L102;
-	}
+            iersav = *ier;
+            ired = 1;
+            *ier = 0;
+            goto L102;
+        }
 
     }
 
     if ( misslx != 0 ) {
-         free(misslx);
-         misslx=0;
+        free(misslx);
+        misslx=0;
     }
 /*     CALL TIMPR(KFILDO,KFILDO,'END   PACK_GP        ') */
     if (iersav != 0) {
-	*ier = iersav;
-	return 0;
+        *ier = iersav;
+        return 0;
     }
 
 /* 900  IF(IER.NE.0)RETURN1 */
@@ -1446,4 +1446,3 @@ L900:
     if ( misslx != 0 ) free(misslx);
     return 0;
 } /* pack_gp__ */
-

--- a/src/pdstemplates.c
+++ b/src/pdstemplates.c
@@ -41,25 +41,25 @@
 //$$$/
 g2int getpdsindex(g2int number)
 {
-           g2int j,getpdsindex=-1;
+    g2int j,getpdsindex=-1;
 
-           for (j=0;j<MAXPDSTEMP;j++) {
-              if (number == templatespds[j].template_num) {
-                 getpdsindex=j;
-                 return(getpdsindex);
-              }
-           }
+    for (j=0;j<MAXPDSTEMP;j++) {
+        if (number == templatespds[j].template_num) {
+            getpdsindex=j;
+            return(getpdsindex);
+        }
+    }
 
-           return(getpdsindex);
+    return(getpdsindex);
 }
 
 
 ///$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    getpdstemplate 
+// SUBPROGRAM:    getpdstemplate
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2000-05-11
 //
-// ABSTRACT: This subroutine returns PDS template information for a 
+// ABSTRACT: This subroutine returns PDS template information for a
 //   specified Product Definition Template 4.NN.
 //   The number of entries in the template is returned along with a map
 //   of the number of octets occupied by each entry.  Also, a flag is
@@ -79,7 +79,7 @@ g2int getpdsindex(g2int number)
 //
 // USAGE:    CALL getpdstemplate(number)
 //   INPUT ARGUMENT LIST:
-//     number   - NN, indicating the number of the Product Definition 
+//     number   - NN, indicating the number of the Product Definition
 //                Template 4.NN that is being requested.
 //
 //   RETURN VALUE:
@@ -95,39 +95,39 @@ g2int getpdsindex(g2int number)
 //$$$/
 gtemplate *getpdstemplate(g2int number)
 {
-           g2int index;
-           gtemplate *new;
+    g2int index;
+    gtemplate *new;
 
-           index=getpdsindex(number);
+    index=getpdsindex(number);
 
-           if (index != -1) {
-              new=(gtemplate *)malloc(sizeof(gtemplate));
-              new->type=4;
-              new->num=templatespds[index].template_num;
-              new->maplen=templatespds[index].mappdslen;
-              new->needext=templatespds[index].needext;
-              new->map=(g2int *)templatespds[index].mappds;
-              new->extlen=0;
-              new->ext=0;        //NULL
-              return(new);
-           }
-           else {
-             printf("getpdstemplate: PDS Template 4.%d not defined.\n",(int)number);
-             return(0);        //NULL
-           }
+    if (index != -1) {
+        new=(gtemplate *)malloc(sizeof(gtemplate));
+        new->type=4;
+        new->num=templatespds[index].template_num;
+        new->maplen=templatespds[index].mappdslen;
+        new->needext=templatespds[index].needext;
+        new->map=(g2int *)templatespds[index].mappds;
+        new->extlen=0;
+        new->ext=0;        //NULL
+        return(new);
+    }
+    else {
+        printf("getpdstemplate: PDS Template 4.%d not defined.\n",(int)number);
+        return(0);        //NULL
+    }
 
-         return(0);        //NULL
+    return(0);        //NULL
 }
-         
-        
+
+
 ///$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    extpdstemplate 
+// SUBPROGRAM:    extpdstemplate
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2000-05-11
 //
 // ABSTRACT: This subroutine generates the remaining octet map for a
 //   given Product Definition Template, if required.  Some Templates can
-//   vary depending on data values given in an earlier part of the 
+//   vary depending on data values given in an earlier part of the
 //   Template, and it is necessary to know some of the earlier entry
 //   values to generate the full octet map of the Template.
 //
@@ -145,9 +145,9 @@ gtemplate *getpdstemplate(g2int number)
 //
 // USAGE:    CALL extpdstemplate(number,list)
 //   INPUT ARGUMENT LIST:
-//     number   - NN, indicating the number of the Product Definition 
+//     number   - NN, indicating the number of the Product Definition
 //                Template 4.NN that is being requested.
-//     list()   - The list of values for each entry in the 
+//     list()   - The list of values for each entry in the
 //                the Product Definition Template 4.NN.
 //
 //   RETURN VALUE:
@@ -161,314 +161,314 @@ gtemplate *getpdstemplate(g2int number)
 //$$$
 gtemplate *extpdstemplate(g2int number,g2int *list)
 {
-           gtemplate *new;
-           g2int index,i,j,k,l;
+    gtemplate *new;
+    g2int index,i,j,k,l;
 
-           index=getpdsindex(number);
-           if (index == -1) return(0);
+    index=getpdsindex(number);
+    if (index == -1) return(0);
 
-           new=getpdstemplate(number);
+    new=getpdstemplate(number);
 
-           if ( ! new->needext ) return(new);
+    if ( ! new->needext ) return(new);
 
-           if ( number == 3 ) {
-              new->extlen=list[26];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<new->extlen;i++) {
-                 new->ext[i]=1;
-              }
-           }
-           else if ( number == 4 ) {
-              new->extlen=list[25];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<new->extlen;i++) {
-                 new->ext[i]=1;
-              }
-           }
-           else if ( number == 8 ) {
-              if ( list[21] > 1 ) {
-                 new->extlen=(list[21]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[21];j++) {
+    if ( number == 3 ) {
+        new->extlen=list[26];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=1;
+        }
+    }
+    else if ( number == 4 ) {
+        new->extlen=list[25];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<new->extlen;i++) {
+            new->ext[i]=1;
+        }
+    }
+    else if ( number == 8 ) {
+        if ( list[21] > 1 ) {
+            new->extlen=(list[21]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[21];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[23+k];
+                }
+            }
+        }
+    }
+    else if ( number == 9 ) {
+        if ( list[28] > 1 ) {
+            new->extlen=(list[28]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[28];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[30+k];
+                }
+            }
+        }
+    }
+    else if ( number == 10 ) {
+        if ( list[22] > 1 ) {
+            new->extlen=(list[22]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[22];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[24+k];
+                }
+            }
+        }
+    }
+    else if ( number == 11 ) {
+        if ( list[24] > 1 ) {
+            new->extlen=(list[24]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[24];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[26+k];
+                }
+            }
+        }
+    }
+    else if ( number == 12 ) {
+        if ( list[23] > 1 ) {
+            new->extlen=(list[23]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[23];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[25+k];
+                }
+            }
+        }
+    }
+    else if ( number == 13 ) {
+        new->extlen=((list[37]-1)*6)+list[26];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        if ( list[37] > 1 ) {
+            for (j=2;j<=list[37];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[39+k];
+                }
+            }
+        }
+        l=(list[37]-1)*6;
+        if ( l<0 ) l=0;
+        for (i=0;i<list[26];i++) {
+            new->ext[l+i]=1;
+        }
+    }
+    else if ( number == 14 ) {
+        new->extlen=((list[36]-1)*6)+list[25];
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        if ( list[36] > 1 ) {
+            for (j=2;j<=list[36];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[38+k];
+                }
+            }
+        }
+        l=(list[36]-1)*6;
+        if ( l<0 ) l=0;
+        for (i=0;i<list[25];i++) {
+            new->ext[l+i]=1;
+        }
+    }
+    else if ( number == 30 ) {
+        new->extlen=list[4]*5;
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<list[4];i++) {
+            l=i*5;
+            new->ext[l]=2;
+            new->ext[l+1]=2;
+            new->ext[l+2]=1;
+            new->ext[l+3]=1;
+            new->ext[l+4]=4;
+        }
+    }
+    else if ( number == 31 ) {
+        new->extlen=list[4]*5;
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<list[4];i++) {
+            l=i*5;
+            new->ext[l]=2;
+            new->ext[l+1]=2;
+            new->ext[l+2]=2;
+            new->ext[l+3]=1;
+            new->ext[l+4]=4;
+        }
+    }
+    else if ( number == 42 ) {
+        if ( list[22] > 1 ) {
+            new->extlen=(list[22]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[22];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[24+k];
+                }
+            }
+        }
+    }
+    else if ( number == 43 ) {
+        if ( list[25] > 1 ) {
+            new->extlen=(list[25]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[25];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[27+k];
+                }
+            }
+        }
+    }
+    else if ( number == 32 ) {
+        new->extlen=list[9]*10;
+        new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+        for (i=0;i<list[9];i++) {
+            l=i*5;
+            new->ext[l]=2;
+            new->ext[l+1]=2;
+            new->ext[l+2]=2;
+            new->ext[l+3]=-1;
+            new->ext[l+4]=-4;
+        }
+    }
+    else if ( number == 46 ) {
+        if ( list[27] > 1 ) {
+            new->extlen=(list[27]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[27];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[29+k];
+                }
+            }
+        }
+    }
+    else if ( number == 47 ) {
+        if ( list[30] > 1 ) {
+            new->extlen=(list[30]-1)*6;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (j=2;j<=list[30];j++) {
+                l=(j-2)*6;
+                for (k=0;k<6;k++) {
+                    new->ext[l+k]=new->map[32+k];
+                }
+            }
+        }
+        else if ( number == 51 ) {
+            new->extlen=list[15]*11;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (i=0;i<list[15];i++) {
+                l=i*6;
+                new->ext[l]=1;
+                new->ext[l+1]=1;
+                new->ext[l+2]=-1;
+                new->ext[l+3]=-4;
+                new->ext[l+4]=-1;
+                new->ext[l+5]=-4;
+            }
+        }
+        else if ( number == 33 ) {
+            new->extlen=list[9];
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (i=0;i<new->extlen;i++) {
+                new->ext[i]=1;
+            }
+        }
+        else if ( number == 34 ) {
+            new->extlen=((list[24]-1)*6)+list[9];
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            if ( list[24] > 1 ) {
+                for (j=2;j<=list[24];j++) {
                     l=(j-2)*6;
                     for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[23+k];
+                        new->ext[l+k]=new->map[26+k];
                     }
-                 }
-              }
-           }
-           else if ( number == 9 ) {
-              if ( list[28] > 1 ) {
-                 new->extlen=(list[28]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[28];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[30+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 10 ) {
-              if ( list[22] > 1 ) {
-                 new->extlen=(list[22]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[22];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[24+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 11 ) {
-              if ( list[24] > 1 ) {
-                 new->extlen=(list[24]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[24];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[26+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 12 ) {
-              if ( list[23] > 1 ) {
-                 new->extlen=(list[23]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[23];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[25+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 13 ) {
-              new->extlen=((list[37]-1)*6)+list[26];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              if ( list[37] > 1 ) {
-                 for (j=2;j<=list[37];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[39+k];
-                    }
-                 }
-              }
-              l=(list[37]-1)*6;
-              if ( l<0 ) l=0;
-              for (i=0;i<list[26];i++) {
+                }
+            }
+            l=(list[24]-1)*6;
+            if ( l<0 ) l=0;
+            for (i=0;i<list[9];i++) {
                 new->ext[l+i]=1;
-              }
-           }
-           else if ( number == 14 ) {
-              new->extlen=((list[36]-1)*6)+list[25];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              if ( list[36] > 1 ) {
-                 for (j=2;j<=list[36];j++) {
+            }
+        }
+        else if ( number == 53 ) {
+            new->extlen=list[3];
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (i=0;i<new->extlen;i++) {
+                new->ext[i]=1;
+            }
+        }
+        else if ( number == 54 ) {
+            new->extlen=list[3];
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (i=0;i<new->extlen;i++) {
+                new->ext[i]=1;
+            }
+        }
+        else if ( number == 91 ) {
+            new->extlen=((list[28]-1)*6)+list[15];
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            if ( list[28] > 1 ) {
+                for (j=2;j<=list[28];j++) {
                     l=(j-2)*6;
                     for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[38+k];
+                        new->ext[l+k]=new->map[30+k];
                     }
-                 }
-              }
-              l=(list[36]-1)*6;
-              if ( l<0 ) l=0;
-              for (i=0;i<list[25];i++) {
+                }
+            }
+            l=(list[29]-1)*6;
+            if ( l<0 ) l=0;
+            for (i=0;i<list[15];i++) {
                 new->ext[l+i]=1;
-              }
-           }
-           else if ( number == 30 ) {
-              new->extlen=list[4]*5;
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<list[4];i++) {
-                 l=i*5;
-                 new->ext[l]=2;
-                 new->ext[l+1]=2;
-                 new->ext[l+2]=1;
-                 new->ext[l+3]=1;
-                 new->ext[l+4]=4;
-              }
-           }
-           else if ( number == 31 ) {
-              new->extlen=list[4]*5;
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<list[4];i++) {
-                 l=i*5;
-                 new->ext[l]=2;
-                 new->ext[l+1]=2;
-                 new->ext[l+2]=2;
-                 new->ext[l+3]=1;
-                 new->ext[l+4]=4;
-              }
-           }
-           else if ( number == 42 ) {
-              if ( list[22] > 1 ) {
-                 new->extlen=(list[22]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[22];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[24+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 43 ) {
-              if ( list[25] > 1 ) {
-                 new->extlen=(list[25]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[25];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[27+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 32 ) {
-              new->extlen=list[9]*10;
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<list[9];i++) {
-                 l=i*5;
-                 new->ext[l]=2;
-                 new->ext[l+1]=2;
-                 new->ext[l+2]=2;
-                 new->ext[l+3]=-1;
-                 new->ext[l+4]=-4;
-              }
-           }
-           else if ( number == 46 ) {
-              if ( list[27] > 1 ) {
-                 new->extlen=(list[27]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[27];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[29+k];
-                    }
-                 }
-              }
-           }
-           else if ( number == 47 ) {
-              if ( list[30] > 1 ) {
-                 new->extlen=(list[30]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[30];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[32+k];
-                    }
-                 }
-              }
-           else if ( number == 51 ) {
-              new->extlen=list[15]*11;
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<list[15];i++) {
-                 l=i*6;
-                 new->ext[l]=1;
-                 new->ext[l+1]=1;
-                 new->ext[l+2]=-1;
-                 new->ext[l+3]=-4;
-                 new->ext[l+4]=-1;
-                 new->ext[l+5]=-4;
-              }
-           }
-           else if ( number == 33 ) {
-              new->extlen=list[9];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<new->extlen;i++) {
-                 new->ext[i]=1;
-              }
-           }
-           else if ( number == 34 ) {
-              new->extlen=((list[24]-1)*6)+list[9];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              if ( list[24] > 1 ) {
-                 for (j=2;j<=list[24];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[26+k];
-                    }
-                 }
-              }
-              l=(list[24]-1)*6;
-              if ( l<0 ) l=0;
-              for (i=0;i<list[9];i++) {
-                new->ext[l+i]=1;
-              }
-           }
-           else if ( number == 53 ) {
-              new->extlen=list[3];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<new->extlen;i++) {
-                 new->ext[i]=1;
-              }
-           }
-           else if ( number == 54 ) {
-              new->extlen=list[3];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<new->extlen;i++) {
-                 new->ext[i]=1;
-              }
-           }
-           else if ( number == 91 ) {
-              new->extlen=((list[28]-1)*6)+list[15];
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              if ( list[28] > 1 ) {
-                 for (j=2;j<=list[28];j++) {
-                    l=(j-2)*6;
-                    for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[30+k];
-                    }
-                 }
-              }
-              l=(list[29]-1)*6;
-              if ( l<0 ) l=0;
-              for (i=0;i<list[15];i++) {
-                new->ext[l+i]=1;
-              }
-             }
+            }
+        }
 // PDT 4.57  (10/07/2015)
-           else if ( number == 57 ) {
-              new->extlen=list[6]*15;
-              new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-              for (i=0;i<list[6];i++) {
-                 l=i*15;
-                 new->ext[l]=1;
-                 new->ext[l+1]=-4;
-                 new->ext[l+2]=1;
-                 new->ext[l+3]=1;
-                 new->ext[l+4]=1;
-                 new->ext[l+5]=2;
-                 new->ext[l+6]=1;
-                 new->ext[l+7]=1;
-                 new->ext[l+8]=-4;
-                 new->ext[l+9]=1;
-                 new->ext[l+10]=-1;
-                 new->ext[l+11]=-4;
-                 new->ext[l+12]=1;
-                 new->ext[l+13]=-1;
-                 new->ext[l+14]=-4;
-              }
-           }
+        else if ( number == 57 ) {
+            new->extlen=list[6]*15;
+            new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+            for (i=0;i<list[6];i++) {
+                l=i*15;
+                new->ext[l]=1;
+                new->ext[l+1]=-4;
+                new->ext[l+2]=1;
+                new->ext[l+3]=1;
+                new->ext[l+4]=1;
+                new->ext[l+5]=2;
+                new->ext[l+6]=1;
+                new->ext[l+7]=1;
+                new->ext[l+8]=-4;
+                new->ext[l+9]=1;
+                new->ext[l+10]=-1;
+                new->ext[l+11]=-4;
+                new->ext[l+12]=1;
+                new->ext[l+13]=-1;
+                new->ext[l+14]=-4;
+            }
+        }
 // PDT 4.61  (10/07/2015)
-           else if ( number == 61 ) {
-              if ( list[30] > 1 ) {
-                 new->extlen=(list[30]-1)*6;
-                 new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
-                 for (j=2;j<=list[30];j++) {
+        else if ( number == 61 ) {
+            if ( list[30] > 1 ) {
+                new->extlen=(list[30]-1)*6;
+                new->ext=(g2int *)malloc(sizeof(g2int)*new->extlen);
+                for (j=2;j<=list[30];j++) {
                     l=(j-2)*6;
                     for (k=0;k<6;k++) {
-                       new->ext[l+k]=new->map[32+k];
+                        new->ext[l+k]=new->map[32+k];
                     }
-                 }
-              }
-           }
+                }
+            }
+        }
 
-           }
+    }
 
-           return(new);
+    return(new);
 
 }

--- a/src/pdstemplates.h
+++ b/src/pdstemplates.h
@@ -1,7 +1,7 @@
 /** @file
  *  @author Gilbert @date 2002-10-26
  *
- * This inculde file contains info on all the available 
+ * This inculde file contains info on all the available
  *   GRIB2 Product Definition Templates used in Section 4 (PDS).
  *   The information decribing each template is stored in the
  *   pdstemplate structure defined below.
@@ -9,12 +9,12 @@
  *   Each Template has three parts: The number of entries in the template
  *   (mappdslen);  A map of the template (mappds), which contains the
  *   number of octets in which to pack each of the template values; and
- *   a logical value (needext) that indicates whether the Template needs 
- *   to be extended.  In some cases the number of entries in a template 
- *   can vary depending upon values specified in the "static" part of 
+ *   a logical value (needext) that indicates whether the Template needs
+ *   to be extended.  In some cases the number of entries in a template
+ *   can vary depending upon values specified in the "static" part of
  *   the template.  ( See Template 4.3 as an example )
  *
- *   NOTE:  Array mappds contains the number of octets in which the 
+ *   NOTE:  Array mappds contains the number of octets in which the
  *   corresponding template values will be stored.  A negative value in
  *   mappds is used to indicate that the corresponding template entry can
  *   contain negative values.  This information is used later when packing
@@ -22,9 +22,9 @@
  *   are stored with the left most bit set to one, and a negative number
  *   of octets value in mappds[] indicates that this possibility should
  *   be considered.  The number of octets used to store the data value
- *   in this case would be the absolute value of the negative value in 
+ *   in this case would be the absolute value of the negative value in
  *   mappds[].
- *  
+ *
  * 2005-12-08  Gilbert   Allow negative scale factors and limits for
  *                       Templates 4.5 and 4.9
  * 2009-12-15  Vuong     Added Product Definition Template 4.31
@@ -44,187 +44,187 @@
 #include "grib2.h"
 
 
-      #define MAXPDSTEMP 47           // maximum number of templates
-      #define MAXPDSMAPLEN 200        // maximum template map length
+#define MAXPDSTEMP 47           // maximum number of templates
+#define MAXPDSMAPLEN 200        // maximum template map length
 
-      struct pdstemplate 
-      {
-          g2int template_num;
-          g2int mappdslen;
-          g2int needext;
-          g2int mappds[MAXPDSMAPLEN];
-      };
+struct pdstemplate
+{
+    g2int template_num;
+    g2int mappdslen;
+    g2int needext;
+    g2int mappds[MAXPDSMAPLEN];
+};
 
-      const struct pdstemplate templatespds[MAXPDSTEMP] = {
-             // 4.0: Analysis or Forecast at Horizontal Level/Layer
-             //      at a point in time
-         {0,15,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
-             // 4.1: Individual Ensemble Forecast at Horizontal Level/Layer
-             //      at a point in time
-         {1,18,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
-             // 4.2: Derived Fcst based on whole Ensemble at Horiz Level/Layer
-             //      at a point in time
-         {2,17,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1} },
-             // 4.3: Derived Fcst based on Ensemble cluster over rectangular
-             //      area at Horiz Level/Layer at a point in time
-         {3,31,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,-4,4,4,1,-1,4,-1,4} },
-             // 4.4: Derived Fcst based on Ensemble cluster over circular
-             //      area at Horiz Level/Layer at a point in time
-         {4,30,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,4,4,1,-1,4,-1,4} },
-             // 4.5: Probablility Forecast at Horiz Level/Layer
-             //      at a point in time
-         {5,22,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,-1,-4,-1,-4} },
-             // 4.6: Percentile Forecast at Horiz Level/Layer
-             //      at a point in time
-         {6,16,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1} },
-             // 4.7: Analysis or Forecast Error at Horizontal Level/Layer
-             //      at a point in time
-         {7,15,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
-             // 4.8: Ave/Accum/etc... at Horiz Level/Layer
-             //      in a time interval
-         {8,29,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.9: Probablility Forecast at Horiz Level/Layer
-             //      in a time interval
-         {9,36,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,-1,-4,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.10: Percentile Forecast at Horiz Level/Layer
-             //       in a time interval
-         {10,30,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.11: Individual Ensemble Forecast at Horizontal Level/Layer
-             //       in a time interval
-         {11,32,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.12: Derived Fcst based on whole Ensemble at Horiz Level/Layer
-             //       in a time interval
-         {12,31,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.13: Derived Fcst based on Ensemble cluster over rectangular
-             //       area at Horiz Level/Layer in a time interval
-         {13,45,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,-4,4,4,1,-1,4,-1,4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.14: Derived Fcst based on Ensemble cluster over circular
-             //       area at Horiz Level/Layer in a time interval
-         {14,44,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,4,4,1,-1,4,-1,4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.15: Average, accumulation, extreme values or other statistically-processed values over a
-             // spatial area at a horizontal level or in a horizontal layer at a point in time
-         {15,18,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
-             // 4.20: Radar Product
-         {20,19,0, {1,1,1,1,1,-4,4,2,4,2,1,1,1,1,1,2,1,3,2} },
-             // 4.30: Satellite Product
-         {30,5,1, {1,1,1,1,1} },
-             // 4.31: Satellite Product
-         {31,5,1, {1,1,1,1,1} },
-             // 4.40: Analysis or forecast at a horizontal level or in a horizontal layer
-             // at a point in time for atmospheric chemical constituents
-         {40,16,0, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
-             // 4.41: Individual ensemble forecast, control and perturbed, at a horizontal level or
-             // in a horizontal layer at a point in time for atmospheric chemical constituents
-         {41,19,0, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
-             // 4.42: Average, accumulation, and/or extreme values or other statistically-processed values
-             // at a horizontal level or in a horizontal layer in a continuous or non-continuous
-             // time interval for atmospheric chemical constituents
-         {42,30,1, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.43: Individual ensemble forecast, control and perturbed, at a horizontal level
-             // or in a horizontal layer in a continuous or non-continuous
-             // time interval for atmospheric chemical constituents
-         {43,33,1, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.254: CCITT IA5 Character String
-         {254,3,0, {1,1,4} },
-             // 4.1000: Cross section of analysis or forecast
-             //         at a point in time
-         {1000,9,0, {1,1,1,1,1,2,1,1,-4} },
-             // 4.1001: Cross section of Ave/Accum/etc... analysis or forecast
-             //         in a time interval
-         {1001,16,0, {1,1,1,1,1,2,1,1,4,4,1,1,1,4,1,4} },
-             // 4.1001: Cross section of Ave/Accum/etc... analysis or forecast
-             //         over latitude or longitude
-         {1002,15,0, {1,1,1,1,1,2,1,1,-4,1,1,1,4,4,2} },
-             // 4.1100: Hovmoller-type grid w/ no averaging or other
-             //         statistical processing
-         {1100,15,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
-             // 4.1100: Hovmoller-type grid with averaging or other
-             //         statistical processing
-         {1101,22,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,4,1,1,1,4,1,4} },
-             // 4.32:Simulate (synthetic) Satellite Product
-         {32,10,1, {1,1,1,1,1,2,1,1,-2,1} },
-             // 4.44: Analysis or forecast at a horizontal level or in a horizontal layer
-             // at a point in time for Aerosol
-         {44,21,0, {1,1,2,1,-1,-4,-1,-4,1,1,1,2,1,1,-2,1,-1,-4,1,-1,-4} },
-             // 4.45: Individual ensemble forecast, control and 
-             // perturbed,  at a horizontal level or in a horizontal layer
-             // at a point in time for Aerosol
-         {45,24,0, {1,1,2,1,-1,-4,-1,-4,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
-             // 4.46: Ave or Accum or Extreme value at level/layer
-             // at horizontal level or in a horizontal in a continuous or
-             // non-continuous time interval for Aerosol
-         {46,35,1, {1,1,2,1,-1,-4,-1,-4,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
-             // 4.47: Individual ensemble forecast, control and 
-             // perturbed, at horizontal level or in a horizontal
-             // in a continuous or non-continuous time interval for Aerosol
-         {47,38,1, {1,1,1,2,1,-1,-4,-1,-4,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+const struct pdstemplate templatespds[MAXPDSTEMP] = {
+    // 4.0: Analysis or Forecast at Horizontal Level/Layer
+    //      at a point in time
+    {0,15,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
+    // 4.1: Individual Ensemble Forecast at Horizontal Level/Layer
+    //      at a point in time
+    {1,18,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
+    // 4.2: Derived Fcst based on whole Ensemble at Horiz Level/Layer
+    //      at a point in time
+    {2,17,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1} },
+    // 4.3: Derived Fcst based on Ensemble cluster over rectangular
+    //      area at Horiz Level/Layer at a point in time
+    {3,31,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,-4,4,4,1,-1,4,-1,4} },
+    // 4.4: Derived Fcst based on Ensemble cluster over circular
+    //      area at Horiz Level/Layer at a point in time
+    {4,30,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,4,4,1,-1,4,-1,4} },
+    // 4.5: Probablility Forecast at Horiz Level/Layer
+    //      at a point in time
+    {5,22,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,-1,-4,-1,-4} },
+    // 4.6: Percentile Forecast at Horiz Level/Layer
+    //      at a point in time
+    {6,16,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1} },
+    // 4.7: Analysis or Forecast Error at Horizontal Level/Layer
+    //      at a point in time
+    {7,15,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
+    // 4.8: Ave/Accum/etc... at Horiz Level/Layer
+    //      in a time interval
+    {8,29,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.9: Probablility Forecast at Horiz Level/Layer
+    //      in a time interval
+    {9,36,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,-1,-4,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.10: Percentile Forecast at Horiz Level/Layer
+    //       in a time interval
+    {10,30,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.11: Individual Ensemble Forecast at Horizontal Level/Layer
+    //       in a time interval
+    {11,32,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.12: Derived Fcst based on whole Ensemble at Horiz Level/Layer
+    //       in a time interval
+    {12,31,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.13: Derived Fcst based on Ensemble cluster over rectangular
+    //       area at Horiz Level/Layer in a time interval
+    {13,45,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,-4,4,4,1,-1,4,-1,4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.14: Derived Fcst based on Ensemble cluster over circular
+    //       area at Horiz Level/Layer in a time interval
+    {14,44,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,1,1,1,1,-4,4,4,1,-1,4,-1,4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.15: Average, accumulation, extreme values or other statistically-processed values over a
+    // spatial area at a horizontal level or in a horizontal layer at a point in time
+    {15,18,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
+    // 4.20: Radar Product
+    {20,19,0, {1,1,1,1,1,-4,4,2,4,2,1,1,1,1,1,2,1,3,2} },
+    // 4.30: Satellite Product
+    {30,5,1, {1,1,1,1,1} },
+    // 4.31: Satellite Product
+    {31,5,1, {1,1,1,1,1} },
+    // 4.40: Analysis or forecast at a horizontal level or in a horizontal layer
+    // at a point in time for atmospheric chemical constituents
+    {40,16,0, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
+    // 4.41: Individual ensemble forecast, control and perturbed, at a horizontal level or
+    // in a horizontal layer at a point in time for atmospheric chemical constituents
+    {41,19,0, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
+    // 4.42: Average, accumulation, and/or extreme values or other statistically-processed values
+    // at a horizontal level or in a horizontal layer in a continuous or non-continuous
+    // time interval for atmospheric chemical constituents
+    {42,30,1, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.43: Individual ensemble forecast, control and perturbed, at a horizontal level
+    // or in a horizontal layer in a continuous or non-continuous
+    // time interval for atmospheric chemical constituents
+    {43,33,1, {1,1,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.254: CCITT IA5 Character String
+    {254,3,0, {1,1,4} },
+    // 4.1000: Cross section of analysis or forecast
+    //         at a point in time
+    {1000,9,0, {1,1,1,1,1,2,1,1,-4} },
+    // 4.1001: Cross section of Ave/Accum/etc... analysis or forecast
+    //         in a time interval
+    {1001,16,0, {1,1,1,1,1,2,1,1,4,4,1,1,1,4,1,4} },
+    // 4.1001: Cross section of Ave/Accum/etc... analysis or forecast
+    //         over latitude or longitude
+    {1002,15,0, {1,1,1,1,1,2,1,1,-4,1,1,1,4,4,2} },
+    // 4.1100: Hovmoller-type grid w/ no averaging or other
+    //         statistical processing
+    {1100,15,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
+    // 4.1100: Hovmoller-type grid with averaging or other
+    //         statistical processing
+    {1101,22,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,4,1,1,1,4,1,4} },
+    // 4.32:Simulate (synthetic) Satellite Product
+    {32,10,1, {1,1,1,1,1,2,1,1,-2,1} },
+    // 4.44: Analysis or forecast at a horizontal level or in a horizontal layer
+    // at a point in time for Aerosol
+    {44,21,0, {1,1,2,1,-1,-4,-1,-4,1,1,1,2,1,1,-2,1,-1,-4,1,-1,-4} },
+    // 4.45: Individual ensemble forecast, control and
+    // perturbed,  at a horizontal level or in a horizontal layer
+    // at a point in time for Aerosol
+    {45,24,0, {1,1,2,1,-1,-4,-1,-4,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
+    // 4.46: Ave or Accum or Extreme value at level/layer
+    // at horizontal level or in a horizontal in a continuous or
+    // non-continuous time interval for Aerosol
+    {46,35,1, {1,1,2,1,-1,-4,-1,-4,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.47: Individual ensemble forecast, control and
+    // perturbed, at horizontal level or in a horizontal
+    // in a continuous or non-continuous time interval for Aerosol
+    {47,38,1, {1,1,1,2,1,-1,-4,-1,-4,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
 
-             //             PDT 4.48
-             // 4.48: Analysis or forecast at a horizontal level or in a horizontal layer
-             // at a point in time for Optical Properties of Aerosol
-         {48,26,0, {1,1,2,1,-1,-4,-1,-4,1,-1,-4,-1,-4,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
+    //             PDT 4.48
+    // 4.48: Analysis or forecast at a horizontal level or in a horizontal layer
+    // at a point in time for Optical Properties of Aerosol
+    {48,26,0, {1,1,2,1,-1,-4,-1,-4,1,-1,-4,-1,-4,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
 
-             //             VALIDATION --- PDT 4.50
-             // 4.50: Analysis or forecast of multi component parameter or
-             // matrix element at a point in time
-         {50,21,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,4,4,4,4} },
+    //             VALIDATION --- PDT 4.50
+    // 4.50: Analysis or forecast of multi component parameter or
+    // matrix element at a point in time
+    {50,21,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,4,4,4,4} },
 
-             //             VALIDATION --- PDT 4.52
-             // 4.52: Analysis or forecast of Wave parameters
-             // at the Sea surface at a point in time
-         {52,15,0, {1,1,1,1,1,1,1,1,2,1,1,-4,1,-1,-4} },
+    //             VALIDATION --- PDT 4.52
+    // 4.52: Analysis or forecast of Wave parameters
+    // at the Sea surface at a point in time
+    {52,15,0, {1,1,1,1,1,1,1,1,2,1,1,-4,1,-1,-4} },
 
-             // 4.51: Categorical forecasts at a horizontal level or
-             // in a horizontal layer at a point in time
-         {51,16,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1} },
+    // 4.51: Categorical forecasts at a horizontal level or
+    // in a horizontal layer at a point in time
+    {51,16,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1} },
 
-             // 4.91: Categorical forecasts at a horizontal level or
-             // in a horizontal layer at a point in time
-             // in a continuous or non-continuous time interval
-         {91,36,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,-1,-4,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.91: Categorical forecasts at a horizontal level or
+    // in a horizontal layer at a point in time
+    // in a continuous or non-continuous time interval
+    {91,36,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,-1,-4,-1,-4,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
 // PDT 4.33  (07/29/2013)
-             // 4.33: Individual ensemble forecast, control, perturbed,
-             // at a horizontal level or in a  horizontal layer
-             // at a point in time for simulated (synthetic) Satellite data
-         {33,18,1, {1,1,1,1,1,2,1,1,-4,1,2,2,2,-1,-4,1,1,1} },
+    // 4.33: Individual ensemble forecast, control, perturbed,
+    // at a horizontal level or in a  horizontal layer
+    // at a point in time for simulated (synthetic) Satellite data
+    {33,18,1, {1,1,1,1,1,2,1,1,-4,1,2,2,2,-1,-4,1,1,1} },
 // PDT 4.34  (07/29/2013)
-             // 4.34: Individual ensemble forecast, control, perturbed,
-             // at a horizontal level or in a  horizontal layer,in a continuous or
-             // non-continuous interval for simulated (synthetic) Satellite data
-         {34,32,1, {1,1,1,1,1,2,1,1,-4,1,2,2,2,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.34: Individual ensemble forecast, control, perturbed,
+    // at a horizontal level or in a  horizontal layer,in a continuous or
+    // non-continuous interval for simulated (synthetic) Satellite data
+    {34,32,1, {1,1,1,1,1,2,1,1,-4,1,2,2,2,-1,-4,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
 // PDT 4.53  (07/29/2013)
-             // 4.53:  Partitioned parameters at
-             // horizontal level or horizontal layer
-             // at a point in time
-         {53,19,1, {1,1,1,1,4,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
+    // 4.53:  Partitioned parameters at
+    // horizontal level or horizontal layer
+    // at a point in time
+    {53,19,1, {1,1,1,1,4,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4} },
 // PDT 4.54  (07/29/2013)
-             // 4.54: Individual ensemble forecast, control, perturbed,
-             // at a horizontal level or in a  horizontal layer
-             // at a point in time for partitioned parameters
-         {54,22,1, {1,1,1,1,4,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
+    // 4.54: Individual ensemble forecast, control, perturbed,
+    // at a horizontal level or in a  horizontal layer
+    // at a point in time for partitioned parameters
+    {54,22,1, {1,1,1,1,4,2,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1} },
 // PDT 4.57  (10/07/2015)
-             // 4.57: Analysis or Forecast at a horizontal or in a
-             // horizontal layer at a point in time for
-             // atmospheric chemical constituents based on 
-             // a distribution function
-         {57,7,1, {1,1,2,2,2,2,1} },
+    // 4.57: Analysis or Forecast at a horizontal or in a
+    // horizontal layer at a point in time for
+    // atmospheric chemical constituents based on
+    // a distribution function
+    {57,7,1, {1,1,2,2,2,2,1} },
 // PDT 4.60  (10/07/2015)
-             // 4.60: Individual ensemble reforecast, control and perturbed,
-             // at a horizontal level or in a horizontal layer
-             // at a point in time
-         {60,24,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1} },
+    // 4.60: Individual ensemble reforecast, control and perturbed,
+    // at a horizontal level or in a horizontal layer
+    // at a point in time
+    {60,24,0, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1} },
 // PDT 4.61  (10/07/2015)
-             // 4.61: Individual ensemble reforecast, control and perturbed,
-             // at a horizontal level or in a  horizontal layer
-             // in a continuous or non-continuous time interval
-         {61,38,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
+    // 4.61: Individual ensemble reforecast, control and perturbed,
+    // at a horizontal level or in a  horizontal layer
+    // in a continuous or non-continuous time interval
+    {61,38,1, {1,1,1,1,1,2,1,1,-4,1,-1,-4,1,-1,-4,1,1,1,2,1,1,1,1,1,2,1,1,1,1,1,1,4,1,1,1,4,1,4} },
 //             VALIDATION --- PDT 4.35
 // PDT 4.35  (10/07/2015)
-             // 4.35: Individual ensemble reforecast, control and perturbed,
-             // at a horizontal level or in a  horizontal layer
-             // in a continuous or non-continuous time interval
-         {35,6,1, {1,1,1,1,1,1} }
+    // 4.35: Individual ensemble reforecast, control and perturbed,
+    // at a horizontal level or in a  horizontal layer
+    // in a continuous or non-continuous time interval
+    {35,6,1, {1,1,1,1,1,1} }
 
-      } ;
+} ;
 
 #endif  /*  _pdstemplates_H  */

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -14,7 +14,7 @@ int enc_png(char *,g2int ,g2int ,g2int ,char *);
 // ABSTRACT: This subroutine packs up a data field into PNG image format.
 //   After the data field is scaled, and the reference value is subtracted out,
 //   it is treated as a grayscale image and passed to a PNG encoder.
-//   It also fills in GRIB2 Data Representation Template 5.41 or 5.40010 with 
+//   It also fills in GRIB2 Data Representation Template 5.41 or 5.40010 with
 //   the appropriate values.
 //
 // PROGRAM HISTORY LOG:
@@ -35,7 +35,7 @@ int enc_png(char *,g2int ,g2int ,g2int ,char *);
 //                [4] = Original field type - currently ignored on input
 //                      Data values assumed to be reals.
 //
-//   OUTPUT ARGUMENT LIST: 
+//   OUTPUT ARGUMENT LIST:
 //     idrstmpl - Contains the array of values for Data Representation
 //                Template 5.41 or 5.40010
 //                [0] = Reference value - set by pngpack routine.
@@ -44,7 +44,7 @@ int enc_png(char *,g2int ,g2int ,g2int ,char *);
 //                [3] = Number of bits containing each grayscale pixel value
 //                [4] = Original field type - currently set = 0 on output.
 //                      Data values assumed to be reals.
-//     cpack    - The packed data field 
+//     cpack    - The packed data field
 //     lcpack   - length of packed field cpack.
 //
 // REMARKS: None
@@ -57,67 +57,67 @@ int enc_png(char *,g2int ,g2int ,g2int ,char *);
 void pngpack(g2float *fld,g2int width,g2int height,g2int *idrstmpl,
              unsigned char *cpack,g2int *lcpack)
 {
-      g2int  *ifld;
-      static g2float alog2=0.69314718;       //  ln(2.0)
-      g2int  j,nbits,imin,imax,maxdif;
-      g2int  ndpts,nbytes;
-      g2float  bscale,dscale,rmax,rmin,temp;
-      unsigned char *ctemp;
-      
-      ifld=0;
-      ndpts=width*height;
-      bscale=int_power(2.0,-idrstmpl[1]);
-      dscale=int_power(10.0,idrstmpl[2]);
+    g2int  *ifld;
+    static g2float alog2=0.69314718;       //  ln(2.0)
+    g2int  j,nbits,imin,imax,maxdif;
+    g2int  ndpts,nbytes;
+    g2float  bscale,dscale,rmax,rmin,temp;
+    unsigned char *ctemp;
+
+    ifld=0;
+    ndpts=width*height;
+    bscale=int_power(2.0,-idrstmpl[1]);
+    dscale=int_power(10.0,idrstmpl[2]);
 //
 //  Find max and min values in the data
 //
-      rmax=fld[0];
-      rmin=fld[0];
-      for (j=1;j<ndpts;j++) {
+    rmax=fld[0];
+    rmin=fld[0];
+    for (j=1;j<ndpts;j++) {
         if (fld[j] > rmax) rmax=fld[j];
         if (fld[j] < rmin) rmin=fld[j];
-      }
-      maxdif = (g2int)rint( (rmax-rmin)*dscale*bscale );
+    }
+    maxdif = (g2int)rint( (rmax-rmin)*dscale*bscale );
 //
 //  If max and min values are not equal, pack up field.
 //  If they are equal, we have a constant field, and the reference
 //  value (rmin) is the value for each point in the field and
 //  set nbits to 0.
 //
-      if (rmin != rmax  &&  maxdif != 0 ) {
+    if (rmin != rmax  &&  maxdif != 0 ) {
         ifld=(g2int *)malloc(ndpts*sizeof(g2int));
         //
-        //  Determine which algorithm to use based on user-supplied 
+        //  Determine which algorithm to use based on user-supplied
         //  binary scale factor and number of bits.
         //
         if (idrstmpl[1] == 0) {
-           //
-           //  No binary scaling and calculate minumum number of 
-           //  bits in which the data will fit.
-           //
-           imin=(g2int)rint(rmin*dscale);
-           imax=(g2int)rint(rmax*dscale);
-           maxdif=imax-imin;
-           temp=log((double)(maxdif+1))/alog2;
-           nbits=(g2int)ceil(temp);
-           rmin=(g2float)imin;
-           //   scale data
-           for(j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
+            //
+            //  No binary scaling and calculate minumum number of
+            //  bits in which the data will fit.
+            //
+            imin=(g2int)rint(rmin*dscale);
+            imax=(g2int)rint(rmax*dscale);
+            maxdif=imax-imin;
+            temp=log((double)(maxdif+1))/alog2;
+            nbits=(g2int)ceil(temp);
+            rmin=(g2float)imin;
+            //   scale data
+            for(j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
         }
         else {
-           //
-           //  Use binary scaling factor and calculate minumum number of 
-           //  bits in which the data will fit.
-           //
-           rmin=rmin*dscale;
-           rmax=rmax*dscale;
-           maxdif=(g2int)rint((rmax-rmin)*bscale);
-           temp=log((double)(maxdif+1))/alog2;
-           nbits=(g2int)ceil(temp);
-           //   scale data
-           for (j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
+            //
+            //  Use binary scaling factor and calculate minumum number of
+            //  bits in which the data will fit.
+            //
+            rmin=rmin*dscale;
+            rmax=rmax*dscale;
+            maxdif=(g2int)rint((rmax-rmin)*bscale);
+            temp=log((double)(maxdif+1))/alog2;
+            nbits=(g2int)ceil(temp);
+            //   scale data
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
         }
         //
         //  Pack data into full octets, then do PNG encode.
@@ -143,22 +143,22 @@ void pngpack(g2float *fld,g2int width,g2int height,g2int *idrstmpl,
         //
         *lcpack=(g2int)enc_png((char *)ctemp,width,height,nbits,(char *)cpack);
         if (*lcpack <= 0) {
-           printf("pngpack: ERROR Packing PNG = %d\n",(int)*lcpack);
+            printf("pngpack: ERROR Packing PNG = %d\n",(int)*lcpack);
         }
         free(ctemp);
 
-      }
-      else {
+    }
+    else {
         nbits=0;
         *lcpack=0;
-      }
+    }
 
 //
 //  Fill in ref value and number of bits in Template 5.0
 //
-      mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
-      idrstmpl[3]=nbits;
-      idrstmpl[4]=0;         // original data were reals
-      if (ifld != 0) free(ifld);
+    mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
+    idrstmpl[3]=nbits;
+    idrstmpl[4]=0;         // original data were reals
+    if (ifld != 0) free(ifld);
 
 }

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -11,7 +11,7 @@ int dec_png(unsigned char *,g2int *,g2int *,char *);
 // SUBPROGRAM:    pngunpack
 //   PRGMMR: Gilbert          ORG: W/NP11    DATE: 2003-08-27
 //
-// ABSTRACT: This subroutine unpacks a data field that was packed into a 
+// ABSTRACT: This subroutine unpacks a data field that was packed into a
 //   PNG image format
 //   using info from the GRIB2 Data Representation Template 5.41 or 5.40010.
 //
@@ -41,38 +41,38 @@ g2int pngunpack(unsigned char *cpack,g2int len,g2int *idrstmpl,g2int ndpts,
                 g2float *fld)
 {
 
-      g2int  *ifld;
-      g2int  j,nbits,iret,width,height;
-      g2float  ref,bscale,dscale;
-      unsigned char *ctemp;
+    g2int  *ifld;
+    g2int  j,nbits,iret,width,height;
+    g2float  ref,bscale,dscale;
+    unsigned char *ctemp;
 
-      rdieee(idrstmpl+0,&ref,1);
-      bscale = int_power(2.0,idrstmpl[1]);
-      dscale = int_power(10.0,-idrstmpl[2]);
-      nbits = idrstmpl[3];
+    rdieee(idrstmpl+0,&ref,1);
+    bscale = int_power(2.0,idrstmpl[1]);
+    dscale = int_power(10.0,-idrstmpl[2]);
+    nbits = idrstmpl[3];
 //
 //  if nbits equals 0, we have a constant field where the reference value
 //  is the data value at each gridpoint
 //
-      if (nbits != 0) {
+    if (nbits != 0) {
 
-         ifld=(g2int *)calloc(ndpts,sizeof(g2int));
-         ctemp=(unsigned char *)calloc(ndpts*4,1);
-         if ( ifld == 0 || ctemp == 0) {
+        ifld=(g2int *)calloc(ndpts,sizeof(g2int));
+        ctemp=(unsigned char *)calloc(ndpts*4,1);
+        if ( ifld == 0 || ctemp == 0) {
             fprintf(stderr,"Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
             return(1);
-         }
-         iret=(g2int)dec_png(cpack,&width,&height,ctemp);
-         gbits(ctemp,ifld,0,nbits,0,ndpts);
-         for (j=0;j<ndpts;j++) {
-           fld[j]=(((g2float)ifld[j]*bscale)+ref)*dscale;
-         }
-         free(ctemp);
-         free(ifld);
-      }
-      else {
-         for (j=0;j<ndpts;j++) fld[j]=ref;
-      }
+        }
+        iret=(g2int)dec_png(cpack,&width,&height,ctemp);
+        gbits(ctemp,ifld,0,nbits,0,ndpts);
+        for (j=0;j<ndpts;j++) {
+            fld[j]=(((g2float)ifld[j]*bscale)+ref)*dscale;
+        }
+        free(ctemp);
+        free(ifld);
+    }
+    else {
+        for (j=0;j<ndpts;j++) fld[j]=ref;
+    }
 
-      return(0);
+    return(0);
 }

--- a/src/rdieee.c
+++ b/src/rdieee.c
@@ -4,10 +4,10 @@
 
 //$$$  SUBPROGRAM DOCUMENTATION BLOCK
 //                .      .    .                                       .
-// SUBPROGRAM:    rdieee 
+// SUBPROGRAM:    rdieee
 //   PRGMMR: Gilbert         ORG: W/NP11    DATE: 2002-10-25
 //
-// ABSTRACT: This subroutine reads a list of real values in 
+// ABSTRACT: This subroutine reads a list of real values in
 //   32-bit IEEE floating point format.
 //
 // PROGRAM HISTORY LOG:
@@ -18,7 +18,7 @@
 //     rieee    - g2int array of floating point values in 32-bit IEEE format.
 //     num      - Number of floating point values to convert.
 //
-//   OUTPUT ARGUMENT LIST:      
+//   OUTPUT ARGUMENT LIST:
 //     a        - float array of real values.  a must be allocated with at
 //                least 4*num bytes of memory before calling this function.
 //
@@ -32,23 +32,23 @@
 void rdieee(g2int *rieee,g2float *a,g2int num)
 {
 
-      g2int  j;
-      g2int  isign,iexp,imant;
+    g2int  j;
+    g2int  isign,iexp,imant;
 
-      g2float  sign,temp;
-      static g2float  two23,two126;
-      static g2int test=0;
-      g2intu msk1=0x80000000;        // 10000000000000000000000000000000 binary
-      g2int msk2=0x7F800000;         // 01111111100000000000000000000000 binary
-      g2int msk3=0x007FFFFF;         // 00000000011111111111111111111111 binary
+    g2float  sign,temp;
+    static g2float  two23,two126;
+    static g2int test=0;
+    g2intu msk1=0x80000000;        // 10000000000000000000000000000000 binary
+    g2int msk2=0x7F800000;         // 01111111100000000000000000000000 binary
+    g2int msk3=0x007FFFFF;         // 00000000011111111111111111111111 binary
 
-      if ( test == 0 ) {
-         two23=(g2float)int_power(2.0,-23);
-         two126=(g2float)int_power(2.0,-126);
-         test=1;
-      }
+    if ( test == 0 ) {
+        two23=(g2float)int_power(2.0,-23);
+        two126=(g2float)int_power(2.0,-126);
+        test=1;
+    }
 
-      for (j=0;j<num;j++) {
+    for (j=0;j<num;j++) {
 //
 //  Extract sign bit, exponent, and mantissa
 //
@@ -59,22 +59,22 @@ void rdieee(g2int *rieee,g2float *a,g2int num)
 
         sign=1.0;
         if (isign == 1) sign=-1.0;
-        
+
         if ( (iexp > 0) && (iexp < 255) ) {
-          temp=(g2float)int_power(2.0,(iexp-127));
-          a[j]=sign*temp*(1.0+(two23*(g2float)imant));
+            temp=(g2float)int_power(2.0,(iexp-127));
+            a[j]=sign*temp*(1.0+(two23*(g2float)imant));
         }
         else if ( iexp == 0 ) {
-          if ( imant != 0 )
-            a[j]=sign*two126*two23*(g2float)imant;
-          else
-            a[j]=sign*0.0;
-          
+            if ( imant != 0 )
+                a[j]=sign*two126*two23*(g2float)imant;
+            else
+                a[j]=sign*0.0;
+
         }
         else if ( iexp == 255 )
-           a[j]=sign*(1E+37);
+            a[j]=sign*(1E+37);
 
 
-      }
+    }
 
 }

--- a/src/reduce.c
+++ b/src/reduce.c
@@ -1,15 +1,15 @@
 /** @file
     reduce.f -- translated by f2c (version 20031025).
     You must link the resulting object file with libf2c:
-	on Microsoft Windows system, link with libf2c.lib;
-	on Linux or Unix systems, link with .../path/to/libf2c.a -lm
-	or, if you install libf2c.a in a standard place, with -lf2c -lm
-	-- in that order, at the end of the command line, as in
-<pre>
-		cc *.o -lf2c -lm
-</pre>
-	Source for libf2c is in /netlib/f2c/libf2c.zip, e.g.,
-		http://www.netlib.org/f2c/libf2c.zip
+    on Microsoft Windows system, link with libf2c.lib;
+    on Linux or Unix systems, link with .../path/to/libf2c.a -lm
+    or, if you install libf2c.a in a standard place, with -lf2c -lm
+    -- in that order, at the end of the command line, as in
+    <pre>
+    cc *.o -lf2c -lm
+    </pre>
+    Source for libf2c is in /netlib/f2c/libf2c.zip, e.g.,
+    http://www.netlib.org/f2c/libf2c.zip
 */
 
 /*#include "f2c.h"*/
@@ -18,10 +18,10 @@
 typedef g2int integer;
 typedef g2float real;
 
-/* Subroutine */ int reduce(integer *kfildo, integer *jmin, integer *jmax, 
-	integer *lbit, integer *nov, integer *lx, integer *ndg, integer *ibit,
-	 integer *jbit, integer *kbit, integer *novref, integer *ibxx2, 
-	integer *ier)
+/* Subroutine */ int reduce(integer *kfildo, integer *jmin, integer *jmax,
+                            integer *lbit, integer *nov, integer *lx, integer *ndg, integer *ibit,
+                            integer *jbit, integer *kbit, integer *novref, integer *ibxx2,
+                            integer *ier)
 {
     /* Initialized data */
 
@@ -36,7 +36,7 @@ typedef g2float real;
     static integer move, novl;
     static char cfeed[1];
     static integer nboxj[31], lxnkp, iorigb, ibxx2m1, movmin,
-	     ntotbt[31], ntotpr, newboxt;
+        ntotbt[31], ntotpr, newboxt;
     integer *newbox, *newboxp;
 
 
@@ -127,7 +127,7 @@ typedef g2float real;
 
     *ier = 0;
     if (*lx == 1) {
-	goto L410;
+        goto L410;
     }
 /*        IF THERE IS ONLY ONE GROUP, RETURN. */
 
@@ -137,15 +137,15 @@ typedef g2float real;
 
     i__1 = *lx;
     for (l = 1; l <= i__1; ++l) {
-	newbox[l - 1] = 0;
+        newbox[l - 1] = 0;
 /* L110: */
     }
 
 /*        INITIALIZE NUMBER OF TOTAL NEW BOXES PER J TO ZERO. */
 
     for (j = 1; j <= 31; ++j) {
-	ntotbt[j - 1] = 999999999;
-	nboxj[j - 1] = 0;
+        ntotbt[j - 1] = 999999999;
+        nboxj[j - 1] = 0;
 /* L112: */
     }
 
@@ -177,69 +177,69 @@ typedef g2float real;
 /*           BITS START INCREASING WITH DECREASING J, STOP.  ALSO, THE */
 /*           NUMBER OF BITS REQUIRED IS KNOWN FOR KBITS = NTOTBT(KBIT). */
 
-	newboxt = 0;
+        newboxt = 0;
 
-	i__1 = *lx;
-	for (l = 1; l <= i__1; ++l) {
+        i__1 = *lx;
+        for (l = 1; l <= i__1; ++l) {
 
-	    if (nov[l] < ibxx2[j]) {
-		newbox[l - 1] = 0;
+            if (nov[l] < ibxx2[j]) {
+                newbox[l - 1] = 0;
 /*                 NO SPLITS OR NEW BOXES. */
-		goto L190;
-	    } else {
-		novl = nov[l];
+                goto L190;
+            } else {
+                novl = nov[l];
 
-		m = (nov[l] - 1) / (ibxx2[j] - 1) + 1;
+                m = (nov[l] - 1) / (ibxx2[j] - 1) + 1;
 /*                 M IS FOUND BY SOLVING THE EQUATION BELOW FOR M: */
 /*                 (NOV(L)+M-1)/M LT IBXX2(J) */
 /*                 M GT (NOV(L)-1)/(IBXX2(J)-1) */
 /*                 SET M = (NOV(L)-1)/(IBXX2(J)-1)+1 */
-L130:
-		novl = (nov[l] + m - 1) / m;
+            L130:
+                novl = (nov[l] + m - 1) / m;
 /*                 THE +M-1 IS NECESSARY.  FOR INSTANCE, 15 WILL FIT */
 /*                 INTO A BOX 4 BITS WIDE, BUT WON'T DIVIDE INTO */
 /*                 TWO BOXES 3 BITS WIDE EACH. */
 
-		if (novl < ibxx2[j]) {
-		    goto L185;
-		} else {
-		    ++m;
+                if (novl < ibxx2[j]) {
+                    goto L185;
+                } else {
+                    ++m;
 /* ***                  WRITE(KFILDO,135)L,NOV(L),NOVL,M,J,IBXX2(J) */
 /* *** 135              FORMAT(/' AT 135--L,NOV(L),NOVL,M,J,IBXX2(J)',6I10) */
-		    goto L130;
-		}
+                    goto L130;
+                }
 
 /*                 THE ABOVE DO LOOP WILL NEVER COMPLETE. */
-	    }
+            }
 
-L185:
-	    newbox[l - 1] = m - 1;
-	    newboxt = newboxt + m - 1;
-L190:
-	    ;
-	}
+        L185:
+            newbox[l - 1] = m - 1;
+            newboxt = newboxt + m - 1;
+        L190:
+            ;
+        }
 
-	nboxj[j - 1] = newboxt;
-	ntotpr = ntotbt[j];
-	ntotbt[j - 1] = (*ibit + *jbit) * (*lx + newboxt) + j * (*lx + 
-		newboxt);
+        nboxj[j - 1] = newboxt;
+        ntotpr = ntotbt[j];
+        ntotbt[j - 1] = (*ibit + *jbit) * (*lx + newboxt) + j * (*lx +
+                                                                 newboxt);
 
-	if (ntotbt[j - 1] >= ntotpr) {
-	    jj = j + 1;
+        if (ntotbt[j - 1] >= ntotpr) {
+            jj = j + 1;
 /*              THE PLUS IS USED BECAUSE J DECREASES PER ITERATION. */
-	    goto L250;
-	} else {
+            goto L250;
+        } else {
 
 /*              SAVE THE TOTAL NEW BOXES AND NEWBOX( ) IN CASE THIS */
 /*              IS THE J TO USE. */
 
-	    newboxtp = newboxt;
+            newboxtp = newboxt;
 
-	    i__1 = *lx;
-	    for (l = 1; l <= i__1; ++l) {
-		newboxp[l - 1] = newbox[l - 1];
+            i__1 = *lx;
+            for (l = 1; l <= i__1; ++l) {
+                newboxp[l - 1] = newbox[l - 1];
 /* L195: */
-	    }
+            }
 
 /*           WRITE(KFILDO,197)NEWBOXT,IBXX2(J) */
 /* 197        FORMAT(/' *****************************************' */
@@ -248,7 +248,7 @@ L190:
 /*    3             /' *****************************************') */
 /*           WRITE(KFILDO,198) (NEWBOX(L),L=1,LX) */
 /* 198        FORMAT(/' '20I6/(' '20I6)) */
-	}
+        }
 
 /* 205     WRITE(KFILDO,209)KBIT,IORIGB */
 /* 209     FORMAT(/' ORIGINAL BITS WITH KBIT OF',I5,' =',I10) */
@@ -289,10 +289,10 @@ L250:
 /*           GROUP HAS A MIN (OR REFERENCE) THAT IS NOT ZERO. */
 /*           THIS SHOULD NOT MATTER TO THE UNPACKER. */
 
-	lxnkp = *lx + newboxtp;
+        lxnkp = *lx + newboxtp;
 /*           LXNKP = THE NEW NUMBER OF BOXES */
 
-	if (lxnkp > *ndg) {
+        if (lxnkp > *ndg) {
 /*              DIMENSIONS NOT LARGE ENOUGH.  PROBABLY AN ERROR */
 /*              OF SOME SORT.  ABORT. */
 /*           WRITE(KFILDO,257)NDG,LXNPK */
@@ -300,91 +300,91 @@ L250:
 /* 257        FORMAT(/' DIMENSIONS OF JMIN, ETC. IN REDUCE =',I8, */
 /*    1              ' NOT LARGE ENOUGH FOR THE EXPANDED NUMBER OF', */
 /*    2              ' GROUPS =',I8,'.  ABORT REDUCE.') */
-	    *ier = 715;
-	    goto L410;
+            *ier = 715;
+            goto L410;
 /*              AN ABORT CAUSES THE CALLING PROGRAM TO REEXECUTE */
 /*              WITHOUT CALLING REDUCE. */
-	}
+        }
 
-	lxn = lxnkp;
+        lxn = lxnkp;
 /*           LXN IS THE NUMBER OF THE BOX IN THE NEW SERIES BEING */
 /*           FILLED.  IT DECREASES PER ITERATION. */
-	ibxx2m1 = ibxx2[jj] - 1;
+        ibxx2m1 = ibxx2[jj] - 1;
 /*           IBXX2M1 IS THE MAXIMUM NUMBER OF VALUES PER GROUP. */
 
-	for (l = *lx; l >= 1; --l) {
+        for (l = *lx; l >= 1; --l) {
 
 /*              THE VALUES IS NOV( ) REPRESENT THOSE VALUES + NOVREF. */
 /*              WHEN VALUES ARE MOVED TO ANOTHER BOX, EACH VALUE */
 /*              MOVED TO A NEW BOX REPRESENTS THAT VALUE + NOVREF. */
 /*              THIS HAS TO BE CONSIDERED IN MOVING VALUES. */
 
-	    if (newboxp[l - 1] * (ibxx2m1 + *novref) + *novref > nov[l] + *
-		    novref) {
+            if (newboxp[l - 1] * (ibxx2m1 + *novref) + *novref > nov[l] + *
+                novref) {
 /*                 IF THE ABOVE TEST IS MET, THEN MOVING IBXX2M1 VALUES */
 /*                 FOR ALL NEW BOXES WILL LEAVE A NEGATIVE NUMBER FOR */
 /*                 THE LAST BOX.  NOT A TOLERABLE SITUATION. */
-		movmin = (nov[l] - newboxp[l - 1] * *novref) / newboxp[l - 1];
-		left = nov[l];
+                movmin = (nov[l] - newboxp[l - 1] * *novref) / newboxp[l - 1];
+                left = nov[l];
 /*                 LEFT = THE NUMBER OF VALUES TO MOVE FROM THE ORIGINAL */
 /*                 BOX TO EACH NEW BOX EXCEPT THE LAST.  LEFT IS THE */
 /*                 NUMBER LEFT TO MOVE. */
-	    } else {
-		movmin = ibxx2m1;
+            } else {
+                movmin = ibxx2m1;
 /*                 MOVMIN VALUES CAN BE MOVED FOR EACH NEW BOX. */
-		left = nov[l];
+                left = nov[l];
 /*                 LEFT IS THE NUMBER OF VALUES LEFT TO MOVE. */
-	    }
+            }
 
-	    if (newboxp[l - 1] > 0) {
-		if ((movmin + *novref) * newboxp[l - 1] + *novref <= nov[l] + 
-			*novref && (movmin + *novref) * (newboxp[l - 1] + 1) 
-			>= nov[l] + *novref) {
-		    goto L288;
-		} else {
+            if (newboxp[l - 1] > 0) {
+                if ((movmin + *novref) * newboxp[l - 1] + *novref <= nov[l] +
+                    *novref && (movmin + *novref) * (newboxp[l - 1] + 1)
+                    >= nov[l] + *novref) {
+                    goto L288;
+                } else {
 /* ***D                 WRITE(KFILDO,287)L,MOVMIN,NOVREF,NEWBOXP(L),NOV(L) */
 /* ***D287              FORMAT(/' AT 287 IN REDUCE--L,MOVMIN,NOVREF,', */
 /* ***D    1                    'NEWBOXP(L),NOV(L)',5I12 */
 /* ***D    2                    ' REDUCE ABORTED.') */
 /*              WRITE(KFILDO,2870) */
 /* 2870          FORMAT(/' AN ERROR IN REDUCE ALGORITHM.  ABORT REDUCE.') */
-		    *ier = 714;
-		    goto L410;
+                    *ier = 714;
+                    goto L410;
 /*                 AN ABORT CAUSES THE CALLING PROGRAM TO REEXECUTE */
 /*                 WITHOUT CALLING REDUCE. */
-		}
+                }
 
-	    }
+            }
 
-L288:
-	    i__1 = newboxp[l - 1] + 1;
-	    for (j = 1; j <= i__1; ++j) {
-		/*move = min(movmin,left);*/
-		move = (movmin < left) ? movmin : left;
-		jmin[lxn] = jmin[l];
-		jmax[lxn] = jmax[l];
-		lbit[lxn] = lbit[l];
-		nov[lxn] = move;
-		--lxn;
-		left -= move + *novref;
+        L288:
+            i__1 = newboxp[l - 1] + 1;
+            for (j = 1; j <= i__1; ++j) {
+                /*move = min(movmin,left);*/
+                move = (movmin < left) ? movmin : left;
+                jmin[lxn] = jmin[l];
+                jmax[lxn] = jmax[l];
+                lbit[lxn] = lbit[l];
+                nov[lxn] = move;
+                --lxn;
+                left -= move + *novref;
 /*                 THE MOVE OF MOVE VALUES REALLY REPRESENTS A MOVE OF */
 /*                 MOVE + NOVREF VALUES. */
 /* L290: */
-	    }
+            }
 
-	    if (left != -(*novref)) {
+            if (left != -(*novref)) {
 /* ***               WRITE(KFILDO,292)L,LXN,MOVE,LXNKP,IBXX2(JJ),LEFT,NOV(L), */
 /* ***     1                          MOVMIN */
 /* *** 292           FORMAT(' AT 292 IN REDUCE--L,LXN,MOVE,LXNKP,', */
 /* ***     1                'IBXX2(JJ),LEFT,NOV(L),MOVMIN'/8I12) */
-	    }
+            }
 
 /* L300: */
-	}
+        }
 
-	*lx = lxnkp;
+        *lx = lxnkp;
 /*           LX IS NOW THE NEW NUMBER OF GROUPS. */
-	*kbit = jj;
+        *kbit = jj;
 /*           KBIT IS NOW THE NEW NUMBER OF BITS REQUIRED FOR PACKING */
 /*           GROUP LENGHTS. */
     }
@@ -409,4 +409,3 @@ L410:
     if ( newboxp != 0 ) free(newboxp);
     return 0;
 } /* reduce_ */
-

--- a/src/seekgb.c
+++ b/src/seekgb.c
@@ -10,7 +10,7 @@
 //   PRGMMR: Gilbert          ORG: W/NP11      DATE: 2002-10-28
 //
 // ABSTRACT: This subprogram searches a file for the next GRIB Message.
-//   The search is done starting at byte offset iseek of the file referenced 
+//   The search is done starting at byte offset iseek of the file referenced
 //   by lugb for mseek bytes at a time.
 //   If found, the starting position and length of the message are returned
 //   in lskip and lgrib, respectively.
@@ -37,21 +37,21 @@
 //$$$
 void seekgb(FILE *lugb,g2int iseek,g2int mseek,g2int *lskip,g2int *lgrib)
 {
-      g2int  ret;
-      g2int k,k4,ipos,nread,lim,start,vers,lengrib;
-      int    end;
-      unsigned char *cbuf;
+    g2int  ret;
+    g2int k,k4,ipos,nread,lim,start,vers,lengrib;
+    int    end;
+    unsigned char *cbuf;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-      *lgrib=0;
-      cbuf=(unsigned char *)malloc(mseek);
-      nread=mseek;
-      ipos=iseek;
+    *lgrib=0;
+    cbuf=(unsigned char *)malloc(mseek);
+    nread=mseek;
+    ipos=iseek;
 
 // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 //  LOOP UNTIL GRIB MESSAGE IS FOUND
 
-      while (*lgrib==0 && nread==mseek) {
+    while (*lgrib==0 && nread==mseek) {
 
 //  READ PARTIAL SECTION
 
@@ -62,24 +62,24 @@ void seekgb(FILE *lugb,g2int iseek,g2int mseek,g2int *lskip,g2int *lgrib)
 //  LOOK FOR 'GRIB...' IN PARTIAL SECTION
 
         for (k=0;k<lim;k++) {
-          gbit(cbuf,&start,(k+0)*8,4*8);
-          gbit(cbuf,&vers,(k+7)*8,1*8);
-          if (start==1196575042 && (vers==1 || vers==2)) {
+            gbit(cbuf,&start,(k+0)*8,4*8);
+            gbit(cbuf,&vers,(k+7)*8,1*8);
+            if (start==1196575042 && (vers==1 || vers==2)) {
 //  LOOK FOR '7777' AT END OF GRIB MESSAGE
-            if (vers == 1) gbit(cbuf,&lengrib,(k+4)*8,3*8);
-            if (vers == 2) gbit(cbuf,&lengrib,(k+12)*8,4*8);
-            ret=fseek(lugb,ipos+k+lengrib-4,SEEK_SET);
+                if (vers == 1) gbit(cbuf,&lengrib,(k+4)*8,3*8);
+                if (vers == 2) gbit(cbuf,&lengrib,(k+12)*8,4*8);
+                ret=fseek(lugb,ipos+k+lengrib-4,SEEK_SET);
 //          Hard code to 4 instead of sizeof(g2int)
-            k4=fread(&end,4,1,lugb);
-            if (k4 == 1 && end == 926365495) {      //GRIB message found
-                *lskip=ipos+k;
-                *lgrib=lengrib;
-                break;
+                k4=fread(&end,4,1,lugb);
+                if (k4 == 1 && end == 926365495) {      //GRIB message found
+                    *lskip=ipos+k;
+                    *lgrib=lengrib;
+                    break;
+                }
             }
-          }
         }
         ipos=ipos+lim;
-      }
+    }
 
-      free(cbuf);
+    free(cbuf);
 }

--- a/src/simpack.c
+++ b/src/simpack.c
@@ -30,21 +30,21 @@
 //                [3] = Number of bits used to pack data, if value is
 //                      > 0 and  <= 31.
 //                      If this input value is 0 or outside above range
-//                      then the num of bits is calculated based on given 
+//                      then the num of bits is calculated based on given
 //                      data and scale factors.
 //                [4] = Original field type - currently ignored on input
 //                      Data values assumed to be reals.
 //
-//   OUTPUT ARGUMENT LIST: 
+//   OUTPUT ARGUMENT LIST:
 //     idrstmpl - Contains the array of values for Data Representation
 //                Template 5.0
 //                [0] = Reference value - set by simpack routine.
 //                [1] = Binary Scale Factor - unchanged from input
 //                [2] = Decimal Scale Factor - unchanged from input
-//                [3] = Number of bits used to pack data, unchanged from 
+//                [3] = Number of bits used to pack data, unchanged from
 //                      input if value is between 0 and 31.
 //                      If this input value is 0 or outside above range
-//                      then the num of bits is calculated based on given 
+//                      then the num of bits is calculated based on given
 //                      data and scale factors.
 //                [4] = Original field type - currently set = 0 on output.
 //                      Data values assumed to be reals.
@@ -55,102 +55,102 @@
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$
 void simpack(g2float *fld,g2int ndpts,g2int *idrstmpl,unsigned char *cpack,g2int *lcpack)
 {
 
-      static g2int zero=0;
-      g2int  *ifld;
-      g2int  j,nbits,imin,imax,maxdif,nbittot,left;
-      g2float  bscale,dscale,rmax,rmin,temp;
-      double maxnum;
-      static g2float alog2=0.69314718;       //  ln(2.0)
-      
-      bscale=int_power(2.0,-idrstmpl[1]);
-      dscale=int_power(10.0,idrstmpl[2]);
-      if (idrstmpl[3] <= 0 || idrstmpl[3] > 31)
-         nbits=0;
-      else
-         nbits=idrstmpl[3];
+    static g2int zero=0;
+    g2int  *ifld;
+    g2int  j,nbits,imin,imax,maxdif,nbittot,left;
+    g2float  bscale,dscale,rmax,rmin,temp;
+    double maxnum;
+    static g2float alog2=0.69314718;       //  ln(2.0)
+
+    bscale=int_power(2.0,-idrstmpl[1]);
+    dscale=int_power(10.0,idrstmpl[2]);
+    if (idrstmpl[3] <= 0 || idrstmpl[3] > 31)
+        nbits=0;
+    else
+        nbits=idrstmpl[3];
 //
 //  Find max and min values in the data
 //
-      rmax=fld[0];
-      rmin=fld[0];
-      for (j=1;j<ndpts;j++) {
+    rmax=fld[0];
+    rmin=fld[0];
+    for (j=1;j<ndpts;j++) {
         if (fld[j] > rmax) rmax=fld[j];
         if (fld[j] < rmin) rmin=fld[j];
-      }
-     
-      ifld=calloc(ndpts,sizeof(g2int));
+    }
+
+    ifld=calloc(ndpts,sizeof(g2int));
 //
 //  If max and min values are not equal, pack up field.
 //  If they are equal, we have a constant field, and the reference
 //  value (rmin) is the value for each point in the field and
 //  set nbits to 0.
 //
-      if (rmin != rmax) {
+    if (rmin != rmax) {
         //
-        //  Determine which algorithm to use based on user-supplied 
+        //  Determine which algorithm to use based on user-supplied
         //  binary scale factor and number of bits.
         //
         if (nbits==0 && idrstmpl[1]==0) {
-           //
-           //  No binary scaling and calculate minumum number of 
-           //  bits in which the data will fit.
-           //
-           imin=(g2int)rint(rmin*dscale);
-           imax=(g2int)rint(rmax*dscale);
-           maxdif=imax-imin;
-           temp=log((double)(maxdif+1))/alog2;
-           nbits=(g2int)ceil(temp);
-           rmin=(g2float)imin;
-           //   scale data
-           for(j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
+            //
+            //  No binary scaling and calculate minumum number of
+            //  bits in which the data will fit.
+            //
+            imin=(g2int)rint(rmin*dscale);
+            imax=(g2int)rint(rmax*dscale);
+            maxdif=imax-imin;
+            temp=log((double)(maxdif+1))/alog2;
+            nbits=(g2int)ceil(temp);
+            rmin=(g2float)imin;
+            //   scale data
+            for(j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(fld[j]*dscale)-imin;
         }
         else if (nbits!=0 && idrstmpl[1]==0) {
-           //
-           //  Use minimum number of bits specified by user and
-           //  adjust binary scaling factor to accomodate data.
-           //
-           rmin=rmin*dscale;
-           rmax=rmax*dscale;
-           maxnum=int_power(2.0,nbits)-1;
-           temp=log(maxnum/(rmax-rmin))/alog2;
-           idrstmpl[1]=(g2int)ceil(-1.0*temp);
-           bscale=int_power(2.0,-idrstmpl[1]);
-           //   scale data
-           for (j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
+            //
+            //  Use minimum number of bits specified by user and
+            //  adjust binary scaling factor to accomodate data.
+            //
+            rmin=rmin*dscale;
+            rmax=rmax*dscale;
+            maxnum=int_power(2.0,nbits)-1;
+            temp=log(maxnum/(rmax-rmin))/alog2;
+            idrstmpl[1]=(g2int)ceil(-1.0*temp);
+            bscale=int_power(2.0,-idrstmpl[1]);
+            //   scale data
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
         }
         else if (nbits==0 && idrstmpl[1]!=0) {
-           //
-           //  Use binary scaling factor and calculate minumum number of 
-           //  bits in which the data will fit.
-           //
-           rmin=rmin*dscale;
-           rmax=rmax*dscale;
-           maxdif=(g2int)rint((rmax-rmin)*bscale);
-           temp=log((double)(maxdif+1))/alog2;
-           nbits=(g2int)ceil(temp);
-           //   scale data
-           for (j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
+            //
+            //  Use binary scaling factor and calculate minumum number of
+            //  bits in which the data will fit.
+            //
+            rmin=rmin*dscale;
+            rmax=rmax*dscale;
+            maxdif=(g2int)rint((rmax-rmin)*bscale);
+            temp=log((double)(maxdif+1))/alog2;
+            nbits=(g2int)ceil(temp);
+            //   scale data
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
         }
         else if (nbits!=0 && idrstmpl[1]!=0) {
-           //
-           //  Use binary scaling factor and use minumum number of 
-           //  bits specified by user.   Dangerous - may loose
-           //  information if binary scale factor and nbits not set
-           //  properly by user.
-           //
-           rmin=rmin*dscale;
-           //   scale data
-           for (j=0;j<ndpts;j++)
-             ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
+            //
+            //  Use binary scaling factor and use minumum number of
+            //  bits specified by user.   Dangerous - may loose
+            //  information if binary scale factor and nbits not set
+            //  properly by user.
+            //
+            rmin=rmin*dscale;
+            //   scale data
+            for (j=0;j<ndpts;j++)
+                ifld[j]=(g2int)rint(((fld[j]*dscale)-rmin)*bscale);
         }
         //
         //  Pack data, Pad last octet with Zeros, if necessary,
@@ -160,24 +160,24 @@ void simpack(g2float *fld,g2int ndpts,g2int *idrstmpl,unsigned char *cpack,g2int
         nbittot=nbits*ndpts;
         left=8-(nbittot%8);
         if (left != 8) {
-          sbit(cpack,&zero,nbittot,left);   // Pad with zeros to fill Octet
-          nbittot=nbittot+left;
+            sbit(cpack,&zero,nbittot,left);   // Pad with zeros to fill Octet
+            nbittot=nbittot+left;
         }
         *lcpack=nbittot/8;
-      }
-      else {
+    }
+    else {
         nbits=0;
         *lcpack=0;
-      }
+    }
 
 //
 //  Fill in ref value and number of bits in Template 5.0
 //
-      //printf("SAGmkieee %f\n",rmin);
-      mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
-      //printf("SAGmkieee %ld\n",idrstmpl[0]);
-      idrstmpl[3]=nbits;
-      idrstmpl[4]=0;         // original data were reals
+    //printf("SAGmkieee %f\n",rmin);
+    mkieee(&rmin,idrstmpl+0,1);   // ensure reference value is IEEE format
+    //printf("SAGmkieee %ld\n",idrstmpl[0]);
+    idrstmpl[3]=nbits;
+    idrstmpl[4]=0;         // original data were reals
 
-      free(ifld);
+    free(ifld);
 }

--- a/src/simunpack.c
+++ b/src/simunpack.c
@@ -10,7 +10,7 @@
 // SUBPROGRAM:    simunpack
 //   PRGMMR: Gilbert          ORG: W/NP11    DATE: 2002-10-29
 //
-// ABSTRACT: This subroutine unpacks a data field that was packed using a 
+// ABSTRACT: This subroutine unpacks a data field that was packed using a
 //   simple packing algorithm as defined in the GRIB2 documention,
 //   using info from the GRIB2 Data Representation Template 5.0.
 //
@@ -34,45 +34,45 @@
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$//
 g2int simunpack(unsigned char *cpack,g2int *idrstmpl,g2int ndpts,g2float *fld)
 {
 
-      g2int  *ifld;
-      g2int  j,nbits,itype;
-      g2float ref,bscale,dscale;
+    g2int  *ifld;
+    g2int  j,nbits,itype;
+    g2float ref,bscale,dscale;
 
-      
-      rdieee(idrstmpl+0,&ref,1);
-      bscale = int_power(2.0,idrstmpl[1]);
-      dscale = int_power(10.0,-idrstmpl[2]);
-      nbits = idrstmpl[3];
-      itype = idrstmpl[4];
 
-      ifld=(g2int *)calloc(ndpts,sizeof(g2int));
-      if ( ifld == 0 ) {
-         fprintf(stderr,"Could not allocate space in simunpack.\n  Data field NOT upacked.\n");
-         return(1);
-      }
-      
+    rdieee(idrstmpl+0,&ref,1);
+    bscale = int_power(2.0,idrstmpl[1]);
+    dscale = int_power(10.0,-idrstmpl[2]);
+    nbits = idrstmpl[3];
+    itype = idrstmpl[4];
+
+    ifld=(g2int *)calloc(ndpts,sizeof(g2int));
+    if ( ifld == 0 ) {
+        fprintf(stderr,"Could not allocate space in simunpack.\n  Data field NOT upacked.\n");
+        return(1);
+    }
+
 //
 //  if nbits equals 0, we have a constant field where the reference value
 //  is the data value at each gridpoint
 //
-      if (nbits != 0) {
-         gbits(cpack,ifld,0,nbits,0,ndpts);
-         for (j=0;j<ndpts;j++) {
-           fld[j]=(((g2float)ifld[j]*bscale)+ref)*dscale;
-         }
-      }
-      else {
-         for (j=0;j<ndpts;j++) {
-           fld[j]=ref;
-         }
-      }
+    if (nbits != 0) {
+        gbits(cpack,ifld,0,nbits,0,ndpts);
+        for (j=0;j<ndpts;j++) {
+            fld[j]=(((g2float)ifld[j]*bscale)+ref)*dscale;
+        }
+    }
+    else {
+        for (j=0;j<ndpts;j++) {
+            fld[j]=ref;
+        }
+    }
 
-      free(ifld);
-      return(0);
+    free(ifld);
+    return(0);
 }

--- a/src/specpack.c
+++ b/src/specpack.c
@@ -12,7 +12,7 @@
 //   PRGMMR: Gilbert          ORG: W/NP11    DATE: 2002-12-19
 //
 // ABSTRACT: This subroutine packs a spectral data field using the complex
-//   packing algorithm for spherical harmonic data as 
+//   packing algorithm for spherical harmonic data as
 //   defined in the GRIB2 Data Representation Template 5.51.
 //
 // PROGRAM HISTORY LOG:
@@ -44,87 +44,87 @@ void specpack(g2float *fld,g2int ndpts,g2int JJ,g2int KK,g2int MM,
               g2int *idrstmpl,unsigned char *cpack,g2int *lcpack)
 {
 
-      g2int    *ifld,tmplsim[5];
-      g2float  bscale,dscale,*unpk,*tfld;
-      g2float  *pscale,tscale;
-      g2int    Js,Ks,Ms,Ts,Ns,inc,incu,incp,n,Nm,m,ipos;
+    g2int    *ifld,tmplsim[5];
+    g2float  bscale,dscale,*unpk,*tfld;
+    g2float  *pscale,tscale;
+    g2int    Js,Ks,Ms,Ts,Ns,inc,incu,incp,n,Nm,m,ipos;
 
-      bscale = int_power(2.0,-idrstmpl[1]);
-      dscale = int_power(10.0,idrstmpl[2]);
-      Js=idrstmpl[5];
-      Ks=idrstmpl[6];
-      Ms=idrstmpl[7];
-      Ts=idrstmpl[8];
+    bscale = int_power(2.0,-idrstmpl[1]);
+    dscale = int_power(10.0,idrstmpl[2]);
+    Js=idrstmpl[5];
+    Ks=idrstmpl[6];
+    Ms=idrstmpl[7];
+    Ts=idrstmpl[8];
 
 //
 //   Calculate Laplacian scaling factors for each possible wave number.
 //
-      pscale=(g2float *)malloc((JJ+MM)*sizeof(g2float));
-      tscale=(g2float)idrstmpl[4]*1E-6;
-      for (n=Js;n<=JJ+MM;n++)
-           pscale[n]=pow((g2float)(n*(n+1)),tscale);
+    pscale=(g2float *)malloc((JJ+MM)*sizeof(g2float));
+    tscale=(g2float)idrstmpl[4]*1E-6;
+    for (n=Js;n<=JJ+MM;n++)
+        pscale[n]=pow((g2float)(n*(n+1)),tscale);
 //
 //   Separate spectral coeffs into two lists; one to contain unpacked
-//   values within the sub-spectrum Js, Ks, Ms, and the other with values 
+//   values within the sub-spectrum Js, Ks, Ms, and the other with values
 //   outside of the sub-spectrum to be packed.
 //
-      tfld=(g2float *)malloc(ndpts*sizeof(g2float));
-      unpk=(g2float *)malloc(ndpts*sizeof(g2float));
-      ifld=(g2int *)malloc(ndpts*sizeof(g2int));
-      inc=0;
-      incu=0;
-      incp=0;
-      for (m=0;m<=MM;m++) {
-         Nm=JJ;      // triangular or trapezoidal
-         if ( KK == JJ+MM ) Nm=JJ+m;          // rhombodial
-         Ns=Js;      // triangular or trapezoidal
-         if ( Ks == Js+Ms ) Ns=Js+m;          // rhombodial
-         for (n=m;n<=Nm;n++) {
+    tfld=(g2float *)malloc(ndpts*sizeof(g2float));
+    unpk=(g2float *)malloc(ndpts*sizeof(g2float));
+    ifld=(g2int *)malloc(ndpts*sizeof(g2int));
+    inc=0;
+    incu=0;
+    incp=0;
+    for (m=0;m<=MM;m++) {
+        Nm=JJ;      // triangular or trapezoidal
+        if ( KK == JJ+MM ) Nm=JJ+m;          // rhombodial
+        Ns=Js;      // triangular or trapezoidal
+        if ( Ks == Js+Ms ) Ns=Js+m;          // rhombodial
+        for (n=m;n<=Nm;n++) {
             if (n<=Ns && m<=Ms) {       // save unpacked value
-               unpk[incu++]=fld[inc++];         // real part
-               unpk[incu++]=fld[inc++];     // imaginary part
+                unpk[incu++]=fld[inc++];         // real part
+                unpk[incu++]=fld[inc++];     // imaginary part
             }
             else {                       // Save value to be packed and scale
                                          // Laplacian scale factor
-               tfld[incp++]=fld[inc++]*pscale[n];      // real part
-               tfld[incp++]=fld[inc++]*pscale[n];      // imaginary part
+                tfld[incp++]=fld[inc++]*pscale[n];      // real part
+                tfld[incp++]=fld[inc++]*pscale[n];      // imaginary part
             }
-         }
-      }
+        }
+    }
 
-      free(pscale);
+    free(pscale);
 
-      if (incu != Ts) {
-         printf("specpack: Incorrect number of unpacked values %d given:\n",(int)Ts);
-         printf("specpack: Resetting idrstmpl[8] to %d\n",(int)incu);
-         Ts=incu;
-      }
+    if (incu != Ts) {
+        printf("specpack: Incorrect number of unpacked values %d given:\n",(int)Ts);
+        printf("specpack: Resetting idrstmpl[8] to %d\n",(int)incu);
+        Ts=incu;
+    }
 //
 //  Add unpacked values to the packed data array in 32-bit IEEE format
 //
-      mkieee(unpk,(g2int *)cpack,Ts);
-      ipos=4*Ts;
+    mkieee(unpk,(g2int *)cpack,Ts);
+    ipos=4*Ts;
 //
 //  Scale and pack the rest of the coefficients
-// 
-      tmplsim[1]=idrstmpl[1];
-      tmplsim[2]=idrstmpl[2];
-      tmplsim[3]=idrstmpl[3];
-      simpack(tfld,ndpts-Ts,tmplsim,cpack+ipos,lcpack);
-      *lcpack=(*lcpack)+ipos;
+//
+    tmplsim[1]=idrstmpl[1];
+    tmplsim[2]=idrstmpl[2];
+    tmplsim[3]=idrstmpl[3];
+    simpack(tfld,ndpts-Ts,tmplsim,cpack+ipos,lcpack);
+    *lcpack=(*lcpack)+ipos;
 //
 //  Fill in Template 5.51
 //
-      idrstmpl[0]=tmplsim[0];
-      idrstmpl[1]=tmplsim[1];
-      idrstmpl[2]=tmplsim[2];
-      idrstmpl[3]=tmplsim[3];
-      idrstmpl[8]=Ts;
-      idrstmpl[9]=1;         // Unpacked spectral data is 32-bit IEEE
+    idrstmpl[0]=tmplsim[0];
+    idrstmpl[1]=tmplsim[1];
+    idrstmpl[2]=tmplsim[2];
+    idrstmpl[3]=tmplsim[3];
+    idrstmpl[8]=Ts;
+    idrstmpl[9]=1;         // Unpacked spectral data is 32-bit IEEE
 
-      free(tfld);
-      free(unpk);
-      free(ifld);
+    free(tfld);
+    free(unpk);
+    free(ifld);
 
-      return;
+    return;
 }

--- a/src/specunpack.c
+++ b/src/specunpack.c
@@ -11,8 +11,8 @@
 // SUBPROGRAM:    specunpack
 //   PRGMMR: Gilbert          ORG: W/NP11    DATE: 2000-06-21
 //
-// ABSTRACT: This subroutine unpacks a spectral data field that was packed 
-//   using the complex packing algorithm for spherical harmonic data as 
+// ABSTRACT: This subroutine unpacks a spectral data field that was packed
+//   using the complex packing algorithm for spherical harmonic data as
 //   defined in the GRIB2 documention,
 //   using info from the GRIB2 Data Representation Template 5.51.
 //
@@ -39,79 +39,79 @@
 //
 // ATTRIBUTES:
 //   LANGUAGE: C
-//   MACHINE:  
+//   MACHINE:
 //
 //$$$
 g2int specunpack(unsigned char *cpack,g2int *idrstmpl,g2int ndpts,g2int JJ,
-               g2int KK, g2int MM, g2float *fld)
+                 g2int KK, g2int MM, g2float *fld)
 {
 
-      g2int  *ifld,j,iofst,nbits;
-      g2float  ref,bscale,dscale,*unpk;
-      g2float  *pscale,tscale;
-      g2int   Js,Ks,Ms,Ts,Ns,Nm,n,m;
-      g2int   inc,incu,incp;
+    g2int  *ifld,j,iofst,nbits;
+    g2float  ref,bscale,dscale,*unpk;
+    g2float  *pscale,tscale;
+    g2int   Js,Ks,Ms,Ts,Ns,Nm,n,m;
+    g2int   inc,incu,incp;
 
-      rdieee(idrstmpl+0,&ref,1);
-      bscale = int_power(2.0,idrstmpl[1]);
-      dscale = int_power(10.0,-idrstmpl[2]);
-      nbits = idrstmpl[3];
-      Js=idrstmpl[5];
-      Ks=idrstmpl[6];
-      Ms=idrstmpl[7];
-      Ts=idrstmpl[8];
+    rdieee(idrstmpl+0,&ref,1);
+    bscale = int_power(2.0,idrstmpl[1]);
+    dscale = int_power(10.0,-idrstmpl[2]);
+    nbits = idrstmpl[3];
+    Js=idrstmpl[5];
+    Ks=idrstmpl[6];
+    Ms=idrstmpl[7];
+    Ts=idrstmpl[8];
 
-      if (idrstmpl[9] == 1) {           // unpacked floats are 32-bit IEEE
+    if (idrstmpl[9] == 1) {           // unpacked floats are 32-bit IEEE
 
-         unpk=(g2float *)malloc(ndpts*sizeof(g2float));
-         ifld=(g2int *)malloc(ndpts*sizeof(g2int));
+        unpk=(g2float *)malloc(ndpts*sizeof(g2float));
+        ifld=(g2int *)malloc(ndpts*sizeof(g2int));
 
-         gbits(cpack,ifld,0,32,0,Ts);
-         iofst=32*Ts;
-         rdieee(ifld,unpk,Ts);          // read IEEE unpacked floats
-         gbits(cpack,ifld,iofst,nbits,0,ndpts-Ts);  // unpack scaled data
+        gbits(cpack,ifld,0,32,0,Ts);
+        iofst=32*Ts;
+        rdieee(ifld,unpk,Ts);          // read IEEE unpacked floats
+        gbits(cpack,ifld,iofst,nbits,0,ndpts-Ts);  // unpack scaled data
 //
 //   Calculate Laplacian scaling factors for each possible wave number.
 //
-         pscale=(g2float *)malloc((JJ+MM+1)*sizeof(g2float));
-         tscale=(g2float)idrstmpl[4]*1E-6;
-         for (n=Js;n<=JJ+MM;n++) 
-              pscale[n]=pow((g2float)(n*(n+1)),-tscale);
+        pscale=(g2float *)malloc((JJ+MM+1)*sizeof(g2float));
+        tscale=(g2float)idrstmpl[4]*1E-6;
+        for (n=Js;n<=JJ+MM;n++)
+            pscale[n]=pow((g2float)(n*(n+1)),-tscale);
 //
 //   Assemble spectral coeffs back to original order.
 //
-         inc=0;
-         incu=0;
-         incp=0;
-         for (m=0;m<=MM;m++) {
+        inc=0;
+        incu=0;
+        incp=0;
+        for (m=0;m<=MM;m++) {
             Nm=JJ;      // triangular or trapezoidal
             if ( KK == JJ+MM ) Nm=JJ+m;          // rhombodial
             Ns=Js;      // triangular or trapezoidal
             if ( Ks == Js+Ms ) Ns=Js+m;          // rhombodial
             for (n=m;n<=Nm;n++) {
-               if (n<=Ns && m<=Ms) {    // grab unpacked value
-                  fld[inc++]=unpk[incu++];         // real part
-                  fld[inc++]=unpk[incu++];     // imaginary part
-               }
-               else {                       // Calc coeff from packed value
-                  fld[inc++]=(((g2float)ifld[incp++]*bscale)+ref)*
-                            dscale*pscale[n];          // real part
-                  fld[inc++]=(((g2float)ifld[incp++]*bscale)+ref)*
-                            dscale*pscale[n];          // imaginary part
-               }
+                if (n<=Ns && m<=Ms) {    // grab unpacked value
+                    fld[inc++]=unpk[incu++];         // real part
+                    fld[inc++]=unpk[incu++];     // imaginary part
+                }
+                else {                       // Calc coeff from packed value
+                    fld[inc++]=(((g2float)ifld[incp++]*bscale)+ref)*
+                        dscale*pscale[n];          // real part
+                    fld[inc++]=(((g2float)ifld[incp++]*bscale)+ref)*
+                        dscale*pscale[n];          // imaginary part
+                }
             }
-         }
+        }
 
-         free(pscale);
-         free(unpk);
-         free(ifld);
+        free(pscale);
+        free(unpk);
+        free(ifld);
 
-      }
-      else {
-         printf("specunpack: Cannot handle 64 or 128-bit floats.\n");
-         for (j=0;j<ndpts;j++) fld[j]=0.0;
-         return -3;
-      }
+    }
+    else {
+        printf("specunpack: Cannot handle 64 or 128-bit floats.\n");
+        for (j=0;j<ndpts;j++) fld[j]=0.0;
+        return -3;
+    }
 
-      return 0;
+    return 0;
 }


### PR DESCRIPTION
Fixes #58 

This PR contains only whitespace cleanup, done automatically by emacs, with no code changes.

This includes the commands:
indent-region
untabify
delete-trailing-whitespace

The goal here is to get the whitespace cleaned up, so that doxygen changes can happen and be more easily reviewed, without containing a bunch of whitespace changes which make the real changes harder to see.