### PR TITLE
Run CI on Windows (clang and gcc)

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -49,7 +49,7 @@ jobs:
       run: |
         cd jasper
         mkdir cmake_build
-        cd build
+        cd cmake_build
         cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
         make -j2
         make install
@@ -66,7 +66,7 @@ jobs:
         cd build
         cmake -DJasper_ROOT=~/Jasper ..
         make -j2
-        
+
     - name: test
       run: |
         cd $GITHUB_WORKSPACE/g2c/build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -34,7 +34,7 @@ jobs:
       run: |
         cd jasper
         mkdir cmake_build
-        cd build
+        cd cmake_build
         cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
         make -j2
         make install
@@ -49,9 +49,9 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper -DENABLE_DOCS=On -DENABLE_OpenJPEG=ON -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0" .. 
+        cmake -DJasper_ROOT=~/Jasper -DENABLE_DOCS=On -DENABLE_OpenJPEG=ON -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0" ..
         make -j2
-        
+
     - name: test
       run: |
         cd $GITHUB_WORKSPACE/g2c/build

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         cd jasper
         mkdir cmake_build
-        cd build
+        cd cmake_build
         cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
         make -j2
         make install
@@ -50,7 +50,7 @@ jobs:
         cd build
         cmake -DJasper_ROOT=~/Jasper -DENABLE_DOCS=ON -DENABLE_OpenJPEG=ON ..
         make -j2
-        
+
     - name: test
       run: |
         cd $GITHUB_WORKSPACE/g2c/build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,49 @@
+name: Windows Build
+on: [push, pull_request]
+
+jobs:
+  windows-build:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        ccompiler: [clang, gcc]
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+    - name: install-dependencies
+      uses: msys2/setup-msys2@v2
+      with:
+        msystem: MINGW64
+        update: true
+        install: >-
+          mingw-w64-x86_64-gcc
+          mingw-w64-x86_64-clang
+          mingw-w64-x86_64-cmake
+          mingw-w64-x86_64-ninja
+          mingw-w64-x86_64-libpng
+          mingw-w64-x86_64-openjpeg2
+
+    - name: checkout
+      uses: actions/checkout@v2
+      with:
+        path: g2c
+
+    - name: build
+      run: |
+        if [[ ${{ matrix.ccompiler }} == "clang" ]]; then
+          export CC=clang
+        elif [[ ${{ matrix.ccompiler }} == "gcc" ]]; then
+          export CC=gcc
+        fi
+        cd g2c
+        mkdir build
+        cd build
+        cmake -DUSE_OpenJPEG=ON -DUSE_Jasper=OFF ..
+        cmake --build .
+
+    - name: test
+      run: |
+        cd g2c/build
+        ctest --output-on-failure

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -148,7 +148,7 @@ install(EXPORT ${PROJECT_NAME}Exports
 if(ENABLE_DOCS)
   find_package(Doxygen REQUIRED)
 endif()
-add_subdirectory(docs)  
+add_subdirectory(docs)
 
 # Run unit tests.
 include(CTest)


### PR DESCRIPTION
Add support to run CI on Windows using clang and gcc. Windows build uses OpenJPEG instead of Jasper.