### PR TITLE
test cleanup

### DIFF
--- a/src/g2_info.c
+++ b/src/g2_info.c
@@ -17,17 +17,17 @@
  * maximum size) of Local Use Sections. Also various checks are
  * performed to see if the message is a valid GRIB2 message.
  *
- * @param cgrib Character pointer to the GRIB2 message.
- * @param listsec0 pointer to an array containing information decoded
- * from GRIB Indicator Section 0. Must be allocated with >= 3
- * elements.
+ * @param cgrib Pointer to a buffer containing the GRIB2 message.
+ * @param listsec0 Pointer to an array that gets the information
+ * decoded from GRIB Indicator Section 0. Must be allocated with >= 3
+ * elements (see ::G2C_SECTION0_LEN).
  * - listsec0(0) Discipline-GRIB Master Table Number ([Code Table 0.0]
  * (https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table0-0.shtml)).
  * - listsec0[1] GRIB Edition Number (currently 2).
  * - listsec0[2] Length of GRIB message.
- * @param listsec1 Pointer to an array containing information read
+ * @param listsec1 Pointer to an array that gets the information read
  * from GRIB Identification Section 1. Must be allocated with >= 13
- * elements.
+ * elements (see ::G2C_SECTION1_LEN).
  * - listsec1[0] Id of orginating centre ([Table 0]
  * (https://www.nco.ncep.noaa.gov/pmb/docs/on388/table0.html)).
  * - listsec1[1] Id of orginating sub-centre ([Table C]
@@ -48,12 +48,13 @@
  * (https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-3.shtml)).
  * - listsec1[12] Type of processed data ([Table 1.4]
  *  (https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_table1-4.shtml)).
- * @param numfields The number of gridded fields found in the GRIB
- * message. That is, the number of occurences of Sections 4 - 7.
- * @param numlocal The number of Local Use Sections ( Section 2 )
- * found in the GRIB message.
+ * @param numfields A pointer that gets the number of gridded fields
+ * found in the GRIB message. That is, the number of occurences of
+ * Sections 4 - 7.
+ * @param numlocal A pointer that gets the number of Local Use
+ * Sections (section 2) found in the GRIB message.
  *
- * @returns 0 foe success, otherwise:
+ * @returns 0 for success, otherwise:
  * - ::G2_INFO_NO_GRIB Beginning characters "GRIB" not found.
  * - ::G2_INFO_GRIB_VERSION GRIB message is not Edition 2.
  * - ::G2_INFO_NO_SEC1 Could not find Section 1, where expected.
@@ -75,6 +76,8 @@ g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
     *numlocal = 0;
     *numfields = 0;
 
+    LOG((2, "g2_info"));
+
     /*  Check for beginning of GRIB message in the first 100 bytes. */
     istart = -1;
     for (j = 0; j < 100; j++)
@@ -92,11 +95,13 @@ g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
         return G2_INFO_NO_GRIB;
     }
 
+    LOG((3, "msg found at byte %ld", istart));
+
     /*  Unpack Section 0 - Indicator Section. */
     iofst = 8 * (istart + 6);
     gbit(cgrib, listsec0, iofst, 8);     /* Discipline */
     iofst = iofst + 8;
-    gbit(cgrib, listsec0 + 1, iofst, 8);     /* GRIB edition number */
+    gbit(cgrib, &listsec0[1], iofst, 8);     /* GRIB edition number */
     iofst = iofst + 8;
     iofst = iofst + 32;
     gbit(cgrib, &lengrib, iofst, 32);        /* Length of GRIB message */
@@ -104,6 +109,7 @@ g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
     listsec0[2] = lengrib;
     lensec0 = 16;
     ipos = istart + lensec0;
+    LOG((3, "unpacked section 0, lengrib %ld now at byte %ld", lengrib, ipos));
 
     /*  Currently handles only GRIB Edition 2. */
     if (listsec0[1] != 2)
@@ -129,10 +135,11 @@ g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
     for (i = 0; i < mapsec1len; i++)
     {
         nbits = mapsec1[i] * 8;
-        gbit(cgrib, listsec1 + i, iofst, nbits);
+        gbit(cgrib, &listsec1[i], iofst, nbits);
         iofst = iofst + nbits;
     }
     ipos = ipos + lensec1;
+    LOG((3, "unpacked section 1, now at byte %ld", ipos));    
 
     /*  Loop through the remaining sections to see if they are
      *  valid. Also count the number of times Section 2 and Section
@@ -142,6 +149,7 @@ g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
         if (cgrib[ipos] == '7' && cgrib[ipos + 1] == '7' && cgrib[ipos + 2] == '7' &&
             cgrib[ipos + 3] == '7')
         {
+	    LOG((3, "found 7777 at byte %ld", ipos));
             ipos = ipos + 4;
             if (ipos != (istart + lengrib))
             {
@@ -155,6 +163,7 @@ g2_info(unsigned char *cgrib, g2int *listsec0, g2int *listsec1,
         gbit(cgrib, &lensec, iofst, 32);        /* Get Length of Section */
         iofst = iofst + 32;
         gbit(cgrib, &isecnum, iofst, 8);         /* Get Section number */
+	LOG((3, "found section number %ld of length %ld", isecnum, lensec));
         iofst = iofst + 8;
         ipos = ipos + lensec;                 /* Update beginning of section pointer */
         if (ipos > (istart + lengrib))

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -271,6 +271,10 @@ g2int jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 /* Logging, for debugging purposes. */
 int g2c_set_log_level(int new_level);
 
+/* Useful constants. */
+#define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */
+#define G2C_SECTION1_LEN 13 /**< Length of section 1 array. */
+
 /* Error codes for G2 API. */
 #define G2_NO_ERROR 0             /**< Function succeeded. */
 #define G2_CREATE_GRIB_VERSION -1 /**< Wrong GRIB version for g2_create(), must be 2. */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -22,6 +22,16 @@
 
 #define G2C_JASPER_JPEG_FORMAT_NAME "jpc" /**< Name of JPEG codec in Jasper. */
 
+#define G2C_MIN_MAX_BYTES 16 /**< Minimum acceptable value for max_bytes parameter of g2c_get_msg(). */
+
+#define G2C_ERROR 1 /**< Returned for test errors. */
+
+#define G2C_MAGIC_HEADER "GRIB" /**< GRIB magic header string. */
+
+#define G2C_MAGIC_HEADER_LEN 8 /**< Full length of magic header string (includes GRIB version byte). */
+
+#define G2C_MAX_MESSAGES 1024 /**< Maximum number of messages in a file. */
+
 /**
  * Struct for GRIB template.
  */

--- a/src/seekgb.c
+++ b/src/seekgb.c
@@ -25,13 +25,14 @@
  *
  * @param lugb FILE pointer for the file to search. File must be
  * opened before this routine is called.
- * @param iseek number of bytes in the file to skip before search.
- * @param mseek number of bytes to search at a time (must be at least
- * 16).
- * @param lskip number of bytes to skip from the beggining of the file
- * to where the GRIB message starts.
- * @param lgrib number of bytes in message (set to 0, if no message
- * found).
+ * @param iseek The number of bytes in the file to skip before search.
+ * @param mseek The maximum number of bytes to search at a time (must
+ * be at least 16, but larger numbers like 4092 will result in better
+ * perfomance).
+ * @param lskip Pointer that gets the number of bytes to skip from the
+ * beggining of the file to where the GRIB message starts.
+ * @param lgrib Pointer that gets the number of bytes in message (set
+ * to 0, if no message found).
  *
  * @author Stephen Gilbert @date 2002-10-28
  */
@@ -42,6 +43,9 @@ seekgb(FILE *lugb, g2int iseek, g2int mseek, g2int *lskip, g2int *lgrib)
     int end;
     unsigned char *cbuf;
 
+
+    LOG((3, "seekgb iseek %ld mseek %ld", iseek, mseek));
+    
     *lgrib = 0;
     cbuf = (unsigned char *)malloc(mseek);
     nread = mseek;
@@ -73,6 +77,7 @@ seekgb(FILE *lugb, g2int iseek, g2int mseek, g2int *lskip, g2int *lgrib)
                     gbit(cbuf, &lengrib, (k + 4) * BITS_PER_BYTE, 3 * BITS_PER_BYTE);
                 if (vers == 2)
                     gbit(cbuf, &lengrib, (k + 12) * BITS_PER_BYTE, 4 * BITS_PER_BYTE);
+		LOG((4, "lengrib %ld", lengrib));
 
                 /* Read the last 4 bytesof the message. */
                 fseek(lugb, ipos + k + lengrib - 4, SEEK_SET);
@@ -84,6 +89,7 @@ seekgb(FILE *lugb, g2int iseek, g2int mseek, g2int *lskip, g2int *lgrib)
                     /* GRIB message found. */
                     *lskip = ipos + k;
                     *lgrib = lengrib;
+		    LOG((4, "found end of message lengrib %ld", lengrib));
                     break;
                 }
             }

--- a/tests/tst_addfield2.c
+++ b/tests/tst_addfield2.c
@@ -6,14 +6,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
 #define MSG_LEN 109
 #define MOST_MSG_LEN 237
 #define FULL_MSG_LEN 241
-#define G2C_ERROR 2
 
 void g2_miss(gribfield *gfld, float *rmiss, int *nmiss);
 

--- a/tests/tst_addfield3.c
+++ b/tests/tst_addfield3.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
@@ -17,7 +17,6 @@
 #define FULL_MSG_LEN MOST_MSG_LEN + 4
 #define FULL_MSG_LEN_MIN MOST_MSG_LEN_MIN + 4
 #define LOCAL_SIZE 10
-#define G2C_ERROR 2
 
 void g2_miss(gribfield *gfld, float *rmiss, int *nmiss);
 

--- a/tests/tst_addfield4.c
+++ b/tests/tst_addfield4.c
@@ -6,7 +6,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
@@ -17,7 +17,6 @@
 #define FULL_MSG_LEN MOST_MSG_LEN + 4
 #define FULL_MSG_LEN_MIN MOST_MSG_LEN_MIN + 4
 #define LOCAL_SIZE 10
-#define G2C_ERROR 2
 
 void g2_miss(gribfield *gfld, float *rmiss, int *nmiss);
 

--- a/tests/tst_addfield_spec.c
+++ b/tests/tst_addfield_spec.c
@@ -6,14 +6,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
 #define MSG_LEN 109
 #define MOST_MSG_LEN 178
 #define FULL_MSG_LEN 182
-#define G2C_ERROR 2
 
 void g2_miss(gribfield *gfld, float *rmiss, int *nmiss);
 

--- a/tests/tst_com.c
+++ b/tests/tst_com.c
@@ -10,7 +10,6 @@
 
 #define DATA_LEN 4
 #define PACKED_LEN 200
-#define G2C_ERROR 2
 
 /* Prototypes we are testing. */
 int comunpack(unsigned char *cpack, g2int lensec, g2int idrsnum,

--- a/tests/tst_decode.c
+++ b/tests/tst_decode.c
@@ -3,11 +3,9 @@
  * Dusan Jovic, July, 2021
  */
 
-#include "grib2.h"
+#include "grib2_int.h"
 
 #include <stdio.h>
-
-#define G2C_ERROR 2
 
 int main()
 {

--- a/tests/tst_drstemplates.c
+++ b/tests/tst_drstemplates.c
@@ -8,8 +8,6 @@
 #include <stdlib.h>
 #include "grib2_int.h"
 
-#define G2C_ERROR 2
-
 /* Prototypes. */
 g2int getdrsindex(g2int number);
 

--- a/tests/tst_g2_addfield.c
+++ b/tests/tst_g2_addfield.c
@@ -6,14 +6,13 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
 #define MSG_LEN 109
 #define MOST_MSG_LEN 178
 #define FULL_MSG_LEN 182
-#define G2C_ERROR 2
 
 void g2_miss(gribfield *gfld, float *rmiss, int *nmiss);
 

--- a/tests/tst_g2_addgrid.c
+++ b/tests/tst_g2_addgrid.c
@@ -11,7 +11,6 @@
 #define SEC1_LEN 21
 #define SEC3_LEN 34
 #define MSG_LEN 109
-#define G2C_ERROR 2
 
 int
 main()

--- a/tests/tst_g2_addlocal.c
+++ b/tests/tst_g2_addlocal.c
@@ -6,12 +6,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
 #define MSG_LEN 52
-#define G2C_ERROR 2
 
 int
 main()

--- a/tests/tst_g2_create.c
+++ b/tests/tst_g2_create.c
@@ -5,10 +5,9 @@
  */
 
 #include <stdio.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define MSG_LEN 37
-#define G2C_ERROR 2
 
 int
 main()

--- a/tests/tst_gbits.c
+++ b/tests/tst_gbits.c
@@ -7,8 +7,6 @@
 #include <stdio.h>
 #include "grib2_int.h"
 
-#define G2C_ERROR 2
-
 int
 main()
 {

--- a/tests/tst_getdim.c
+++ b/tests/tst_getdim.c
@@ -6,10 +6,9 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC3_LEN 72
-#define G2C_ERROR 2
 
 /* Prototypes for some functions tested in this program. */
 g2int getdim(unsigned char *csec3, g2int *width, g2int *height, g2int *iscan);

--- a/tests/tst_gridtemplates.c
+++ b/tests/tst_gridtemplates.c
@@ -8,11 +8,8 @@
 #include <stdlib.h>
 #include "grib2_int.h"
 
-#define G2C_ERROR 2
-
 /* Prototypes. */
 g2int getgridindex(g2int number);
-
 
 int
 main()

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -6,11 +6,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define DATA_LEN 4
 #define PACKED_LEN 200
-#define G2C_ERROR 2
 
 /* Prototypes we are testing. */
 int enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,

--- a/tests/tst_pdstemplates.c
+++ b/tests/tst_pdstemplates.c
@@ -8,8 +8,6 @@
 #include <stdlib.h>
 #include "grib2_int.h"
 
-#define G2C_ERROR 2
-
 /* Prototypes. */
 g2int getpdsindex(g2int number);
 

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -6,16 +6,11 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define DATA_LEN 4
 #define PACKED_LEN 80
-#define G2C_ERROR 2
 #define EPSILON .0001
-
-/* Prototypes we are testing. */
-int enc_png(char *data, g2int width, g2int height, g2int nbits, char *pngbuf);
-int dec_png(unsigned char *pngbuf, g2int *width, g2int *height, char *cout);
 
 int
 main()
@@ -23,11 +18,11 @@ main()
     printf("Testing PNG functions.\n");
     printf("Testing enc_png() call...");
     {
-        char data[4] = {1, 2, 3, 4};
+        unsigned char data[4] = {1, 2, 3, 4};
         g2int width = 1, height = 1, nbits = 32;
         g2int width_in, height_in;
-        char pngbuf[200];
-        char cout[200];
+        unsigned char pngbuf[200];
+        unsigned char cout[200];
         int i, ret;
 
         /* Encode some data. */

--- a/tests/tst_seekgb.c
+++ b/tests/tst_seekgb.c
@@ -7,8 +7,6 @@
 #include <stdio.h>
 #include "grib2_int.h"
 
-#define G2C_ERROR 2
-
 #define GRIB2_FILE "gdaswave.t00z.wcoast.0p16.f000.grib2"
 #define GRIB2_INDEX_FILE "gdaswave.t00z.wcoast.0p16.f000.grib2.idx"
 
@@ -45,7 +43,7 @@ main()
         if (!(f = fopen(GRIB2_INDEX_FILE, "r")))
             return G2C_ERROR;
 
-        /* Run seekgb() on data file. */
+        /* Run seekgb() on non-data file. */
         seekgb(f, 0, 16, &lskip, &lgrib);
 
         /* Check results. */

--- a/tests/tst_simpack.c
+++ b/tests/tst_simpack.c
@@ -10,7 +10,6 @@
 
 #define DATA_LEN 4
 #define PACKED_LEN 40
-#define G2C_ERROR 2
 
 g2int simunpack(unsigned char *cpack, g2int *idrstmpl, g2int ndpts,
 		float *fld);

--- a/tests/tst_spec.c
+++ b/tests/tst_spec.c
@@ -6,11 +6,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define DATA_LEN 4
 #define PACKED_LEN 200
-#define G2C_ERROR 2
 
 /* Prototypes we are testing. */
 

--- a/tests/tst_unpack.c
+++ b/tests/tst_unpack.c
@@ -6,13 +6,12 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "grib2.h"
+#include "grib2_int.h"
 
 #define SEC0_LEN 16
 #define SEC1_LEN 21
 #define SEC3_LEN 34
 #define FULL_MSG_LEN 182
-#define G2C_ERROR 2
 
 int
 main()


### PR DESCRIPTION
Fixes #284 
Part of #285

Now include grib2_int.h instead of grib2.h in all tests.

Also some doxygen cleanup in a few files.