### PR TITLE
fixed some doxygen warnings in drstemplates.h, grib2.h, pdstemplates.h, gridtemplates.h

### DIFF
--- a/src/decenc_openjpeg.c
+++ b/src/decenc_openjpeg.c
@@ -1,4 +1,5 @@
-/** @file
+/** 
+ * @file
  * @brief JPEG functions, originally from ECMWF, modified for use in NCEPLIBS-g2c.
  *
  * Copyright 2005-2019 ECMWF.

--- a/src/drstemplates.h
+++ b/src/drstemplates.h
@@ -33,12 +33,15 @@
 #define MAXDRSTEMP 9              // maximum number of templates
 #define MAXDRSMAPLEN 200          // maximum template map length
 
+/**
+ * Stuct for GRIB2 Data Representation Section (DRS) template.
+ */
 struct drstemplate
 {
-    g2int template_num;
-    g2int mapdrslen;
-    g2int needext;
-    g2int mapdrs[MAXDRSMAPLEN];
+    g2int template_num; /*< The number of entries in the template. */
+    g2int mapdrslen; /*< Length of map of the template. */
+    g2int needext; /*< Whether the Template needs to be extended. */
+    g2int mapdrs[MAXDRSMAPLEN]; /*< A map of the template. */
 };
 
 const struct drstemplate templatesdrs[MAXDRSTEMP] = {

--- a/src/grib2.h
+++ b/src/grib2.h
@@ -163,24 +163,30 @@ typedef unsigned long g2intu;
 #endif
 typedef float g2float;
 
+/**
+ * Struct for GRIB template.
+ */
 struct gtemplate {
-    g2int type;           /* 3=Grid Defintion Template.                       */
-    /* 4=Product Defintion Template.                    */
-    /* 5=Data Representation Template.                  */
-    g2int num;            /* template number.                                 */
-    g2int maplen;         /* number of entries in the static part             */
-    /*                    of the template.              */
-    g2int *map;           /* num of octets of each entry in the               */
-    /*         static part of the template.             */
-    g2int needext;        /* indicates whether or not the template needs      */
-    /*     to be extended.                              */
-    g2int extlen;         /* number of entries in the template extension.     */
-    g2int *ext;           /* num of octets of each entry in the extension     */
-    /*                      part of the template.       */
+    g2int type; /*< 3=Grid Defintion Template. */
+    /*< 4=Product Defintion Template. */
+    /*< 5=Data Representation Template. */
+    g2int num;            /*< template number.                                 */
+    g2int maplen;         /*< number of entries in the static part             */
+    /*< of the template.              */
+    g2int *map;           /*< num of octets of each entry in the               */
+    /*< static part of the template.             */
+    g2int needext;        /*< indicates whether or not the template needs      */
+    /*< to be extended.                              */
+    g2int extlen; /*< number of entries in the template extension.     */
+    g2int *ext; /*< num of octets of each entry in the extension     */
+    /*< part of the template.       */
 };
 
 typedef struct gtemplate gtemplate;
 
+/**
+ * Struct for GRIB field.
+ */
 struct gribfield {
     g2int   version,discipline;
     g2int   *idsect;

--- a/src/gridtemplates.h
+++ b/src/gridtemplates.h
@@ -41,6 +41,9 @@
 #define MAXGRIDTEMP 31              // maximum number of templates
 #define MAXGRIDMAPLEN 200           // maximum template map length
 
+/**
+ * Struct for grid template.
+ */
 struct gridtemplate
 {
     g2int template_num;

--- a/src/pdstemplates.h
+++ b/src/pdstemplates.h
@@ -49,6 +49,9 @@
 #define MAXPDSTEMP 47           // maximum number of templates
 #define MAXPDSMAPLEN 200        // maximum template map length
 
+/**
+ * Struct for PDS template.
+ */
 struct pdstemplate
 {
     g2int template_num;


### PR DESCRIPTION
Part of #54

fixed some doxygen warnings in drstemplates.h, grib2.h, pdstemplates.h, gridtemplates.h