### PR TITLE
add g2_unpack2() prototype to grib2.h.in, also whitespace cleanup of header file

### DIFF
--- a/src/compack.c
+++ b/src/compack.c
@@ -55,7 +55,7 @@ compack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
     g2int kfildo,  minpk,  inc,  maxgrps,  ibit, jbit, kbit, novref, lbitref;
     g2int missopt, miss1, miss2, ier;
     g2float bscale, dscale, rmax, rmin, temp;
-    static g2float alog2 = 0.69314718;       /*  ln(2.0) */
+    static g2float alog2 = ALOG2;       /*  ln(2.0) */
     static g2int one = 1;
 
     bscale = int_power(2.0, -idrstmpl[1]);

--- a/src/g2_getfld.c
+++ b/src/g2_getfld.c
@@ -7,17 +7,6 @@
 #include <stdlib.h>
 #include "grib2.h"
 
-g2int g2_unpack1(unsigned char *,g2int *,g2int **,g2int *);
-g2int g2_unpack2(unsigned char *,g2int *,g2int *,unsigned char **);
-g2int g2_unpack3(unsigned char *,g2int *,g2int **,g2int **,
-                 g2int *,g2int **,g2int *);
-g2int g2_unpack4(unsigned char *,g2int *,g2int *,g2int **,
-                 g2int *,g2float **,g2int *);
-g2int g2_unpack5(unsigned char *,g2int *,g2int *,g2int *, g2int **,g2int *);
-g2int g2_unpack6(unsigned char *,g2int *,g2int ,g2int *, g2int **);
-g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,
-                 g2int ,g2int *,g2int ,g2float **);
-
 /**
  * This subroutine returns all the metadata, template values, bit-map
  * (if applicable), and the unpacked data for a given data field. All

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -130,7 +130,7 @@ struct gribfield
     /** Source of grid definition (see [Table
      * 3.0](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table3-0.shtml)).
      * - 0 Specified in [Table
-       3.1](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table3-1.shtml).
+     3.1](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table3-1.shtml).
      *  - 1 Predetermined grid Defined by originating centre. */
     g2int griddef;
 
@@ -170,7 +170,7 @@ struct gribfield
      * specified by igdtnum. */
     g2int *igdtmpl;
 
-    /** Product Definition Template Number (see 
+    /** Product Definition Template Number (see
      * [Table 4.0](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table4-0.shtml)). */
     g2int ipdtnum;
 
@@ -236,50 +236,57 @@ struct gribfield
 typedef struct gribfield gribfield; /**< Struct for GRIB field. */
 
 /*  Prototypes for unpacking sections API  */
-g2int g2_unpack1(unsigned char *,g2int *,g2int **,g2int *);
-g2int g2_unpack3(unsigned char *,g2int *,g2int **,g2int **,g2int *,g2int **,g2int *);
-g2int g2_unpack4(unsigned char *,g2int *,g2int *,g2int **,g2int *,g2float **,g2int *);
-g2int g2_unpack5(unsigned char *,g2int *,g2int *,g2int *,g2int **,g2int *);
-g2int g2_unpack6(unsigned char *,g2int *,g2int ,g2int *,g2int **);
-g2int g2_unpack7(unsigned char *,g2int *,g2int ,g2int *,g2int ,g2int *,g2int ,g2float **);
+g2int g2_unpack1(unsigned char *cgrib, g2int *iofst, g2int **ids, g2int *idslen);
+g2int g2_unpack2(unsigned char *cgrib, g2int *iofst, g2int *lencsec2,
+                 unsigned char **csec2);
+g2int g2_unpack3(unsigned char *cgrib, g2int *iofst, g2int **igds, g2int **igdstmpl,
+                 g2int *mapgridlen, g2int **ideflist, g2int *idefnum);
+g2int g2_unpack4(unsigned char *cgrib, g2int *iofst, g2int *ipdsnum, g2int **ipdstmpl,
+                 g2int *mappdslen, g2float **coordlist, g2int *numcoord);
+g2int g2_unpack5(unsigned char *cgrib, g2int *iofst, g2int *ndpts, g2int *idrsnum,
+                 g2int **idrstmpl, g2int *mapdrslen);
+g2int g2_unpack6(unsigned char *cgrib, g2int *iofst, g2int ngpts, g2int *ibmap,
+                 g2int **bmap);
+g2int g2_unpack7(unsigned char *cgrib, g2int *iofst, g2int igdsnum, g2int *igdstmpl,
+                 g2int idrsnum, g2int *idrstmpl, g2int ndpts, g2float **fld);
 
 /*  Prototypes for unpacking API  */
-void seekgb(FILE *,g2int ,g2int ,g2int *,g2int *);
-g2int g2_info(unsigned char *,g2int *,g2int *,g2int *,g2int *);
-g2int g2_getfld(unsigned char *,g2int ,g2int ,g2int ,gribfield **);
+void seekgb(FILE *, g2int , g2int , g2int *, g2int *);
+g2int g2_info(unsigned char *, g2int *, g2int *, g2int *, g2int *);
+g2int g2_getfld(unsigned char *, g2int , g2int , g2int , gribfield **);
 void g2_free(gribfield *);
 
 /*  Prototypes for packing API  */
-g2int g2_create(unsigned char *,g2int *,g2int *);
-g2int g2_addlocal(unsigned char *,unsigned char *,g2int );
-g2int g2_addgrid(unsigned char *,g2int *,g2int *,g2int *,g2int );
-g2int g2_addfield(unsigned char *,g2int ,g2int *,
-                  g2float *,g2int ,g2int ,g2int *,
-                  g2float *,g2int ,g2int ,g2int *);
+g2int g2_create(unsigned char *, g2int *, g2int *);
+g2int g2_addlocal(unsigned char *, unsigned char *, g2int);
+g2int g2_addgrid(unsigned char *, g2int *, g2int *, g2int *, g2int);
+g2int g2_addfield(unsigned char *, g2int , g2int *,
+                  g2float *, g2int , g2int , g2int *,
+                  g2float *, g2int , g2int , g2int *);
 g2int g2_gribend(unsigned char *);
 
 /*  Prototypes for supporting routines  */
-extern double int_power(double, g2int );
-extern void mkieee(g2float *,g2int *,g2int);
-void rdieee(g2int *,g2float *,g2int );
+extern double int_power(double,  g2int);
+extern void mkieee(g2float *, g2int *, g2int);
+void rdieee(g2int *, g2float *, g2int);
 extern gtemplate *getpdstemplate(g2int);
-extern gtemplate *extpdstemplate(g2int,g2int *);
+extern gtemplate *extpdstemplate(g2int, g2int *);
 extern gtemplate *getdrstemplate(g2int);
-extern gtemplate *extdrstemplate(g2int,g2int *);
+extern gtemplate *extdrstemplate(g2int, g2int *);
 extern gtemplate *getgridtemplate(g2int);
-extern gtemplate *extgridtemplate(g2int,g2int *);
-extern void simpack(g2float *,g2int,g2int *,unsigned char *,g2int *);
-extern void compack(g2float *,g2int,g2int,g2int *,unsigned char *,g2int *);
-void misspack(g2float *,g2int ,g2int ,g2int *, unsigned char *, g2int *);
-void gbit(unsigned char *,g2int *,g2int ,g2int );
-void sbit(unsigned char *,g2int *,g2int ,g2int );
-void gbits(unsigned char *,g2int *,g2int ,g2int ,g2int ,g2int );
-void sbits(unsigned char *,g2int *,g2int ,g2int ,g2int ,g2int );
+extern gtemplate *extgridtemplate(g2int, g2int *);
+extern void simpack(g2float *, g2int, g2int *, unsigned char *, g2int *);
+extern void compack(g2float *, g2int, g2int, g2int *, unsigned char *, g2int *);
+void misspack(g2float *, g2int , g2int , g2int *,  unsigned char *,  g2int *);
+void gbit(unsigned char *, g2int *, g2int , g2int);
+void sbit(unsigned char *, g2int *, g2int , g2int);
+void gbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
+void sbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
 
-int pack_gp(g2int *, g2int *, g2int *,
-            g2int *, g2int *, g2int *, g2int *, g2int *,
-            g2int *, g2int *, g2int *, g2int *,
-            g2int *, g2int *, g2int *, g2int *, g2int *,
-            g2int *, g2int *, g2int *);
+int pack_gp(g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *);
 
 #endif  /*  _grib2_H  */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -17,6 +17,8 @@
 
 #define G2_VERSION "g2clib-@pVersion@" /**< Current version of NCEPLIBS-g2c library. */
 
+#define ALOG2 (0.69314718) /**< ln(2.0) */
+
 typedef int64_t g2int; /**< Long integer type. */
 typedef uint64_t g2intu; /**< Unsigned long integer type. */
 typedef float g2float; /**< Float type. */

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -54,7 +54,7 @@ jpcpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
         unsigned char *cpack, g2int *lcpack)
 {
     g2int  *ifld = NULL;
-    static g2float alog2 = 0.69314718;       /*  ln(2.0) */
+    static g2float alog2 = ALOG2;       /*  ln(2.0) */
     g2int  j, nbits, imin, imax, maxdif;
     g2int  ndpts, nbytes, nsize, retry;
     g2float  bscale, dscale, rmax, rmin, temp;

--- a/src/misspack.c
+++ b/src/misspack.c
@@ -55,7 +55,7 @@ misspack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
     g2int imax, lg, mtemp, ier, igmax;
     g2int kfildo, minpk, inc, maxgrps, ibit, jbit, kbit, novref, lbitref;
     g2float rmissp, rmisss, bscale, dscale, rmin, temp;
-    static g2float alog2 = 0.69314718;       /*  ln(2.0) */
+    static g2float alog2 = ALOG2;       /*  ln(2.0) */
     static g2int one = 1;
 
     bscale = int_power(2.0, -idrstmpl[1]);

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -39,7 +39,7 @@ pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
         unsigned char *cpack, g2int *lcpack)
 {
     g2int *ifld = NULL;
-    static g2float alog2 = 0.69314718;       /*  ln(2.0) */
+    static g2float alog2 = ALOG2;       /*  ln(2.0) */
     g2int j, nbits, imin, imax, maxdif;
     g2int ndpts, nbytes;
     g2float bscale, dscale, rmax, rmin, temp;

--- a/src/simpack.c
+++ b/src/simpack.c
@@ -39,7 +39,7 @@ simpack(g2float *fld, g2int ndpts, g2int *idrstmpl,
     g2int j, nbits, imin, imax, maxdif, nbittot, left;
     g2float bscale, dscale, rmax, rmin, temp;
     double maxnum;
-    static g2float alog2 = 0.69314718;       /*  ln(2.0) */
+    static g2float alog2 = ALOG2;       /*  ln(2.0) */
 
     bscale = int_power(2.0, -idrstmpl[1]);
     dscale = int_power(10.0, idrstmpl[2]);

--- a/tests/tst_g2_addlocal.c
+++ b/tests/tst_g2_addlocal.c
@@ -13,9 +13,6 @@
 #define MSG_LEN 52
 #define G2C_ERROR 2
 
-g2int g2_unpack2(unsigned char *cgrib, g2int *iofst, g2int *lencsec2,
-                 unsigned char **csec2);
-
 int
 main()
 {

--- a/tests/tst_unpack.c
+++ b/tests/tst_unpack.c
@@ -14,10 +14,6 @@
 #define FULL_MSG_LEN 182
 #define G2C_ERROR 2
 
-/* This prototype is missing from cgrib2.h. See
- * https://github.com/NOAA-EMC/NCEPLIBS-g2c/issues/157. */
-g2int g2_unpack2(unsigned char *cgrib, g2int *iofst, g2int *lencsec2,
-                 unsigned char **csec2);
 int
 main()
 {


### PR DESCRIPTION
Part of #192 
Fixes #157
Fixes #169

add g2_unpack2() prototype to grib2.h.in, also whitespace cleanup of header file