### PR TITLE
Fix typedef to use portable integers

### DIFF
--- a/src/grib2.h
+++ b/src/grib2.h
@@ -154,8 +154,8 @@
 
 #define G2_VERSION "g2clib-1.6.4" /**< Current version of NCEPLIBS-g2c library. */
 
-typedef long g2int; /**< Long integer type. */
-typedef unsigned long g2intu; /**< Unsigned long integer type. */
+typedef int64_t g2int; /**< Long integer type. */
+typedef uint64_t g2intu; /**< Unsigned long integer type. */
 typedef float g2float; /**< Float type. */
 
 /**

--- a/src/grib2.h
+++ b/src/grib2.h
@@ -151,6 +151,7 @@
 #ifndef _grib2_H
 #define _grib2_H
 #include <stdio.h>
+#include <stdint.h>
 
 #define G2_VERSION "g2clib-1.6.4" /**< Current version of NCEPLIBS-g2c library. */
 


### PR DESCRIPTION
'long' and 'unsigned long' are not guaranteed to be 64 bit. Use portable types int64_t and unit64_t.

Fix #123