### PR TITLE
setting grib2.h version in CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ endif()
 
 target_link_libraries(${lib_name} INTERFACE m)
 
-set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER "src/grib2.h")
+set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER "${CMAKE_BINARY_DIR}/src/grib2.h")
 
 target_include_directories(
   ${lib_name}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,8 @@ add_library(${lib_name} STATIC ${c_src})
 target_compile_definitions(${lib_name} PUBLIC)
 set_property(TARGET ${lib_name} PROPERTY C_STANDARD 99)
 
-set(private_includes "")
+set(private_includes "${CMAKE_BINARY_DIR}/src")
+
 
 if(PNG_FOUND)
   message(STATUS "Found PNG:")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,14 +70,9 @@ set(lib_name ${PROJECT_NAME})
 add_library(${lib_name} STATIC ${c_src})
 
 target_compile_definitions(${lib_name} PUBLIC)
-target_include_directories(${lib_name} PUBLIC
-    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
-    $<INSTALL_INTERFACE:include>)
-#  target_include_directories(${lib_name} PRIVATE ${CMAKE_BINARY_DIR}/src)
 set_property(TARGET ${lib_name} PROPERTY C_STANDARD 99)
 
 set(private_includes "")
-
 
 if(PNG_FOUND)
   message(STATUS "Found PNG:")
@@ -113,7 +108,7 @@ set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER "src/grib2.h")
 target_include_directories(
   ${lib_name}
   PRIVATE ${private_includes}
-  PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+  PUBLIC $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
          $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,10 @@ set(lib_name ${PROJECT_NAME})
 add_library(${lib_name} STATIC ${c_src})
 
 target_compile_definitions(${lib_name} PUBLIC)
-target_include_directories(${lib_name} PRIVATE ${CMAKE_BINARY_DIR}/src)
+target_include_directories(${lib_name} PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/src>
+    $<INSTALL_INTERFACE:include>)
+#  target_include_directories(${lib_name} PRIVATE ${CMAKE_BINARY_DIR}/src)
 set_property(TARGET ${lib_name} PROPERTY C_STANDARD 99)
 
 set(private_includes "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,9 +65,10 @@ set(lib_name ${PROJECT_NAME})
 add_library(${lib_name} STATIC ${c_src})
 
 target_compile_definitions(${lib_name} PUBLIC)
+target_include_directories(${lib_name} PRIVATE ${CMAKE_BINARY_DIR}/src)
 set_property(TARGET ${lib_name} PROPERTY C_STANDARD 99)
 
-set(private_includes "${CMAKE_BINARY_DIR}/src")
+set(private_includes "")
 
 
 if(PNG_FOUND)

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -6,6 +6,7 @@ if(ENABLE_DOCS)
 
   # Create doxyfile.
   set(abs_top_srcdir "${CMAKE_SOURCE_DIR}")
+  set(abs_top_builddir "${CMAKE_BINARY_DIR}")  
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
 
   # Build documentation with target all.

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -820,7 +820,8 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  = @abs_top_srcdir@/docs/user_guide.md \
-                         @abs_top_srcdir@/src
+                         @abs_top_srcdir@/src \
+                         @abs_top_builddir@/src                          
 
 # This tag can be used to specify the character encoding of the source files
 # that doxygen parses. Internally doxygen uses the UTF-8 encoding. Doxygen uses

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -3,6 +3,11 @@
 #
 # Mark Potts, Kyle Gerheiser
 
+# Create this header file, which has the contents of the VERSION file
+# substituted in.
+CONFIGURE_FILE("${CMAKE_SOURCE_DIR}/src/grib2.h.in" "${CMAKE_BINARY_DIR}/src/grib2.h"
+  @ONLY)
+
 set(c_src
     ${CMAKE_CURRENT_SOURCE_DIR}/cmplxpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compack.c

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -54,4 +54,5 @@ set(c_src
     ${CMAKE_CURRENT_SOURCE_DIR}/simunpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/specpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/specunpack.c
+    ${CMAKE_CURRENT_BINARY_DIR}/grib2.h
     PARENT_SCOPE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,7 +14,6 @@ set(c_src
     ${CMAKE_CURRENT_SOURCE_DIR}/comunpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/dec_jpeg2000.c
     ${CMAKE_CURRENT_SOURCE_DIR}/dec_png.c
-    ${CMAKE_CURRENT_SOURCE_DIR}/decenc_openjpeg.c
     ${CMAKE_CURRENT_SOURCE_DIR}/drstemplates.c
     ${CMAKE_CURRENT_SOURCE_DIR}/enc_jpeg2000.c
     ${CMAKE_CURRENT_SOURCE_DIR}/enc_png.c
@@ -56,3 +55,9 @@ set(c_src
     ${CMAKE_CURRENT_SOURCE_DIR}/specunpack.c
     ${CMAKE_CURRENT_BINARY_DIR}/grib2.h
     PARENT_SCOPE)
+
+# If OpenJPEG is in use, add this file.  
+if(USE_OpenJPEG)
+  set(c_src ${c_src} ${CMAKE_CURRENT_SOURCE_DIR}/decenc_openjpeg.c PARENT_SCOPE)
+endif()
+  

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -153,7 +153,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#define G2_VERSION "g2clib-1.6.4" /**< Current version of NCEPLIBS-g2c library. */
+#define G2_VERSION "g2clib-@pVersion@" /**< Current version of NCEPLIBS-g2c library. */
 
 typedef int64_t g2int; /**< Long integer type. */
 typedef uint64_t g2intu; /**< Unsigned long integer type. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ function(g2c_test name)
   add_executable(${name} ${name}.c)
   add_dependencies(${name} g2c)
   target_link_libraries(${name} PRIVATE g2c)
+  target_include_directories(${name} PRIVATE ${CMAKE_BINARY_DIR}/src)
   add_test(NAME ${name} COMMAND ${name})
 endfunction()
 


### PR DESCRIPTION
Fixes #29.

The grib2.h file contains a version that must be changed with every release. This PR causes CMake to put the current version into the file at build time.