### PR TITLE
fixed sign confusion with data buffers in enc_png() and dec_png()

### DIFF
--- a/src/dec_png.c
+++ b/src/dec_png.c
@@ -50,7 +50,6 @@ user_read_data(png_structp png_ptr, png_bytep data, png_uint_32 length)
     mem = (png_stream *)png_get_io_ptr(png_ptr);
     ptr = (void *)mem->stream_ptr;
     offset = mem->stream_len;
-/*     printf("SAGrd %ld %ld %x\n",offset,length,ptr);  */
     memcpy(data, ptr + offset, length);
     mem->stream_len += length;
 }
@@ -81,30 +80,30 @@ dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
 
     /* Check if stream is a valid PNG format. */
     if (png_sig_cmp(pngbuf, 0, 8) != 0)
-        return (-3);
+        return -3;
 
     /* Create and initialize png_structs. */
     if (!(png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, (png_voidp)NULL,
                                            NULL, NULL)))
-        return (-1);
+        return -1;
 
     if (!(info_ptr = png_create_info_struct(png_ptr)))
     {
         png_destroy_read_struct(&png_ptr, (png_infopp)NULL, (png_infopp)NULL);
-        return (-2);
+        return -2;
     }
 
     if (!(end_info = png_create_info_struct(png_ptr)))
     {
         png_destroy_read_struct(&png_ptr, (png_infopp)info_ptr, (png_infopp)NULL);
-        return (-2);
+        return -2;
     }
 
     /* Set Error callback. */
     if (setjmp(png_jmpbuf(png_ptr)))
     {
         png_destroy_read_struct(&png_ptr,  &info_ptr, &end_info);
-        return (-3);
+        return -3;
     }
 
     /* Initialize info for reading PNG stream from memory. */

--- a/src/dec_png.c
+++ b/src/dec_png.c
@@ -68,7 +68,8 @@ user_read_data(png_structp png_ptr, png_bytep data, png_uint_32 length)
  * @author Stephen Gilbert
  */
 int
-dec_png(unsigned char *pngbuf, g2int *width, g2int *height, char *cout)
+dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
+        unsigned char *cout)
 {
     int interlace, color, compres, filter, bit_depth;
     g2int j, k, n, bytes, clen;

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -78,7 +78,8 @@ void user_flush_data(png_structp png_ptr)
  * @author Stephen Gilbert
  */
 int
-enc_png(char *data, g2int width, g2int height, g2int nbits, char *pngbuf)
+enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
+        unsigned char *pngbuf)
 {
     int color_type;
     g2int j, bytes, pnglen, bit_depth;

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -90,19 +90,19 @@ enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
 
     /* Create and initialize png_structs. */
     if (!(png_ptr = png_create_write_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL)))
-        return (-1);
+        return -1;
 
     if (!(info_ptr = png_create_info_struct(png_ptr)))
     {
         png_destroy_write_struct(&png_ptr, (png_infopp)NULL);
-        return (-2);
+        return -2;
     }
 
     /* Set Error callback. */
     if (setjmp(png_jmpbuf(png_ptr)))
     {
         png_destroy_write_struct(&png_ptr, &info_ptr);
-        return (-3);
+        return -3;
     }
 
     /* Initialize info for writing PNG stream to memory. */

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -6,7 +6,8 @@
 #include <math.h>
 #include "grib2.h"
 
-int enc_png(char *, g2int, g2int, g2int, char *);
+int enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
+            unsigned char *pngbuf);
 
 /**
  * This subroutine packs up a data field into PNG image format. After
@@ -114,8 +115,8 @@ pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
         sbits(ctemp, ifld, 0, nbits, 0, ndpts);
 
         /* Encode data into PNG Format. */
-        if ((*lcpack = (g2int)enc_png((char *)ctemp, width, height, nbits,
-                                      (char *)cpack)) <= 0)
+        if ((*lcpack = (g2int)enc_png(ctemp, width, height, nbits,
+                                      cpack)) <= 0)
             printf("pngpack: ERROR Packing PNG = %d\n", (int)*lcpack);
         
         free(ctemp);

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -8,7 +8,8 @@
 #include <stdlib.h>
 #include "grib2.h"
 
-int dec_png(unsigned char *, g2int *, g2int *, char *);
+int dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
+            unsigned char *cout);
 
 /**
  * This subroutine unpacks a data field that was packed into a PNG

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -19,7 +19,7 @@ int dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
  * @param cpack The packed data field (character*1 array).
  * @param len length of packed field cpack().
  * @param idrstmpl Pointer to array of values for Data Representation
- * Template 5.41 or 5.40010.
+ * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml) or 5.40010.
  * @param ndpts The number of data values to unpack.
  * @param fld Contains the unpacked data values.
  *
@@ -50,7 +50,7 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
         if (!ifld || !ctemp)
         {
             fprintf(stderr,"Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
-            return(1);
+            return 1;
         }
         dec_png(cpack, &width, &height, ctemp);
         gbits(ctemp, ifld, 0, nbits, 0, ndpts);
@@ -65,5 +65,5 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
             fld[j] = ref;
     }
 
-    return(0);
+    return 0;
 }


### PR DESCRIPTION
Fixes #166 
Part of #52 

Fixed sign confusion with data buffers in enc_png() and dec_png().

Fixing this caused a few warnings to go away.