### PR TITLE
more doxygen warning fixes for enc_jpeg2000.c enc_png.c g2_create.c grib2.h gridtemplates.h jpcunpack.c pack_gp.c pngunpack.c reduce.c simunpack.c

### DIFF
--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -51,9 +51,10 @@ void dummy(void) {}
  *
  * @author Stephen Gilbert @date 2002-12-02
  */
-int enc_jpeg2000(unsigned char *cin,g2int width,g2int height,g2int nbits,
-                 g2int ltype, g2int ratio, g2int retry, char *outjpc,
-                 g2int jpclen)
+int
+enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
+	     g2int ltype, g2int ratio, g2int retry, char *outjpc,
+	     g2int jpclen)
 {
     int ier,rwcnt;
     jas_image_t image;

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -32,7 +32,8 @@ void user_flush_data(png_structp );
  *
  * @author Stephen Gilbert
 */
-void user_write_data(png_structp png_ptr,png_bytep data, png_uint_32 length)
+void
+user_write_data(png_structp png_ptr, png_bytep data, png_uint_32 length)
 {
     unsigned char *ptr;
     g2int offset;

--- a/src/g2_create.c
+++ b/src/g2_create.c
@@ -4,7 +4,7 @@
  */
 #include <stdio.h>
 #include "grib2.h"
-#define MAPSEC1LEN 13 /*< Length of Map Section 1. */
+#define MAPSEC1LEN 13 /**< Length of Map Section 1. */
 
 /**
  * This routine initializes a new GRIB2 message and packs GRIB2

--- a/src/grib2.h
+++ b/src/grib2.h
@@ -152,37 +152,37 @@
 #define _grib2_H
 #include <stdio.h>
 
-#define G2_VERSION "g2clib-1.6.2" /*< Current version of NCEPLIBS-g2c library. */
+#define G2_VERSION "g2clib-1.6.2" /**< Current version of NCEPLIBS-g2c library. */
 
 #ifdef __64BIT__
-typedef int g2int; /*< Integer type. */
-typedef unsigned int g2intu; /*< Unsigned integer type. */
+typedef int g2int; /**< Integer type. */
+typedef unsigned int g2intu; /**< Unsigned integer type. */
 #else
-typedef long g2int; /*< Long integer type. */
-typedef unsigned long g2intu; /*< Unsigned long integer type. */
+typedef long g2int; /**< Long integer type. */
+typedef unsigned long g2intu; /**< Unsigned long integer type. */
 #endif
-typedef float g2float; /*< Float type. */
+typedef float g2float; /**< Float type. */
 
 /**
  * Struct for GRIB template.
  */
 struct gtemplate {
-    g2int type; /*< 3=Grid Defintion Template. */
-    /*< 4=Product Defintion Template. */
-    /*< 5=Data Representation Template. */
-    g2int num;            /*< template number.                                 */
-    g2int maplen;         /*< number of entries in the static part             */
-    /*< of the template.              */
-    g2int *map;           /*< num of octets of each entry in the               */
-    /*< static part of the template.             */
-    g2int needext;        /*< indicates whether or not the template needs      */
-    /*< to be extended.                              */
-    g2int extlen; /*< number of entries in the template extension.     */
-    g2int *ext; /*< num of octets of each entry in the extension     */
-    /*< part of the template.       */
+    g2int type; /**< 3=Grid Defintion Template. */
+    /**< 4=Product Defintion Template. */
+    /**< 5=Data Representation Template. */
+    g2int num;            /**< template number.                                 */
+    g2int maplen;         /**< number of entries in the static part             */
+    /**< of the template.              */
+    g2int *map;           /**< num of octets of each entry in the               */
+    /**< static part of the template.             */
+    g2int needext;        /**< indicates whether or not the template needs      */
+    /**< to be extended.                              */
+    g2int extlen; /**< number of entries in the template extension.     */
+    g2int *ext; /**< num of octets of each entry in the extension     */
+    /**< part of the template.       */
 };
 
-typedef struct gtemplate gtemplate; /*< Struct for GRIB template. */
+typedef struct gtemplate gtemplate; /**< Struct for GRIB template. */
 
 /**
  * Struct for GRIB field.
@@ -212,7 +212,7 @@ struct gribfield {
     g2float *fld;
 };
 
-typedef struct gribfield gribfield; /*< Struct for GRIB field. */
+typedef struct gribfield gribfield; /**< Struct for GRIB field. */
 
 /*  Prototypes for unpacking sections API  */
 g2int g2_unpack1(unsigned char *,g2int *,g2int **,g2int *);

--- a/src/gridtemplates.h
+++ b/src/gridtemplates.h
@@ -38,8 +38,8 @@
 #define _gridtemplates_H
 #include "grib2.h"
 
-#define MAXGRIDTEMP 31              // maximum number of templates
-#define MAXGRIDMAPLEN 200           // maximum template map length
+#define MAXGRIDTEMP 31 /**< maximum number of templates */
+#define MAXGRIDMAPLEN 200 /**< maximum template map length */
 
 /**
  * Struct for grid template.
@@ -52,6 +52,9 @@ struct gridtemplate
     g2int mapgrid[MAXGRIDMAPLEN];
 };
 
+/**
+ * Templates grid. 
+ */
 const struct gridtemplate templatesgrid[MAXGRIDTEMP] = {
     // 3.0: Lat/Lon grid
     { 0, 19, 0, {1,1,4,1,4,1,4,4,4,4,4,-4,4,1,-4,4,4,4,1} },

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -21,10 +21,13 @@ int dec_jpeg2000(char *,g2int ,g2int *);
  * @param ndpts The number of data values to unpack.
  * @param fld Contains the unpacked data values.
  *
+ * @return 0 for success, 1 for memory allocation error.
+ *
  * @author Stephem Gilbert @date 2003-08-27
  */
-g2int jpcunpack(unsigned char *cpack,g2int len,g2int *idrstmpl,g2int ndpts,
-                g2float *fld)
+g2int
+jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+	  g2float *fld)
 {
 
     g2int  *ifld;

--- a/src/pack_gp.c
+++ b/src/pack_gp.c
@@ -5,10 +5,10 @@
 /*#include "f2c.h"*/
 #include <stdlib.h>
 #include "grib2.h"
-typedef g2int integer;
-typedef g2int logical;
-#define TRUE_ (1)
-#define FALSE_ (0)
+typedef g2int integer; /**< Integer type. */
+typedef g2int logical; /**< Logical type. */
+#define TRUE_ (1) /**< True. */
+#define FALSE_ (0) /**< False. */
 
 /**
  * Determines groups of variable size, but at least of size minpk, the
@@ -154,14 +154,17 @@ typedef g2int logical;
  * j=1,lx. (output)
  * @param novref reference value for nov( ). (output) 
  * @param lbitref reference value for lbit( ). (output) 
+ * @param ier Error code
+ * - 0 No error.
+ * - 706 value will not pack in 30 bits--fatal 
+ * - 714 error in reduce--non-fatal 
+ * - 715 ngp not large enough in reduce--non-fatal 
+ * - 716 minpk inceased--non-fatal 
+ * - 717 inc set 
+ * - 1--non-fatal 
+ * * alternate return when ier ne 0 and fatal error. 
  *
- * @return
- * - 706 = value will not pack in 30 bits--fatal 
- * - 714 = error in reduce--non-fatal 
- * - 715 = ngp not large enough in reduce--non-fatal 
- * - 716 = minpk inceased--non-fatal 
- * - 717 = inc set = 1--non-fatal 
- * * = alternate return when ier ne 0 and fatal error. 
+ * @return 0 - check ier for error code.
  *
  *        INTERNAL VARIABLES 
  * <pre>
@@ -249,11 +252,12 @@ typedef g2int logical;
  *                       pack jmin( ). 
  * </pre>
 */
-int pack_gp(integer *kfildo, integer *ic, integer *nxy,
-	    integer *is523, integer *minpk, integer *inc, integer *missp, integer
-	    *misss, integer *jmin, integer *jmax, integer *lbit, integer *nov,
-	    integer *ndg, integer *lx, integer *ibit, integer *jbit, integer *
-	    kbit, integer *novref, integer *lbitref, integer *ier)
+int
+pack_gp(integer *kfildo, integer *ic, integer *nxy,
+	integer *is523, integer *minpk, integer *inc, integer *missp, integer
+	*misss, integer *jmin, integer *jmax, integer *lbit, integer *nov,
+	integer *ndg, integer *lx, integer *ibit, integer *jbit, integer *
+	kbit, integer *novref, integer *lbitref, integer *ier)
 {
     /* Initialized data */
 

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -19,12 +19,14 @@ int dec_png(unsigned char *,g2int *,g2int *,char *);
  * @param ndpts The number of data values to unpack.
  * @param fld Contains the unpacked data values.
  *
+ * @return 0 for success, 1 for memory allocation error.
+ *
  * @author Stephen Gilbert @date 2003-08-27
  */
-g2int pngunpack(unsigned char *cpack,g2int len,g2int *idrstmpl,g2int ndpts,
-                g2float *fld)
+g2int
+pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+	  g2float *fld)
 {
-
     g2int  *ifld;
     g2int  j,nbits,iret,width,height;
     g2float  ref,bscale,dscale;

--- a/src/reduce.c
+++ b/src/reduce.c
@@ -8,8 +8,8 @@
 /*#include "f2c.h"*/
 #include <stdlib.h>
 #include "grib2.h"
-typedef g2int integer; /*< Integer type. */
-typedef g2float real; /*< Float type. */
+typedef g2int integer; /**< Integer type. */
+typedef g2float real; /**< Float type. */
 
 /**
  * Determines whether the number of groups should be increased in

--- a/src/reduce.c
+++ b/src/reduce.c
@@ -57,6 +57,8 @@ typedef g2float real; /**< Float type. */
  * - 714 = problem in algorithm. reduce aborted. 
  * - 715 = ngp not large enough. reduce aborted. 
  *
+ * @return always returns 0, see parameter ier for error code.
+ *
  * <pre>
  * ntotbt(j) = the total bits used for the packing bits j 
  *                       (j=1,30). (internal) 

--- a/src/simunpack.c
+++ b/src/simunpack.c
@@ -18,11 +18,13 @@
  * allocated with at least ndpts*sizeof(g2float) bytes before calling
  * this routine.
  *
+ * @return 0 for success, error code otherwise.
+ *
  * @author Stephen Gilbert @date 2002-10-29
  */
-g2int simunpack(unsigned char *cpack,g2int *idrstmpl,g2int ndpts,g2float *fld)
+g2int
+simunpack(unsigned char *cpack, g2int *idrstmpl, g2int ndpts, g2float *fld)
 {
-
     g2int  *ifld;
     g2int  j,nbits,itype;
     g2float ref,bscale,dscale;


### PR DESCRIPTION
Part of #54

more doxygen warning fixes for enc_jpeg2000.c enc_png.c g2_create.c grib2.h gridtemplates.h jpcunpack.c pack_gp.c pngunpack.c reduce.c simunpack.c 

