### PR TITLE
moving to internal header file for some functions and defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ set_target_properties(${lib_name} PROPERTIES PUBLIC_HEADER "src/grib2.h")
 target_include_directories(
   ${lib_name}
   PRIVATE ${private_includes}
-  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>"
+  PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src;${CMAKE_CURRENT_SOURCE_DIR}/src>"
          $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
 )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,6 +4,7 @@
 # Mark Potts, Kyle Gerheiser
 
 set(c_src
+    ${CMAKE_CURRENT_SOURCE_DIR}/grib2_int.h
     ${CMAKE_CURRENT_SOURCE_DIR}/cmplxpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/compack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/comunpack.c

--- a/src/cmplxpack.c
+++ b/src/cmplxpack.c
@@ -4,7 +4,7 @@
  * @author Stephen Gilbert @date 2004-08-27
  */
 
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine packs up a data field using a complex packing

--- a/src/compack.c
+++ b/src/compack.c
@@ -7,7 +7,7 @@
 
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine packs up a data field using a complex packing

--- a/src/comunpack.c
+++ b/src/comunpack.c
@@ -5,7 +5,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks a data field that was packed using a

--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -15,7 +15,7 @@ void dummy(void) {}
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "grib2.h"
+#include "grib2_int.h"
 #include "jasper/jasper.h"
 
 /**

--- a/src/dec_png.c
+++ b/src/dec_png.c
@@ -16,7 +16,7 @@ void dummy(void) {}
 #include <stdlib.h>
 #include <string.h>
 #include <png.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * Struct for PNG stream.

--- a/src/decenc_openjpeg.c
+++ b/src/decenc_openjpeg.c
@@ -18,7 +18,7 @@
 
 #if !defined USE_JPEG2000 && defined USE_OPENJPEG
 
-#include "grib2.h"
+#include "grib2_int.h"
 #include "openjpeg.h"
 
 #include <assert.h>

--- a/src/drstemplates.c
+++ b/src/drstemplates.c
@@ -13,7 +13,7 @@
  */
 
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 #include "drstemplates.h"
 
 /**

--- a/src/drstemplates.h
+++ b/src/drstemplates.h
@@ -31,7 +31,7 @@
 #ifndef _drstemplates_H
 #define _drstemplates_H
 
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define MAXDRSTEMP 9 /**< maximum number of templates */
 #define MAXDRSMAPLEN 200 /**< maximum template map length */

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -9,7 +9,7 @@ void dummy(void) {}
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 #include "jasper/jasper.h"
 
 #define MAXOPTSSIZE 1024 /**< Maximum size of options. */

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <png.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #ifndef USE_PNG
 void dummy(void) {}

--- a/src/g2_addfield.c
+++ b/src/g2_addfield.c
@@ -8,12 +8,6 @@
 #include <stdlib.h>
 #include "grib2_int.h"
 
-g2int getdim(unsigned char *, g2int *, g2int *, g2int *);
-g2int getpoly(unsigned char *, g2int *, g2int *, g2int *);
-void simpack(g2float *,  g2int,  g2int *,  unsigned char *,  g2int *);
-void cmplxpack(g2float *,  g2int,  g2int,  g2int *,  unsigned char *,  g2int *);
-void specpack(g2float *, g2int, g2int, g2int, g2int, g2int *, unsigned char *,
-              g2int *);
 #ifdef USE_PNG
 void pngpack(g2float *, g2int, g2int, g2int *, unsigned char *, g2int *);
 #endif  /* USE_PNG */
@@ -363,7 +357,7 @@ g2_addfield(unsigned char *cgrib, g2int ipdsnum, g2int *ipdstmpl,
                 width = ndpts;
                 height = 1;
             }
-            else if (iscan & 32 == 32)
+            else if ((iscan & 32) == 32)
             {   /* Scanning mode: bit 3  */
                 itemp = width;
                 width = height;
@@ -395,7 +389,7 @@ g2_addfield(unsigned char *cgrib, g2int ipdsnum, g2int *ipdstmpl,
                 width = ndpts;
                 height = 1;
             }
-            else if (iscan & 32 == 32)
+            else if ((iscan & 32) == 32)
             {   /* Scanning mode: bit 3  */
                 itemp = width;
                 width = height;

--- a/src/g2_addfield.c
+++ b/src/g2_addfield.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 g2int getdim(unsigned char *, g2int *, g2int *, g2int *);
 g2int getpoly(unsigned char *, g2int *, g2int *, g2int *);

--- a/src/g2_addgrid.c
+++ b/src/g2_addgrid.c
@@ -7,7 +7,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This routine packs up a [Grid Definition Section (Section

--- a/src/g2_addlocal.c
+++ b/src/g2_addlocal.c
@@ -4,7 +4,7 @@
  */
 
 #include <stdio.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This routine adds a [Local Use Section (Section

--- a/src/g2_create.c
+++ b/src/g2_create.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define MAPSEC1LEN 13 /**< Length of Map Section 1. */
 #define LENSEC0 16 /**< Length of GRIB Section 0. */

--- a/src/g2_free.c
+++ b/src/g2_free.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdlib.h>
-#include  "grib2.h"
+#include  "grib2_int.h"
 
 /**
  * This routine frees up memory that was allocated for struct

--- a/src/g2_getfld.c
+++ b/src/g2_getfld.c
@@ -5,7 +5,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine returns all the metadata, template values, bit-map

--- a/src/g2_gribend.c
+++ b/src/g2_gribend.c
@@ -4,7 +4,7 @@
  * @author Stephen Gilbert @date 2002-10-31
  */
 #include <stdio.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This routine finalizes a GRIB2 message after all grids and fields

--- a/src/g2_info.c
+++ b/src/g2_info.c
@@ -9,7 +9,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine searches through a GRIB2 message and returns the

--- a/src/g2_miss.c
+++ b/src/g2_miss.c
@@ -5,7 +5,7 @@
  * @author Stephen Gilbeert @date 2004-12-16
  */
 
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This routine checks the Data Representation Template to see if

--- a/src/g2_unpack1.c
+++ b/src/g2_unpack1.c
@@ -8,7 +8,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks [Section 1 - Identification

--- a/src/g2_unpack2.c
+++ b/src/g2_unpack2.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks [Section 2 (Local Use

--- a/src/g2_unpack3.c
+++ b/src/g2_unpack3.c
@@ -5,7 +5,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This routine unpacks [Section 3 (Grid Definition

--- a/src/g2_unpack4.c
+++ b/src/g2_unpack4.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks [Section 4 (Product Definition

--- a/src/g2_unpack5.c
+++ b/src/g2_unpack5.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks Section 5 (Data Representation Section) as

--- a/src/g2_unpack6.c
+++ b/src/g2_unpack6.c
@@ -4,7 +4,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks Section 6 (Bit-Map Section) as defined in

--- a/src/g2_unpack7.c
+++ b/src/g2_unpack7.c
@@ -6,7 +6,7 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <string.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 g2int simunpack(unsigned char *,g2int *, g2int,g2float *);
 int comunpack(unsigned char *,g2int,g2int,g2int *,g2int,g2float *);

--- a/src/g2_unpack7.c
+++ b/src/g2_unpack7.c
@@ -8,16 +8,6 @@
 #include <string.h>
 #include "grib2_int.h"
 
-g2int simunpack(unsigned char *,g2int *, g2int,g2float *);
-int comunpack(unsigned char *,g2int,g2int,g2int *,g2int,g2float *);
-g2int specunpack(unsigned char *,g2int *,g2int,g2int,g2int, g2int, g2float *);
-#ifdef USE_PNG
-g2int pngunpack(unsigned char *,g2int,g2int *,g2int, g2float *);
-#endif  /* USE_PNG */
-#if defined USE_JPEG2000 || defined USE_OPENJPEG
-g2int jpcunpack(unsigned char *,g2int,g2int *,g2int, g2float *);
-#endif  /* USE_JPEG2000 */
-
 /**
  *
  * This subroutine unpacks Section 7 (Data Section) as defined in GRIB

--- a/src/gbits.c
+++ b/src/gbits.c
@@ -3,7 +3,7 @@
  * string.
  * @author NOAA Programmer
  */
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * Get bits - unpack bits: Extract arbitrary size values from a packed

--- a/src/getdim.c
+++ b/src/getdim.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine returns the dimensions and scanning mode of a grid

--- a/src/getpoly.c
+++ b/src/getpoly.c
@@ -6,7 +6,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine returns the J, K, and M pentagonal resolution

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -6,6 +6,7 @@
  * -----|------------|---------
  * 2002-10-25 | Gilbert | Initial
  * 2009-01-14 | Vuong | Changed struct template to gtemplate
+ * 2021-11-9 | Ed Hartnett | Moved many prototypes to new internal header grib2_int.h.
  *
  * @author Stephen Gilbert @date 2002-10-25
  */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -17,8 +17,6 @@
 
 #define G2_VERSION "g2clib-@pVersion@" /**< Current version of NCEPLIBS-g2c library. */
 
-#define ALOG2 (0.69314718) /**< ln(2.0) */
-
 typedef int64_t g2int; /**< Long integer type. */
 typedef uint64_t g2intu; /**< Unsigned long integer type. */
 typedef float g2float; /**< Float type. */
@@ -266,29 +264,5 @@ g2int g2_addfield(unsigned char *, g2int , g2int *,
                   g2float *, g2int , g2int , g2int *,
                   g2float *, g2int , g2int , g2int *);
 g2int g2_gribend(unsigned char *);
-
-/*  Prototypes for supporting routines  */
-extern double int_power(double,  g2int);
-extern void mkieee(g2float *, g2int *, g2int);
-void rdieee(g2int *, g2float *, g2int);
-extern gtemplate *getpdstemplate(g2int);
-extern gtemplate *extpdstemplate(g2int, g2int *);
-extern gtemplate *getdrstemplate(g2int);
-extern gtemplate *extdrstemplate(g2int, g2int *);
-extern gtemplate *getgridtemplate(g2int);
-extern gtemplate *extgridtemplate(g2int, g2int *);
-extern void simpack(g2float *, g2int, g2int *, unsigned char *, g2int *);
-extern void compack(g2float *, g2int, g2int, g2int *, unsigned char *, g2int *);
-void misspack(g2float *, g2int , g2int , g2int *,  unsigned char *,  g2int *);
-void gbit(unsigned char *, g2int *, g2int , g2int);
-void sbit(unsigned char *, g2int *, g2int , g2int);
-void gbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
-void sbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
-
-int pack_gp(g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *);
 
 #endif  /*  _grib2_H  */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -16,7 +16,7 @@
 #include <stdio.h>
 #include <stdint.h>
 
-#define G2_VERSION "g2clib-@pVersion@" /**< Current version of NCEPLIBS-g2c library. */
+#define G2_VERSION "@pVersion@" /**< Current version of NCEPLIBS-g2c library. */
 
 typedef int64_t g2int; /**< Long integer type. */
 typedef uint64_t g2intu; /**< Unsigned long integer type. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -251,18 +251,22 @@ g2int g2_unpack7(unsigned char *cgrib, g2int *iofst, g2int igdsnum, g2int *igdst
                  g2int idrsnum, g2int *idrstmpl, g2int ndpts, g2float **fld);
 
 /*  Prototypes for unpacking API  */
-void seekgb(FILE *, g2int , g2int , g2int *, g2int *);
-g2int g2_info(unsigned char *, g2int *, g2int *, g2int *, g2int *);
-g2int g2_getfld(unsigned char *, g2int , g2int , g2int , gribfield **);
-void g2_free(gribfield *);
+void seekgb(FILE *lugb, g2int iseek, g2int mseek, g2int *lskip,
+            g2int *lgrib);
+g2int g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
+              g2int *numfields, g2int *numlocal);
+g2int g2_getfld(unsigned char *cgrib, g2int ifldnum, g2int unpack, g2int expand,
+                gribfield **gfld);
+void g2_free(gribfield *gfld);
 
 /*  Prototypes for packing API  */
-g2int g2_create(unsigned char *, g2int *, g2int *);
-g2int g2_addlocal(unsigned char *, unsigned char *, g2int);
-g2int g2_addgrid(unsigned char *, g2int *, g2int *, g2int *, g2int);
-g2int g2_addfield(unsigned char *, g2int , g2int *,
-                  g2float *, g2int , g2int , g2int *,
-                  g2float *, g2int , g2int , g2int *);
-g2int g2_gribend(unsigned char *);
+g2int g2_create(unsigned char *cgrib, g2int *listsec0, g2int *listsec1);
+g2int g2_addlocal(unsigned char *cgrib, unsigned char *csec2, g2int lcsec2);
+g2int g2_addgrid(unsigned char *cgrib, g2int *igds, g2int *igdstmpl, g2int *ideflist,
+                 g2int idefnum);
+g2int g2_addfield(unsigned char *cgrib, g2int ipdsnum, g2int *ipdstmpl,
+                  g2float *coordlist, g2int numcoord, g2int idrsnum, g2int *idrstmpl,
+                  g2float *fld, g2int ngrdpts, g2int ibmap, g2int *bmap);
+g2int g2_gribend(unsigned char *cgrib);
 
 #endif  /*  _grib2_H  */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -19,28 +19,52 @@
 
 #define ALOG2 (0.69314718) /**< ln(2.0) */
 
-/*  Prototypes for supporting routines  */
-extern double int_power(double,  g2int);
-extern void mkieee(g2float *, g2int *, g2int);
-void rdieee(g2int *, g2float *, g2int);
-extern gtemplate *getpdstemplate(g2int);
-extern gtemplate *extpdstemplate(g2int, g2int *);
-extern gtemplate *getdrstemplate(g2int);
-extern gtemplate *extdrstemplate(g2int, g2int *);
-extern gtemplate *getgridtemplate(g2int);
-extern gtemplate *extgridtemplate(g2int, g2int *);
-extern void simpack(g2float *, g2int, g2int *, unsigned char *, g2int *);
-extern void compack(g2float *, g2int, g2int, g2int *, unsigned char *, g2int *);
-void misspack(g2float *, g2int , g2int , g2int *,  unsigned char *,  g2int *);
-void gbit(unsigned char *, g2int *, g2int , g2int);
-void sbit(unsigned char *, g2int *, g2int , g2int);
-void gbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
-void sbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
+/* Legacy support functions. */
+double int_power(double x, g2int y);
+void mkieee(g2float *a, g2int *rieee, g2int num);
+void rdieee(g2int *rieee, g2float *a, g2int num);
 
-int pack_gp(g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
-            g2int *,  g2int *,  g2int *);
+/* Get the various templates. */
+gtemplate *getdrstemplate(g2int number);
+gtemplate *extdrstemplate(g2int number, g2int *list);
+gtemplate *getpdstemplate(g2int number);
+gtemplate *extpdstemplate(g2int number, g2int *list);
+gtemplate *getgridtemplate(g2int number);
+gtemplate *extgridtemplate(g2int number, g2int *list);
+
+/* Packing and unpacking data. */
+void simpack(g2float *fld, g2int ndpts, g2int *idrstmpl, 
+             unsigned char *cpack, g2int *lcpack);
+g2int simunpack(unsigned char *cpack, g2int *idrstmpl, g2int ndpts,
+                g2float *fld);
+void compack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
+             unsigned char *cpack, g2int *lcpack);
+int comunpack(unsigned char *cpack, g2int lensec, g2int idrsnum,
+              g2int *idrstmpl, g2int ndpts, g2float *fld);
+void misspack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
+              unsigned char *cpack, g2int *lcpack);
+void cmplxpack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
+               unsigned char *cpack, g2int *lcpack);
+g2int getpoly(unsigned char *csec3, g2int *jj, g2int *kk, g2int *mm);
+void specpack(g2float *fld, g2int ndpts, g2int JJ, g2int KK, g2int MM, 
+              g2int *idrstmpl, unsigned char *cpack, g2int *lcpack);
+g2int specunpack(unsigned char *cpack, g2int *idrstmpl, g2int ndpts, g2int JJ,
+                 g2int KK, g2int MM, g2float *fld);
+g2int getdim(unsigned char *csec3, g2int *width, g2int *height, g2int *iscan);
+
+/* Packing and unpacking bits. */
+void gbit(unsigned char *in, g2int *iout, g2int iskip, g2int nbyte);
+void sbit(unsigned char *out, g2int *in, g2int iskip, g2int nbyte);
+void gbits(unsigned char *in, g2int *iout, g2int iskip, g2int nbyte,
+           g2int nskip, g2int n);
+void sbits(unsigned char *out, g2int *in, g2int iskip, g2int nbyte,
+           g2int nskip, g2int n);
+
+/* Deal with grib groups. */
+int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
+            g2int *is523, g2int *minpk, g2int *inc, g2int *missp, g2int *misss,
+            g2int *jmin, g2int *jmax, g2int *lbit, g2int *nov,
+            g2int *ndg, g2int *lx, g2int *ibit, g2int *jbit, g2int *kbit,
+            g2int *novref, g2int *lbitref, g2int *ier);
 
 #endif  /*  _grib2_int_H  */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -52,6 +52,23 @@ g2int specunpack(unsigned char *cpack, g2int *idrstmpl, g2int ndpts, g2int JJ,
                  g2int KK, g2int MM, g2float *fld);
 g2int getdim(unsigned char *csec3, g2int *width, g2int *height, g2int *iscan);
 
+int enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
+            unsigned char *pngbuf);
+int dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
+            unsigned char *cout);
+void pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl, 
+             unsigned char *cpack, g2int *lcpack);
+g2int pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                g2float *fld);
+int enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
+                 g2int ltype, g2int ratio, g2int retry, char *outjpc,
+                 g2int jpclen);
+int dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld);
+void jpcpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
+             unsigned char *cpack, g2int *lcpack);
+g2int jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                g2float *fld);
+
 /* Packing and unpacking bits. */
 void gbit(unsigned char *in, g2int *iout, g2int iskip, g2int nbyte);
 void sbit(unsigned char *out, g2int *in, g2int iskip, g2int nbyte);

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -1,0 +1,46 @@
+/** @file
+ * @brief Header file with internal function prototypes NCEPLIBS-g2c
+ * library.
+ *
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2021-11-08 | Ed Hartnett | Initial
+ *
+ * @author Ed Hartnett @date 2021-11-08
+ */
+
+#ifndef _grib2_int_H
+#define _grib2_int_H
+
+#include <stdio.h>
+#include <stdint.h>
+#include "grib2.h"
+
+#define ALOG2 (0.69314718) /**< ln(2.0) */
+
+/*  Prototypes for supporting routines  */
+extern double int_power(double,  g2int);
+extern void mkieee(g2float *, g2int *, g2int);
+void rdieee(g2int *, g2float *, g2int);
+extern gtemplate *getpdstemplate(g2int);
+extern gtemplate *extpdstemplate(g2int, g2int *);
+extern gtemplate *getdrstemplate(g2int);
+extern gtemplate *extdrstemplate(g2int, g2int *);
+extern gtemplate *getgridtemplate(g2int);
+extern gtemplate *extgridtemplate(g2int, g2int *);
+extern void simpack(g2float *, g2int, g2int *, unsigned char *, g2int *);
+extern void compack(g2float *, g2int, g2int, g2int *, unsigned char *, g2int *);
+void misspack(g2float *, g2int , g2int , g2int *,  unsigned char *,  g2int *);
+void gbit(unsigned char *, g2int *, g2int , g2int);
+void sbit(unsigned char *, g2int *, g2int , g2int);
+void gbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
+void sbits(unsigned char *, g2int *, g2int , g2int , g2int , g2int);
+
+int pack_gp(g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *,  g2int *,  g2int *,
+            g2int *,  g2int *,  g2int *);
+
+#endif  /*  _grib2_int_H  */

--- a/src/gridtemplates.c
+++ b/src/gridtemplates.c
@@ -16,7 +16,7 @@
  * @author Stephen Gilbert @date 2001-06-28
  */
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 #include "gridtemplates.h"
 
 /**

--- a/src/gridtemplates.h
+++ b/src/gridtemplates.h
@@ -38,7 +38,7 @@
  */
 #ifndef _gridtemplates_H
 #define _gridtemplates_H
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define MAXGRIDTEMP 31 /**< Maximum number of templates. */
 #define MAXGRIDMAPLEN 200 /**< Maximum template map length. */

--- a/src/int_power.c
+++ b/src/int_power.c
@@ -2,7 +2,7 @@
  * @brief Provide function similar to C pow() power function.
  * @author Wesley Ebisuzaki
  */
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * Function similar to C pow() power function.

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -4,7 +4,7 @@
  */
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 int enc_jpeg2000(unsigned char *, g2int, g2int, g2int,
                  g2int, g2int, g2int, char *, g2int);

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -6,9 +6,6 @@
 #include <math.h>
 #include "grib2_int.h"
 
-int enc_jpeg2000(unsigned char *, g2int, g2int, g2int,
-                 g2int, g2int, g2int, char *, g2int);
-
 /**
  * This subroutine packs up a data field into a JPEG2000 code
  * stream. After the data field is scaled, and the reference value is

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -7,8 +7,6 @@
 #include <stdlib.h>
 #include "grib2_int.h"
 
-int dec_jpeg2000(char *, g2int, g2int *);
-
 /**
  * This subroutine unpacks a data field that was packed into a
  * JPEG2000 code stream using info from the GRIB2 Data Representation

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -5,7 +5,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 int dec_jpeg2000(char *, g2int, g2int *);
 

--- a/src/misspack.c
+++ b/src/misspack.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This function packs up a data field using a complex packing

--- a/src/mkieee.c
+++ b/src/mkieee.c
@@ -18,89 +18,88 @@
  *
  * @author Stephen Gilbert @date 2002-10-29
  */
-void mkieee(g2float *a,g2int *rieee,g2int num)
+void
+mkieee(g2float *a, g2int *rieee, g2int num)
 {
+    g2int j,n,ieee,iexp,imant;
+    double atemp;
+    static double two23, two126;
+    static g2int test = 0;
 
-    g2int  j,n,ieee,iexp,imant;
-    double  atemp;
-
-    static double  two23,two126;
-    static g2int test=0;
-    //g2intu msk1=0x80000000;        // 10000000000000000000000000000000 binary
-    //g2int msk2=0x7F800000;         // 01111111100000000000000000000000 binary
-    //g2int msk3=0x007FFFFF;         // 00000000011111111111111111111111 binary
-
-    if ( test == 0 ) {
-        two23=(double)int_power(2.0,23);
-        two126=(double)int_power(2.0,126);
-        test=1;
+    if (test == 0)
+    {
+        two23 = (double)int_power(2.0, 23);
+        two126 = (double)int_power(2.0, 126);
+        test = 1;
     }
 
-    for (j=0;j<num;j++) {
+    for (j = 0; j < num; j++)
+    {
 
         ieee=0;
 
-        if (a[j] == 0.0) {
-            rieee[j]=ieee;
+        if (a[j] == 0.0)
+        {
+            rieee[j] = ieee;
             continue;
         }
 
-//
-//  Set Sign bit (bit 31 - leftmost bit)
-//
-        if (a[j] < 0.0) {
+        //  Set Sign bit (bit 31 - leftmost bit).
+        if (a[j] < 0.0)
+        {
             ieee= 1 << 31;
             atemp=-1.0*a[j];
         }
-        else {
+        else
+        {
             ieee= 0 << 31;
             atemp=a[j];
         }
-        //printf("sign %ld %x \n",ieee,ieee);
-//
-//  Determine exponent n with base 2
-//
-        if ( atemp >= 1.0 ) {
+
+        //  Determine exponent n with base 2.
+        if (atemp >= 1.0)
+        {
             n = 0;
-            while ( int_power(2.0,n+1) <= atemp ) {
+            while (int_power(2.0,n+1) <= atemp)
+            {
                 n++;
             }
         }
-        else {
+        else
+        {
             n = -1;
-            while ( int_power(2.0,n) > atemp ) {
+            while (int_power(2.0,n) > atemp)
                 n--;
-            }
         }
-        iexp=n+127;
-        if (n >  127) iexp=255;     // overflow
-        if (n < -127) iexp=0;
-        //printf("exp %ld %ld \n",iexp,n);
+        iexp = n + 127;
+        if (n >  127)
+            iexp = 255;     // overflow
+        if (n < -127)
+            iexp = 0;
+
         //      set exponent bits ( bits 30-23 )
         ieee = ieee | ( iexp << 23 );
-//
-//  Determine Mantissa
-//
-        if (iexp != 255) {
+
+        //  Determine Mantissa
+        if (iexp != 255)
+        {
             if (iexp != 0)
-                atemp=(atemp/int_power(2.0,n))-1.0;
+                atemp = (atemp / int_power(2.0, n)) - 1.0;
             else
-                atemp=atemp*two126;
-            imant=(g2int)rint(atemp*two23);
+                atemp = atemp * two126;
+            imant = (g2int)rint(atemp * two23);
         }
-        else {
-            imant=0;
+        else
+        {
+            imant = 0;
         }
-        //printf("mant %ld %x \n",imant,imant);
+
         //      set mantissa bits ( bits 22-0 )
         ieee = ieee | imant;
-//
-//  Transfer IEEE bit string to rieee array
-//
-        rieee[j]=ieee;
 
+        //  Transfer IEEE bit string to rieee array
+        rieee[j] = ieee;
     }
 
     return;
-
 }

--- a/src/mkieee.c
+++ b/src/mkieee.c
@@ -1,10 +1,10 @@
 /** @file
  * @author Stephen Gilbert @date 2002-10-29
  */
+
 #include <stdlib.h>
 #include <math.h>
 #include "grib2_int.h"
-
 
 /**
  * This subroutine stores a list of real values in 32-bit IEEE

--- a/src/mkieee.c
+++ b/src/mkieee.c
@@ -3,7 +3,7 @@
  */
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 
 /**

--- a/src/pack_gp.c
+++ b/src/pack_gp.c
@@ -254,10 +254,10 @@ typedef g2int logical; /**< Logical type. */
  */
 int
 pack_gp(integer *kfildo, integer *ic, integer *nxy,
-        integer *is523, integer *minpk, integer *inc, integer *missp, integer
-        *misss, integer *jmin, integer *jmax, integer *lbit, integer *nov,
-        integer *ndg, integer *lx, integer *ibit, integer *jbit, integer *
-        kbit, integer *novref, integer *lbitref, integer *ier)
+        integer *is523, integer *minpk, integer *inc, integer *missp, integer *misss,
+        integer *jmin, integer *jmax, integer *lbit, integer *nov,
+        integer *ndg, integer *lx, integer *ibit, integer *jbit, integer *kbit,
+        integer *novref, integer *lbitref, integer *ier)
 {
     /* Initialized data */
 

--- a/src/pack_gp.c
+++ b/src/pack_gp.c
@@ -4,7 +4,7 @@
 
 /*#include "f2c.h"*/
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 typedef g2int integer; /**< Integer type. */
 typedef g2int logical; /**< Logical type. */
 #define TRUE_ (1) /**< True. */

--- a/src/pdstemplates.c
+++ b/src/pdstemplates.c
@@ -19,7 +19,7 @@
  */
 
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 #include "pdstemplates.h"
 
 /**

--- a/src/pdstemplates.h
+++ b/src/pdstemplates.h
@@ -42,7 +42,7 @@
 
 #ifndef _pdstemplates_H
 #define _pdstemplates_H
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define MAXPDSTEMP 47 /**< Maximum number of templates. */
 #define MAXPDSMAPLEN 200 /**< Maximum template map length. */

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -6,9 +6,6 @@
 #include <math.h>
 #include "grib2_int.h"
 
-int enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
-            unsigned char *pngbuf);
-
 /**
  * This subroutine packs up a data field into PNG image format. After
  * the data field is scaled, and the reference value is subtracted

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -4,7 +4,7 @@
  */
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 int enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
             unsigned char *pngbuf);

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -8,9 +8,6 @@
 #include <stdlib.h>
 #include "grib2_int.h"
 
-int dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
-            unsigned char *cout);
-
 /**
  * This subroutine unpacks a data field that was packed into a PNG
  * image format using info from the GRIB2 Data Representation Template

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 int dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
             unsigned char *cout);

--- a/src/rdieee.c
+++ b/src/rdieee.c
@@ -3,7 +3,7 @@
  * point format.
  * @author Stephen Gilbert @date 2002-10-25
  */
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine reads a list of real values in 32-bit IEEE floating

--- a/src/rdieee.c
+++ b/src/rdieee.c
@@ -17,7 +17,8 @@
  *
  * @author Stephen Gilbert @date 2002-10-25
  */
-void rdieee(g2int *rieee,g2float *a,g2int num)
+void
+rdieee(g2int *rieee, g2float *a, g2int num)
 {
 
     g2int  j;

--- a/src/reduce.c
+++ b/src/reduce.c
@@ -8,7 +8,6 @@
  * @date November 2001
  */
 
-/*#include "f2c.h"*/
 #include <stdlib.h>
 #include "grib2_int.h"
 typedef g2int integer; /**< Integer type. */

--- a/src/reduce.c
+++ b/src/reduce.c
@@ -10,7 +10,7 @@
 
 /*#include "f2c.h"*/
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 typedef g2int integer; /**< Integer type. */
 typedef g2float real; /**< Float type. */
 

--- a/src/seekgb.c
+++ b/src/seekgb.c
@@ -4,7 +4,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subprogram searches a file for the next GRIB Message. The

--- a/src/seekgb.c
+++ b/src/seekgb.c
@@ -29,13 +29,14 @@
  *
  * @author Stephen Gilbert @date 2002-10-28
  */
-void seekgb(FILE *lugb,g2int iseek,g2int mseek,g2int *lskip,g2int *lgrib)
+void
+seekgb(FILE *lugb, g2int iseek, g2int mseek, g2int *lskip,
+       g2int *lgrib)
 {
     g2int k,k4,ipos,nread,lim,start,vers,lengrib;
     int    end;
     unsigned char *cbuf;
 
-// - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     *lgrib=0;
     cbuf=(unsigned char *)malloc(mseek);
     nread=mseek;

--- a/src/simpack.c
+++ b/src/simpack.c
@@ -5,7 +5,7 @@
 
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine packs up a data field using the simple packing

--- a/src/simunpack.c
+++ b/src/simunpack.c
@@ -3,7 +3,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks a data field that was packed using a simple

--- a/src/specpack.c
+++ b/src/specpack.c
@@ -7,7 +7,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine packs a spectral data field using the complex

--- a/src/specunpack.c
+++ b/src/specunpack.c
@@ -6,7 +6,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <math.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 /**
  * This subroutine unpacks a spectral data field that was packed using

--- a/tests/tst_com.c
+++ b/tests/tst_com.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define DATA_LEN 4
 #define PACKED_LEN 200

--- a/tests/tst_drstemplates.c
+++ b/tests/tst_drstemplates.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define G2C_ERROR 2
 

--- a/tests/tst_g2_addgrid.c
+++ b/tests/tst_g2_addgrid.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21

--- a/tests/tst_gbits.c
+++ b/tests/tst_gbits.c
@@ -5,7 +5,7 @@
  */
 
 #include <stdio.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define G2C_ERROR 2
 

--- a/tests/tst_gridtemplates.c
+++ b/tests/tst_gridtemplates.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define G2C_ERROR 2
 

--- a/tests/tst_pdstemplates.c
+++ b/tests/tst_pdstemplates.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define G2C_ERROR 2
 

--- a/tests/tst_simpack.c
+++ b/tests/tst_simpack.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define DATA_LEN 4
 #define PACKED_LEN 40


### PR DESCRIPTION
Fixes #192 
Fixes #141

In this PR I split the header file into an external and internal header. THe internal header will contain prototypes which are part of the library but not part of the public API.

Also changed preprocessor define G2_VERSION so it no longer includes library name - just the version.