### PR TITLE
Fix tst_jpeg.c

### DIFF
--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -19,7 +19,7 @@
  *
  * ### Program History Log
  * Date | Programmer | Comments
- * -----|------------|--------- 
+ * -----|------------|---------
  * 2002-12-02 | Gilbert | Initial
  * 2004-12-16 | Gilbert | Added retry argument allowing increased guard bits.
  *
@@ -41,9 +41,7 @@
  *
  * @return
  * - > 0 = Length in bytes of encoded JPEG2000 code stream
- * - -3 = Error decode jpeg2000 code stream.
- * - -5 = decoded image had multiple color components. Only grayscale
- *    is expected.
+ * - -3 = Error encode jpeg2000 code stream.
  *
  * @note Requires JasPer Software version 1.500.4 or 1.700.2 or later.
  *
@@ -63,7 +61,7 @@ enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
     /* Set lossy compression options, if requested. */
     if (ltype != 1)
         opts[0] = (char)0;
-    else 
+    else
         snprintf(opts,MAXOPTSSIZE,"mode=real\nrate=%f",1.0/(float)ratio);
 
     if (retry == 1)  /* option to increase number of guard bits */

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -26,22 +26,20 @@ int
 main()
 {
     printf("Testing JPEG functions.\n");
-    printf("Testing enc_jpeg2000() call...");
+    printf("Testing enc_jpeg2000()/dec_jpeg2000() call...");
     {
-        unsigned char data[4] = {1, 2, 3, 4};
+        unsigned char data[DATA_LEN] = {1, 2, 3, 4};
         g2int width = 2, height = 2, nbits = 4;
-        g2int ltype = 0, ratio = 0, retry = 0, jpclen = 200;
-        char outjpc[200];
-        g2int outfld[4];
-        /* int i; */
+        g2int ltype = 0, ratio = 0, retry = 0, jpclen = PACKED_LEN;
+        char outjpc[PACKED_LEN];
+        g2int outfld[DATA_LEN];
+        int i;
         int ret;
 
         /* Encode some data. */
-        /* 168 on Linux, but 133 on windows? */
         if ((ret = enc_jpeg2000(data, width, height, nbits, ltype,
-                                ratio, retry, outjpc, jpclen)) < 133)
+                                ratio, retry, outjpc, jpclen)) < 0)
         {
-            printf("%d\n", ret);
             return G2C_ERROR;
         }
 
@@ -49,13 +47,11 @@ main()
         if ((ret = dec_jpeg2000(outjpc, jpclen, outfld)))
             return G2C_ERROR;
 
-        /* Not sure why we don't get the same answers... */
-        /* for (i = 0; i < 4; i++) */
-        /* { */
-        /*     printf("%d\n", outjpc[i]); */
-        /*     /\* if (outjpc[i] != data[i]) *\/ */
-        /*     /\*     return G2C_ERROR; *\/ */
-        /* } */
+        for (i = 0; i < 4; i++)
+        {
+            if (outfld[i] != data[i])
+                return G2C_ERROR;
+        }
     }
     printf("ok!\n");
     printf("Testing jpcpack()/jpcunpack() call...");

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -47,7 +47,7 @@ main()
         if ((ret = dec_jpeg2000(outjpc, jpclen, outfld)))
             return G2C_ERROR;
 
-        for (i = 0; i < 4; i++)
+        for (i = 0; i < DATA_LEN; i++)
         {
             if (outfld[i] != data[i])
                 return G2C_ERROR;


### PR DESCRIPTION
Fix the first test in tst_jpeg.c to actually compare the input array passed to enc_jpeg2000 function with the output array from dec_jpeg2000.

Fixes #226