### PR TITLE
Add capability to handle PNG compression of double

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -28,6 +28,10 @@ jobs:
             options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
           }
         - {
+            name: "png_on jasper_on openjpeg_on",
+            options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=ON -DJasper_ROOT=~/Jasper"
+          }
+        - {
             name: "png_off jasper_off openjpeg_on",
             options: "-DUSE_PNG=OFF -DUSE_Jasper=OFF -DUSE_OpenJPEG=ON "
           }
@@ -98,6 +102,7 @@ jobs:
         cd g2c
         mkdir build
         cd build
+        ls -l ~/Jasper/lib
         cmake ${{ matrix.config.options }} ..
         make -j2
 

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -6,6 +6,9 @@ jobs:
     runs-on: macos-latest
     env:
       CC: clang
+      LDFLAGS: "-L/usr/local/opt/jpeg/lib"
+      CPPFLAGS: "-I/usr/local/opt/jpeg/include"
+      PKG_CONFIG_PATH: "/usr/local/opt/jpeg/lib/pkgconfig"      
 
     strategy:
       fail-fast: false
@@ -19,18 +22,14 @@ jobs:
             name: "png_on jasper_off openjpeg_off",
             options: "-DUSE_PNG=ON  -DUSE_Jasper=OFF -DUSE_OpenJPEG=OFF"
           }
-        - {
-            name: "png_off jasper_on openjpeg_off",
-            options: "-DUSE_PNG=OFF -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
-          }
-        - {
-            name: "png_on jasper_on openjpeg_off",
-            options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
-          }
-        - {
-            name: "png_on jasper_on openjpeg_on",
-            options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=ON -DJasper_ROOT=~/Jasper"
-          }
+        # - {
+        #     name: "png_off jasper_on openjpeg_off",
+        #     options: "-DUSE_PNG=OFF -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
+        #   }
+        # - {
+        #     name: "png_on jasper_on openjpeg_off",
+        #     options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
+        #   }
         - {
             name: "png_off jasper_off openjpeg_on",
             options: "-DUSE_PNG=OFF -DUSE_Jasper=OFF -DUSE_OpenJPEG=ON "
@@ -47,7 +46,7 @@ jobs:
         sudo rm -rf /Library/Frameworks/Mono.framework
 
         brew update
-        brew install doxygen openjpeg 
+        brew install openjpeg libjpeg
 
     - name: checkout-jasper
       uses: actions/checkout@v2
@@ -61,7 +60,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/Jasper
-        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}-macOS-1
+        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}-macOS
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -102,8 +101,8 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        ls -l ~/Jasper/lib
-        cmake ${{ matrix.config.options }} ..
+        ls -l /usr/local/opt/jpeg/lib
+        cmake --trace ${{ matrix.config.options }} -DCMAKE_C_FLAGS="-L/usr/local/opt/jpeg/lib" -DCMAKE_CPP_FLAGS="-L/usr/local/opt/jpeg/include" ..
         make -j2
 
     - name: test

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -61,7 +61,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/Jasper
-        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}-macOS
+        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}-macOS-1
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -241,6 +241,12 @@ g2int g2_addfield(unsigned char *cgrib, g2int ipdsnum, g2int *ipdstmpl,
                   g2float *fld, g2int ngrdpts, g2int ibmap, g2int *bmap);
 g2int g2_gribend(unsigned char *cgrib);
 
+/* Compression. */
+void pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
+             unsigned char *cpack, g2int *lcpack);
+g2int pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                g2float *fld);
+
 /* Error codes for G2 API. */
 #define G2_NO_ERROR 0             /**< Function succeeded. */
 #define G2_CREATE_GRIB_VERSION -1 /**< Wrong GRIB version for g2_create(), must be 2. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -246,6 +246,10 @@ void pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack);
 g2int pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 g2float *fld);
+void pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+             unsigned char *cpack, g2int *lcpack);
+g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                double *fld);
 
 /* Error codes for G2 API. */
 #define G2_NO_ERROR 0             /**< Function succeeded. */

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -33,6 +33,7 @@
  output. Data values assumed to be reals.
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
+ * @return void
  *
  * @author Stephen Gilbert @date 2003-08-27
  * @author Ed Hartnett
@@ -55,7 +56,9 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     bscale = int_power(2.0, -idrstmpl[1]);
     dscale = int_power(10.0, idrstmpl[2]);
 
-    /* Find max and min values in the data. */
+    /* Find max and min values in the data. Either rmax and rmin will
+     * be used (if fld_is_double is not true), or rmaxd and rmind will
+     * be used (if fld_is_double is true). */
     rmaxd = dfld[0];
     rmind = dfld[0];
     rmax = ffld[0];

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -15,10 +15,11 @@
  * PNG encoder. It also fills in GRIB2 Data Representation Template
  * 5.41 or 5.40010 with the appropriate values.
  *
- * @param fld Contains the data values to pack.
+ * @param fld Pointer to array of float or double that contains the
+ * data values to pack.
  * @param fld_is_double If non-zero, then fld is double, otherwise float.
- * @param width number of points in the x direction.
- * @param height number of points in the y direction.
+ * @param width Number of points in the x direction.
+ * @param height Number of points in the y direction.
  * @param idrstmpl Contains the array of values for Data
  * Representation
  * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml)
@@ -34,6 +35,7 @@
  * @param lcpack length of packed field cpack.
  *
  * @author Stephen Gilbert @date 2003-08-27
+ * @author Ed Hartnett
  */
 static void
 pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrstmpl, 
@@ -190,9 +192,10 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
  * PNG encoder. It also fills in GRIB2 Data Representation Template
  * 5.41 or 5.40010 with the appropriate values.
  *
- * @param fld Contains the data values to pack.
- * @param width number of points in the x direction.
- * @param height number of points in the y direction.
+ * @param fld Pointer to array of float that contains the data values
+ * to pack.
+ * @param width Number of points in the x direction.
+ * @param height Number of points in the y direction.
  * @param idrstmpl Contains the array of values for Data
  * Representation
  * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml)
@@ -208,6 +211,7 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
  * @param lcpack length of packed field cpack.
  *
  * @author Stephen Gilbert @date 2003-08-27
+ * @author Ed Hartnett
  */
 void
 pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl, 
@@ -224,9 +228,10 @@ pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
  * PNG encoder. It also fills in GRIB2 Data Representation Template
  * 5.41 or 5.40010 with the appropriate values.
  *
- * @param fld Contains the data values to pack.
- * @param width number of points in the x direction.
- * @param height number of points in the y direction.
+ * @param fld Pointer to array of double that contains the data values
+ * to pack.
+ * @param width Number of points in the x direction.
+ * @param height Number of points in the y direction.
  * @param idrstmpl Contains the array of values for Data
  * Representation
  * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml)
@@ -242,6 +247,7 @@ pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @param lcpack length of packed field cpack.
  *
  * @author Stephen Gilbert @date 2003-08-27
+ * @author Ed Hartnett
  */
 void
 pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl, 

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -56,10 +56,12 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     dscale = int_power(10.0, idrstmpl[2]);
 
     /* Find max and min values in the data. */
+    rmaxd = dfld[0];
+    rmind = dfld[0];
+    rmax = ffld[0];
+    rmin = ffld[0];
     if (fld_is_double)
     {
-	rmaxd = dfld[0];
-	rmind = dfld[0];
 	for (j = 1; j < ndpts; j++)
 	{
 	    if (dfld[j] > rmaxd)
@@ -71,8 +73,6 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     }
     else
     {
-	rmax = ffld[0];
-	rmin = ffld[0];
 	for (j = 1; j < ndpts; j++)
 	{
 	    if (ffld[j] > rmax)

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -86,7 +86,7 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     /* If max and min values are not equal, pack up field. If they are
      * equal, we have a constant field, and the reference value (rmin)
      * is the value for each point in the field and set nbits to 0. */
-    if ((fld_is_double && rmind != rmaxd) || (!fld_is_double && rmin != rmax)   &&  maxdif != 0)
+    if (((fld_is_double && rmind != rmaxd) || (!fld_is_double && rmin != rmax)) && maxdif != 0)
     {
         ifld = malloc(ndpts * sizeof(g2int));
 

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -35,8 +35,7 @@
  * @param lcpack length of packed field cpack.
  * @return void
  *
- * @author Stephen Gilbert @date 2003-08-27
- * @author Ed Hartnett
+ * @author Ed Hartnett @date Aug 8, 2022
  */
 static void
 pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrstmpl, 
@@ -249,8 +248,7 @@ pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
  *
- * @author Stephen Gilbert @date 2003-08-27
- * @author Ed Hartnett
+ * @author Ed Hartnett @date Aug 8, 2022
  */
 void
 pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl, 

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -14,15 +14,19 @@
  * 5.41 or 5.40010.
  *
  * @param cpack The packed data field (character*1 array).
- * @param len length of packed field cpack().
+ * @param len The length of packed field cpack().
  * @param idrstmpl Pointer to array of values for Data Representation
- * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml) or 5.40010.
+ * [Template
+ * 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml)
+ * or 5.40010.
  * @param ndpts The number of data values to unpack.
- * @param fld Contains the unpacked data values.
+ * @param fld Pointer that will get the unpacked data values.
+ * @param fld_is_double If non-zero, then fld will get data as double,
+ * otherwise float.
  *
  * @return 0 for success, 1 for memory allocation error.
  *
- * @author Stephen Gilbert @date 2003-08-27
+ * @author Stephen Gilbert, Ed Hartnett @date Aug 8, 2022
  */
 static g2int
 pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
@@ -92,6 +96,7 @@ pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @return 0 for success, 1 for memory allocation error.
  *
  * @author Stephen Gilbert @date 2003-08-27
+ * @author Ed Hartnett
  */
 g2int
 pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
@@ -114,7 +119,7 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  *
  * @return 0 for success, 1 for memory allocation error.
  *
- * @author Stephen Gilbert @date 2003-08-27
+ * @author Ed Hartnett @date Aug 8, 2022
  */
 g2int
 pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -24,14 +24,15 @@
  *
  * @author Stephen Gilbert @date 2003-08-27
  */
-g2int
-pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-          g2float *fld)
+static g2int
+pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+	      void *fld, int fld_is_double)
 {
     g2int *ifld;
     g2int j, nbits, width, height;
     g2float ref, bscale, dscale;
     unsigned char *ctemp;
+    float *ffld = fld;
 
     rdieee(idrstmpl, &ref, 1);
     bscale = int_power(2.0, idrstmpl[1]);
@@ -52,15 +53,61 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
         dec_png(cpack, &width, &height, ctemp);
         gbits(ctemp, ifld, 0, nbits, 0, ndpts);
         for (j = 0; j < ndpts; j++)
-            fld[j] = (((g2float)ifld[j] * bscale) + ref) * dscale;
+            ffld[j] = (((g2float)ifld[j] * bscale) + ref) * dscale;
         free(ctemp);
         free(ifld);
     }
     else
     {
         for (j = 0; j < ndpts; j++)
-            fld[j] = ref;
+            ffld[j] = ref;
     }
 
     return 0;
+}
+
+/**
+ * This subroutine unpacks a data field that was packed into a PNG
+ * image format using info from the GRIB2 Data Representation Template
+ * 5.41 or 5.40010.
+ *
+ * @param cpack The packed data field (character*1 array).
+ * @param len length of packed field cpack().
+ * @param idrstmpl Pointer to array of values for Data Representation
+ * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml) or 5.40010.
+ * @param ndpts The number of data values to unpack.
+ * @param fld Contains the unpacked data values.
+ *
+ * @return 0 for success, 1 for memory allocation error.
+ *
+ * @author Stephen Gilbert @date 2003-08-27
+ */
+g2int
+pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+          g2float *fld)
+{
+    return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+}
+
+/**
+ * This subroutine unpacks a data field that was packed into a PNG
+ * image format using info from the GRIB2 Data Representation Template
+ * 5.41 or 5.40010.
+ *
+ * @param cpack The packed data field (character*1 array).
+ * @param len length of packed field cpack().
+ * @param idrstmpl Pointer to array of values for Data Representation
+ * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml) or 5.40010.
+ * @param ndpts The number of data values to unpack.
+ * @param fld Contains the unpacked data values.
+ *
+ * @return 0 for success, 1 for memory allocation error.
+ *
+ * @author Stephen Gilbert @date 2003-08-27
+ */
+g2int
+pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+	   double *fld)
+{
+    return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);
 }

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -33,6 +33,7 @@ pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
     g2float ref, bscale, dscale;
     unsigned char *ctemp;
     float *ffld = fld;
+    double *dfld = fld;
 
     rdieee(idrstmpl, &ref, 1);
     bscale = int_power(2.0, idrstmpl[1]);
@@ -53,14 +54,24 @@ pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
         dec_png(cpack, &width, &height, ctemp);
         gbits(ctemp, ifld, 0, nbits, 0, ndpts);
         for (j = 0; j < ndpts; j++)
-            ffld[j] = (((g2float)ifld[j] * bscale) + ref) * dscale;
+	{
+	    if (fld_is_double)
+		dfld[j] = (((double)ifld[j] * bscale) + ref) * dscale;
+	    else
+		ffld[j] = (((g2float)ifld[j] * bscale) + ref) * dscale;
+	}
         free(ctemp);
         free(ifld);
     }
     else
     {
         for (j = 0; j < ndpts; j++)
-            ffld[j] = ref;
+	{
+	    if (fld_is_double)
+		dfld[j] = ref;
+	    else
+		ffld[j] = ref;
+	}
     }
 
     return 0;

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -11,6 +11,7 @@
 #define DATA_LEN 4
 #define PACKED_LEN 80
 #define G2C_ERROR 2
+#define EPSILON .0001
 
 /* Prototypes we are testing. */
 int enc_png(char *data, g2int width, g2int height, g2int nbits, char *pngbuf);
@@ -93,7 +94,7 @@ main()
 	for (i = 0; i < DATA_LEN; i++)
 	{
 	    /* printf("%g %g\n", fld[i], fld_in[i]); */
-	    if (fld[i] != fld_in[i])
+	    if (abs(fld[i] - fld_in[i]) > EPSILON)
 		return G2C_ERROR;
 	}
     }

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -131,6 +131,38 @@ main()
 	}
     }
     printf("ok!\n");
+    printf("Testing pngpackd()/pngunpackd() calls with different settings...");
+    {
+	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
+	double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
+	double fld_in[DATA_LEN];
+	unsigned char cpack[PACKED_LEN];
+	g2int lcpack;
+        /* See https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml */
+        g2int idrstmpl[5] = {
+            0, /* Reference value (R) (IEEE 32-bit floating-point value) */
+            0, /* Binary scale factor (E) */
+            1, /* Decimal scale factor (D) */
+            32, /* Number of bits required to hold the resulting scaled and referenced data values. (i.e. The depth of the grayscale image.) (see Note 2) */
+            0  /* Type of original field values (see Code Table 5.1) */
+        };
+	int i;
+
+	/* Pack the data. */
+	pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+
+	/* Unpack the data. */
+	if (pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+	    return G2C_ERROR;
+
+	for (i = 0; i < DATA_LEN; i++)
+	{
+	    /* printf("%g %g\n", fld[i], fld_in[i]); */
+	    if (abs(fld[i] - fld_in[i]) > EPSILON)
+		return G2C_ERROR;
+	}
+    }
+    printf("ok!\n");
     printf("Testing pngpack()/pngunpack() calls with constant data...");
     {
 	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
@@ -153,6 +185,38 @@ main()
 
 	/* Unpack the data. */
 	if (pngunpack(cpack, len, idrstmpl, ndpts, fld_in))
+	    return G2C_ERROR;
+
+	for (i = 0; i < DATA_LEN; i++)
+	{
+	    /* printf("%g %g\n", fld[i], fld_in[i]); */
+	    if (fld[i] != fld_in[i])
+		return G2C_ERROR;
+	}
+    }
+    printf("ok!\n");
+    printf("Testing pngpackd()/pngunpackd() calls with constant data...");
+    {
+	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
+	double fld[DATA_LEN] = {1.0, 1.0, 1.0, 1.0};
+	double fld_in[DATA_LEN];
+	unsigned char cpack[PACKED_LEN];
+	g2int lcpack;
+        /* See https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml */
+        g2int idrstmpl[5] = {
+            0, /* Reference value (R) (IEEE 32-bit floating-point value) */
+            0, /* Binary scale factor (E) */
+            1, /* Decimal scale factor (D) */
+            24, /* Number of bits required to hold the resulting scaled and referenced data values. (i.e. The depth of the grayscale image.) (see Note 2) */
+            0  /* Type of original field values (see Code Table 5.1) */
+        };
+	int i;
+
+	/* Pack the data. */
+	pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+
+	/* Unpack the data. */
+	if (pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
 	    return G2C_ERROR;
 
 	for (i = 0; i < DATA_LEN; i++)

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -15,10 +15,6 @@
 /* Prototypes we are testing. */
 int enc_png(char *data, g2int width, g2int height, g2int nbits, char *pngbuf);
 int dec_png(unsigned char *pngbuf, g2int *width, g2int *height, char *cout);
-g2int pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                g2float *fld);
-void pngpack(g2float *fld, g2int width, g2int height, g2int *idrstmpl, 
-             unsigned char *cpack, g2int *lcpack);
 
 int
 main()

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -73,6 +73,31 @@ main()
 	}
     }
     printf("ok!\n");
+    printf("Testing pngpackd()/pngunpackd() calls...");
+    {
+	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
+	double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
+	double fld_in[DATA_LEN];
+	unsigned char cpack[PACKED_LEN];
+	g2int lcpack;
+        g2int idrstmpl[5] = {0, 1, 1, 16, 0};
+	int i;
+
+	/* Pack the data. */
+	pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+
+	/* Unpack the data. */
+	if (pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+	    return G2C_ERROR;
+
+	for (i = 0; i < DATA_LEN; i++)
+	{
+	    /* printf("%g %g\n", fld[i], fld_in[i]); */
+	    if (fld[i] != fld_in[i])
+		return G2C_ERROR;
+	}
+    }
+    printf("ok!\n");
     printf("Testing pngpack()/pngunpack() calls with different settings...");
     {
 	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	


### PR DESCRIPTION
Fixes #260 

This is needed for the C library to take over PNG compression for the Fortran library.