### PR TITLE
adding link to previous versions of docs

### DIFF
--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -1,6 +1,10 @@
 @mainpage
 
-## NCEPLIBS-g2c
+## Documentation for Previous Versions of NCEPLIBS-g2c
+
+* [NCEPLIBS-g2c Version 1.6.4](ver-1.6.4/index.html)
+
+## Introduction
 
 This document briefly describes the routines available for
 encoding/decoding GRIB Edition 2 (GRIB2) messages with the


### PR DESCRIPTION
Fixes #126 

Now we can support old versions of the documentation too.