### PR TITLE
now always use c99 in compiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ set(lib_name ${PROJECT_NAME})
 add_library(${lib_name} STATIC ${c_src})
 
 target_compile_definitions(${lib_name} PUBLIC)
+set_property(TARGET ${lib_name} PROPERTY C_STANDARD 99)
 
 set(private_includes "")
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,8 @@
+# This is the CMake file for the src directory of the NCEPLIBS-g2c
+# project.
+#
+# Mark Potts, Kyle Gerheiser
+
 set(c_src
     ${CMAKE_CURRENT_SOURCE_DIR}/cmplxpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compack.c


### PR DESCRIPTION
Fixes #129 

now always use c99 in compiles