### PR TITLE
g2c versions of jpcpack/jpcunpack

### DIFF
--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -258,18 +258,11 @@ void pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack);
 g2int pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 float *fld);
-void pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack);
-g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                double *fld);
 void jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack);
 g2int jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 float *fld);
-void jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack);
-g2int jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                double *fld);
+
 
 /* Internal functions. */
 int g2c_xml_init();
@@ -285,6 +278,20 @@ int g2c_set_log_level(int new_level);
 
 /* Error handling. */
 const char *g2c_strerror(int g2cerr);
+
+/* Compression. */
+void pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+             unsigned char *cpack, g2int *lcpack);
+g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                double *fld);
+int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+                 unsigned char *cpack, g2int *lcpack);
+g2int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                   double *fld);
+g2int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
+                 unsigned char *cpack, g2int *lcpack);
+g2int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                   float *fld);
 
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -286,11 +286,11 @@ g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 double *fld);
 int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-g2int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
-g2int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
+int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-g2int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    float *fld);
 
 /* Useful constants. */

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -286,9 +286,11 @@ jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * cpack. This must be set by the calling function to the size
  * available in cpack.
  *
+ * @return 0 for success, error code otherwise.
+ *
  * @author Ed Hartnett
  */
-g2int
+int
 g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack)
 {
@@ -331,6 +333,8 @@ g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @param lcpack Pointer that gets the length of packed field in
  * cpack. This must be set by the calling function to the size
  * available in cpack.
+ *
+ * @return 0 for success, error code otherwise.
  *
  * @author Ed Hartnett
  */

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -32,7 +32,7 @@
  *
  * @author Ed Hartnett @date 2022-09-06
  */
-static g2int
+static int
 jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 	      void *fld, int fld_is_double)
 {
@@ -135,7 +135,7 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  *
  * @author Ed Hartnett @date 2022-08-12
  */
-g2int
+int
 g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                double *fld)
 {
@@ -164,7 +164,7 @@ g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  *
  * @author Ed Hartnett @date 2022-08-12
  */
-g2int
+int
 g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                float *fld)
 {

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -1,5 +1,5 @@
 /** @file
- * @brief Unpack a data field that was packed into a JPEG2000 code
+ * @brief Unpack a data field that was packed with JPEG2000.
  * stream
  * @author Stephem Gilbert @date 2003-08-27
  */
@@ -8,10 +8,14 @@
 #include "grib2_int.h"
 
 /**
- * Unpack JPEG2000 compressed data into an array of floats, using info
- * from the GRIB2 Data Representation [Template
+ * This internal function will unpack JPEG2000 compressed data into an
+ * array of floats or doubles, using info from the GRIB2 Data
+ * Representation [Template
  * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
  * or 5.40000.
+ *
+ * This function is used by jpcunpack(), g2c_jpcunpackf(), and
+ * g2c_jpcunpackd().
  *
  * @param cpack The packed data.
  * @param len The length of the packed data.
@@ -26,8 +30,7 @@
  *
  * @return 0 for success, 1 for memory allocation error.
  *
- * @author Stephem Gilbert @date 2003-08-27
- * @author Ed Hartnett
+ * @author Ed Hartnett @date 2022-09-06
  */
 static g2int
 jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
@@ -102,7 +105,6 @@ jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @return 0 for success, 1 for memory allocation error.
  *
  * @author Stephem Gilbert @date 2003-08-27
- * @author Ed Hartnett
  */
 g2int
 jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
@@ -112,10 +114,12 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 }
 
 /**
- * Unpack JPEG2000 compressed data into an array of doubles, using
- * info from the GRIB2 Data Representation [Template
+ * Unpack JPEG2000 compressed data into an array of doubles, using info
+ * from the GRIB2 Data Representation [Template
  * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
  * or 5.40000.
+ *
+ * This function is the V2 API version of jpcunpack() for doubles.
  *
  * @param cpack The packed data.
  * @param len The length of the packed data.
@@ -132,8 +136,37 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @author Ed Hartnett @date 2022-08-12
  */
 g2int
-jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-	   double *fld)
+g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+               double *fld)
 {
     return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);
+}
+
+/**
+ * Unpack JPEG2000 compressed data into an array of floats, using
+ * info from the GRIB2 Data Representation [Template
+ * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
+ * or 5.40000.
+ *
+ * This function is the V2 API version of jpcunpack() for floats.
+ *
+ * @param cpack The packed data.
+ * @param len The length of the packed data.
+ * @param idrstmpl Pointer to array of values for Data Representation
+ * [Template
+ * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
+ * or 5.40000.
+ * @param ndpts The number of data values to unpack.
+ * @param fld A pointer that gets the unpacked data values as an array
+ * of double.
+ *
+ * @return 0 for success, 1 for memory allocation error.
+ *
+ * @author Ed Hartnett @date 2022-08-12
+ */
+g2int
+g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+               float *fld)
+{
+    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
 }

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -79,7 +79,7 @@ main()
         }
     }
     printf("ok!\n");
-    printf("Testing jpcpackd()/jpcunpackd() call...");
+    printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call...");
     {
         g2int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
@@ -91,10 +91,10 @@ main()
         int i;
 
         /* Pack the data. */
-        jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+        g2c_jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
         /* Unpack the data. */
-        if (jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+        if (g2c_jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)
@@ -141,7 +141,7 @@ main()
         }
     }
     printf("ok!\n");
-    printf("Testing jpcpackd()/jpcunpackd() call with different drstmpl values...");
+    printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call with different drstmpl values...");
     {
         g2int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
@@ -163,10 +163,10 @@ main()
         int i;
 
         /* Pack the data. */
-        jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+        g2c_jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
         /* Unpack the data. */
-        if (jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+        if (g2c_jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)
@@ -213,7 +213,7 @@ main()
         }
     }
     printf("ok!\n");
-    printf("Testing jpcpackd()/jpcunpackd() call with constant data field...");
+    printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call with constant data field...");
     {
         g2int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
@@ -235,10 +235,10 @@ main()
         int i;
 
         /* Pack the data. */
-        jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+        g2c_jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
         /* Unpack the data. */
-        if (jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+        if (g2c_jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)


### PR DESCRIPTION
Part of #299 

g2c_ versions of the jpc and png pack/unpack functions. Needed to support g2 use of the C library.