### PR TITLE
Add a function to check for "GRIB" at the beginning of the message

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,4 +50,5 @@ set(c_src
     ${CMAKE_CURRENT_SOURCE_DIR}/simunpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/specpack.c
     ${CMAKE_CURRENT_SOURCE_DIR}/specunpack.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/util.c
     PARENT_SCOPE)

--- a/src/g2_addgrid.c
+++ b/src/g2_addgrid.c
@@ -70,34 +70,20 @@ g2int
 g2_addgrid(unsigned char *cgrib, g2int *igds, g2int *igdstmpl, g2int *ideflist,
            g2int idefnum)
 {
-    static unsigned char G = 0x47;       /* 'G' */
-    static unsigned char R = 0x52;       /* 'R' */
-    static unsigned char I = 0x49;       /* 'I' */
-    static unsigned char B = 0x42;       /* 'B' */
-    static unsigned char seven = 0x37;   /* '7' */
-
     static g2int one = 1, three = 3, miss = 65535;
     g2int lensec3, iofst, ibeg, lencurr, len;
     g2int i, j, temp, ilen, isecnum, nbits;
     gtemplate *mapgrid = 0;
+    int ret;
 
-    /* Check to see if beginning of GRIB message exists. */
-    if (cgrib[0] != G || cgrib[1] != R || cgrib[2] != I || cgrib[3] != B)
+    /* Check for GRIB header and terminator. Translate the error codes
+     * to the legacy G2 error codes. */
+    if ((ret = g2c_check_msg(cgrib, &lencurr, 1)))
     {
-        printf("g2_addgrid: GRIB not found in given message.\n");
-        printf("g2_addgrid: Call to routine gribcreate required to initialize GRIB messge.\n");
-        return G2_ADD_MSG_INIT;
-    }
-
-    /* Get current length of GRIB message. */
-    gbit(cgrib, &lencurr, 96, 32);
-
-    /* Check to see if GRIB message is already complete. */
-    if (cgrib[lencurr - 4] == seven && cgrib[lencurr - 3] == seven &&
-        cgrib[lencurr - 2] == seven && cgrib[lencurr - 1] == seven)
-    {
-        printf("g2_addgrid: GRIB message already complete.  Cannot add new section.\n");
-        return G2_ADD_MSG_COMPLETE;
+        if (ret == G2C_NOT_GRIB)
+            return G2_ADD_MSG_INIT;
+        if (ret == G2C_MSG_COMPLETE)
+            return G2_ADD_MSG_COMPLETE;
     }
 
     /* Loop through all current sections of the GRIB message to find

--- a/src/g2_addlocal.c
+++ b/src/g2_addlocal.c
@@ -39,34 +39,19 @@
 g2int
 g2_addlocal(unsigned char *cgrib, unsigned char *csec2, g2int lcsec2)
 {
-    static unsigned char G = 0x47;       /* 'G' */
-    static unsigned char R = 0x52;       /* 'R' */
-    static unsigned char I = 0x49;       /* 'I' */
-    static unsigned char B = 0x42;       /* 'B' */
-    static unsigned char seven = 0x37;   /* '7' */
-
     static g2int two = 2;
     g2int j, k, lensec2, iofst, ibeg, lencurr, ilen, len, istart;
     g2int isecnum;
-    g2int ierr = 0;
+    int ret;
 
-    /* Check to see if beginning of GRIB message exists. */
-    if (cgrib[0] != G || cgrib[1] != R || cgrib[2] != I || cgrib[3] != B)
+    /* Check for GRIB header and terminator. Translate the error codes
+     * to the legacy G2 error codes. */
+    if ((ret = g2c_check_msg(cgrib, &lencurr, 1)))
     {
-        printf("g2_addlocal: GRIB not found in given message.\n");
-        printf("g2_addlocal: Call to routine g2_create required to initialize GRIB messge.\n");
-        return G2_ADD_MSG_INIT;
-    }
-
-    /* Get current length of GRIB message. */
-    gbit(cgrib, &lencurr, 96, 32);
-
-    /* Check to see if GRIB message is already complete. */
-    if (cgrib[lencurr - 4] == seven && cgrib[lencurr - 3] == seven &&
-        cgrib[lencurr - 2] == seven && cgrib[lencurr - 1] == seven)
-    {
-        printf("g2_addlocal: GRIB message already complete.  Cannot add new section.\n");
-        return G2_ADD_MSG_COMPLETE;
+        if (ret == G2C_NOT_GRIB)
+            return G2_ADD_MSG_INIT;
+        if (ret == G2C_MSG_COMPLETE)
+            return G2_ADD_MSG_COMPLETE;
     }
 
     /*  Loop through all current sections of the GRIB message to find

--- a/src/g2_gribend.c
+++ b/src/g2_gribend.c
@@ -38,21 +38,18 @@ g2int g2_gribend(unsigned char *cgrib)
 {
     g2int iofst, lencurr, len, ilen, isecnum;
     g2int lengrib;
-    static unsigned char G = 0x47;       /* 'G' */
-    static unsigned char R = 0x52;       /* 'R' */
-    static unsigned char I = 0x49;       /* 'I' */
-    static unsigned char B = 0x42;       /* 'B' */
-    static unsigned char seven = 0x37;   /* '7' */
+    unsigned char seven = 0x37;   /* '7' */
+    int ret;
 
-    /* Check to see if beginning of GRIB message exists. */
-    if (cgrib[0] != G || cgrib[1] != R || cgrib[2] != I || cgrib[3] != B)
+    /* Check for GRIB header and terminator. Translate the error codes
+     * to the legacy G2 error codes. */
+    if ((ret = g2c_check_msg(cgrib, &lencurr, 1)))
     {
-        printf("g2_gribend: GRIB not found in given message.\n");
-        return G2_GRIBEND_MSG_INIT;
+        if (ret == G2C_NOT_GRIB)
+            return G2_ADD_MSG_INIT;
+        if (ret == G2C_MSG_COMPLETE)
+            return G2_ADD_MSG_COMPLETE;
     }
-
-    /* Get current length of GRIB message. */
-    gbit(cgrib, &lencurr, 96, 32);
 
     /*  Loop through all current sections of the GRIB message to find
      *  the last section number. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -317,4 +317,9 @@ g2int g2_gribend(unsigned char *cgrib);
 #define G2_ADDFIELD_ERR -10       /**< In g2_addfield() error packing data field. */
 #define G2_ADDGRID_BAD_GDT -5     /**< In g2_addgrid() Could not find requested Grid Definition Template. */
 
+/* These are the new error codes. */
+#define G2C_NO_ERROR 0       /**< No error. */
+#define G2C_NOT_GRIB -50     /**< GRIB header not found. */
+#define G2C_MSG_COMPLETE -51 /**< GRIB message already complete. */
+
 #endif  /*  _grib2_H  */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -15,6 +15,7 @@
 
 #include <stdio.h>
 #include <stdint.h>
+#include <assert.h>
 #include "grib2.h"
 
 #define ALOG2 (0.69314718) /**< ln(2.0) */
@@ -83,5 +84,8 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
             g2int *jmin, g2int *jmax, g2int *lbit, g2int *nov,
             g2int *ndg, g2int *lx, g2int *ibit, g2int *jbit, g2int *kbit,
             g2int *novref, g2int *lbitref, g2int *ier);
+
+/* Check the message header and check for message termination. */
+int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 #endif  /*  _grib2_int_H  */

--- a/src/util.c
+++ b/src/util.c
@@ -1,0 +1,57 @@
+/** 
+ * @file
+ * @brief Internal utility functions for the g2c library.
+ * @author Ed Hartnett @date Nov 11, 2021
+ */
+
+#include "grib2_int.h"
+
+/**
+ * Check for 'GRIB' at the beginning of a GRIB message, and check to
+ * see if the message is already terminated with '7777'.
+ *
+ * @param cgrib Buffer that contains the GRIB message.
+ * @param lencurr Pointer that gets the length of the GRIB message.
+ * @param verbose If non-zero, print any error messages to stdout.
+ *
+ * @return
+ * - ::G2C_NO_ERROR No error.
+ * - ::G2C_NOT_GRIB GRIB header not found.
+ * - ::G2C_MSG_COMPLETE GRIB message already complete.
+ *
+ * @author Ed Hartnett @date Nov 11, 2021
+ */
+int
+g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose)
+{
+    unsigned char G = 0x47;       /* 'G' */
+    unsigned char R = 0x52;       /* 'R' */
+    unsigned char I = 0x49;       /* 'I' */
+    unsigned char B = 0x42;       /* 'B' */
+    unsigned char seven = 0x37;   /* '7' */
+
+    assert(cgrib && lencurr);
+
+    /* Check to see if beginning of GRIB message exists. */
+    if (cgrib[0] != G || cgrib[1] != R || cgrib[2] != I || cgrib[3] != B)
+    {
+        if (verbose)
+            printf("GRIB not found in given message. A call to routine g2_create() "
+                   "is required to to initialize GRIB messge.\n");
+        return G2C_NOT_GRIB;
+    }
+
+    /* Get current length of GRIB message. */
+    gbit(cgrib, lencurr, 96, 32);
+
+    /* Check to see if GRIB message is already complete. */
+    if (cgrib[*lencurr - 4] == seven && cgrib[*lencurr - 3] == seven &&
+        cgrib[*lencurr - 2] == seven && cgrib[*lencurr - 1] == seven)
+    {
+        if (verbose)
+            printf("GRIB message already complete.  Cannot add new section.\n");
+        return G2C_MSG_COMPLETE;
+    }
+
+    return G2C_NO_ERROR;
+}


### PR DESCRIPTION
Fixes #172
Part of #173

There are numerous places where we check for "GRIB" at the beginning of the message, and "7777" at the end of the message.

I have added function g2c_check_message() to handle this, and instead of checking this everywhere, we just call g2c_check_message().

Also starting to use new error codes that will go with the new g2c API. These error codes will apply across the whole library, not vary from function to function.