### PR TITLE
fixed remaining warnings, turned on Werror in CI so no more code warnings will be permitted

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -49,7 +49,7 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper -DENABLE_DOCS=On -DENABLE_OpenJPEG=ON -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address -Wall" ..
+        cmake -DJasper_ROOT=~/Jasper -DENABLE_DOCS=On -DENABLE_OpenJPEG=ON -DCMAKE_C_FLAGS="-g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address -Wall -Werror" ..
         make -j2
 
     - name: test

--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -86,7 +86,7 @@ dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld)
     if (image->numcmpts_ != 1)
     {
         printf("dec_jpeg2000: Found color image.  Grayscale expected.\n");
-        return (-5);
+        return -5;
     }
 
     /* Create a data matrix of grayscale image values decoded from the

--- a/src/enc_png.c
+++ b/src/enc_png.c
@@ -60,8 +60,6 @@ user_write_data(png_structp png_ptr, png_bytep data, png_uint_32 length)
  */
 void user_flush_data(png_structp png_ptr)
 {
-    int *do_nothing;
-    do_nothing = NULL;
 }
 
 /**

--- a/src/g2_addlocal.c
+++ b/src/g2_addlocal.c
@@ -48,7 +48,6 @@ g2_addlocal(unsigned char *cgrib, unsigned char *csec2, g2int lcsec2)
     static g2int two = 2;
     g2int j, k, lensec2, iofst, ibeg, lencurr, ilen, len, istart;
     g2int isecnum;
-    g2int ierr = 0;
 
     /* Check to see if beginning of GRIB message exists. */
     if (cgrib[0] != G || cgrib[1] != R || cgrib[2] != I || cgrib[3] != B)

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -48,7 +48,7 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
             fprintf(stderr, "Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
             return(1);
         }
-        dec_jpeg2000(cpack, len, ifld);
+        dec_jpeg2000((char *)cpack, len, ifld);
         for (j = 0; j < ndpts; j++)
             fld[j] = (((g2float)ifld[j] * bscale) + ref) * dscale;
         free(ifld);

--- a/src/misspack.c
+++ b/src/misspack.c
@@ -47,7 +47,7 @@ misspack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
     static g2int zero = 0;
     g2int *gref, *gwidth, *glen;
     g2int glength, grpwidth;
-    g2int i, n, iofst, imin, ival1, ival2, isd, minsd, nbitsd;
+    g2int i, n, iofst, imin, ival1, ival2, isd, minsd, nbitsd = 0;
     g2int nbitsgref, left, iwmax, ngwidthref, nbitsgwidth, ilmax;
     g2int nglenref, nglenlast, nbitsglen;
     g2int j, missopt, nonmiss, itemp, maxorig, nbitorig, miss1, miss2;
@@ -202,8 +202,8 @@ misspack(g2float *fld, g2int ndpts, g2int idrsnum, g2int *idrstmpl,
             nbitsd = nbitorig;
 
         /*   increase number of bits to even multiple of 8 (octet) */
-        if ((nbitsd%8) != 0)
-            nbitsd = nbitsd+(8-(nbitsd%8));
+        if (nbitsd % 8)
+            nbitsd = nbitsd + (8 - (nbitsd % 8));
 
         /*  Store extra spatial differencing info into the packed data
          *  section. */

--- a/src/reduce.c
+++ b/src/reduce.c
@@ -104,7 +104,8 @@ reduce(integer *kfildo, integer *jmin, integer *jmax,
     static real pimp;
     static integer move, novl;
     static char cfeed[1];
-    static integer nboxj[31], lxnkp, iorigb, ibxx2m1, movmin,
+    /* static integer nboxj[31]; */
+    static integer lxnkp, iorigb, ibxx2m1, movmin,
         ntotbt[31], ntotpr, newboxt;
     integer *newbox, *newboxp;
 
@@ -140,7 +141,7 @@ reduce(integer *kfildo, integer *jmin, integer *jmax,
 
     for (j = 1; j <= 31; ++j) {
         ntotbt[j - 1] = 999999999;
-        nboxj[j - 1] = 0;
+        /* nboxj[j - 1] = 0; */
 /* L112: */
     }
 
@@ -214,7 +215,7 @@ reduce(integer *kfildo, integer *jmin, integer *jmax,
             ;
         }
 
-        nboxj[j - 1] = newboxt;
+        /* nboxj[j - 1] = newboxt; */
         ntotpr = ntotbt[j];
         ntotbt[j - 1] = (*ibit + *jbit) * (*lx + newboxt) + j * (*lx +
                                                                  newboxt);


### PR DESCRIPTION
Fixes #52 

Fix remaining warnings in code with gcc -Wall.

Turn on warning checking in CI with -Werror.