### PR TITLE
Removing g2int from new g2c_ function parameters

### DIFF
--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -20,9 +20,14 @@
  * JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using [JasPer
  * Software](https://github.com/jasper-software/jasper).
  *
- * @param injpc Input JPEG2000 code stream.
- * @param bufsize Length (in bytes) of the input JPEG2000 code stream.
- * @param outfld Output matrix of grayscale image values.
+ * @param injpc Pointer to buffer that holds the input JPEG2000 code
+ * stream.
+ * @param bufsize Length (in bytes) of the buffer that holds the input
+ * JPEG2000 code stream.
+ * @param outfld Pointer to either int or g2int array, already
+ * allocated, that gets the unpacked data.
+ * @param out_is_g2int Non-zero if the output array is of type g2int
+ * (i.e. 64-bit ints), zero if output is an int array (32-bits).
  *
  * @return
  * - 0 Successful decode
@@ -34,8 +39,8 @@
  * @author Stephen Gilbert @date 2002-12-02
  * @author Ed Hartnett
  */
-int
-dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld)
+static int
+int_dec_jpeg2000(char *injpc, g2int bufsize, void *outfld, int out_is_g2int)
 {
     g2int i, j, k;
     jas_image_t *image = NULL;
@@ -109,9 +114,18 @@ dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld)
 
     /* Copy data matrix to output integer array. */
     k = 0;
-    for (i = 0; i < pcmpt->height_; i++)
-        for (j = 0; j < pcmpt->width_; j++)
-            outfld[k++] = data->rows_[i][j];
+    if (out_is_g2int)
+    {
+        for (i = 0; i < pcmpt->height_; i++)
+            for (j = 0; j < pcmpt->width_; j++)
+                ((g2int *)outfld)[k++] = data->rows_[i][j];
+    }
+    else
+    {
+        for (i = 0; i < pcmpt->height_; i++)
+            for (j = 0; j < pcmpt->width_; j++)
+                ((int *)outfld)[k++] = data->rows_[i][j];
+    }
 
     /* Clean up JasPer work structures. */
     jas_matrix_destroy(data);
@@ -128,3 +142,58 @@ dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld)
 
     return 0;
 }
+
+/**
+ * This Function decodes a JPEG2000 code stream specified in the
+ * JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using [JasPer
+ * Software](https://github.com/jasper-software/jasper).
+ *
+ * @param injpc Pointer to buffer that holds the input JPEG2000 code
+ * stream.
+ * @param bufsize Length (in bytes) of the buffer that holds the input
+ * JPEG2000 code stream.
+ * @param outfld Pointer to int array, already allocated, that gets
+ * the unpacked data.
+ *
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2_JASPER_DECODE Error decode jpeg2000 code stream.
+ * - ::G2_JASPER_DECODE_COLOR decoded image had multiple color
+ *     components. Only grayscale is expected.
+ * - ::G2_JASPER_INIT Error inializing Jasper library.
+ *
+ * @author Ed Hartnett @date 9/7/22
+ */
+int
+g2c_dec_jpeg2000(char *injpc, size_t bufsize, int *outfld)
+{
+    return int_dec_jpeg2000(injpc, bufsize, outfld, 0);
+}
+
+/**
+ * This Function decodes a JPEG2000 code stream specified in the
+ * JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using [JasPer
+ * Software](https://github.com/jasper-software/jasper).
+ *
+ * @param injpc Pointer to buffer that holds the input JPEG2000 code
+ * stream.
+ * @param bufsize Length (in bytes) of the buffer that holds the input
+ * JPEG2000 code stream.
+ * @param outfld Pointer to g2int array, already allocated, that gets
+ * the unpacked data.
+ *
+ * @return
+ * - 0 Successful decode
+ * - ::G2_JASPER_DECODE Error decode jpeg2000 code stream.
+ * - ::G2_JASPER_DECODE_COLOR decoded image had multiple color
+ *     components. Only grayscale is expected.
+ * - ::G2_JASPER_INIT Error inializing Jasper library.
+ *
+ * @author Stephen Gilbert, Ed Hartnett 
+ */
+int
+dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld)
+{
+    return int_dec_jpeg2000(injpc, bufsize, outfld, 1);
+}
+

--- a/src/dec_jpeg2000.c
+++ b/src/dec_jpeg2000.c
@@ -1,6 +1,12 @@
 /** @file
  * @brief Decodes JPEG2000 code stream.
  * @author Stephen Gilbert @date 2002-12-02
+ *
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2002-12-02 | Gilbert | Initial
+ * 2022-04-15 | Hartnett | Converted to use jas_ instead of jpc_ functions.
  */
 
 #include <stdio.h>
@@ -13,12 +19,6 @@
  * This Function decodes a JPEG2000 code stream specified in the
  * JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1) using [JasPer
  * Software](https://github.com/jasper-software/jasper).
- *
- * ### Program History Log
- * Date | Programmer | Comments
- * -----|------------|---------
- * 2002-12-02 | Gilbert | Initial
- * 2022-04-15 | Hartnett | Converted to use jas_ instead of jpc_ functions.
  *
  * @param injpc Input JPEG2000 code stream.
  * @param bufsize Length (in bytes) of the input JPEG2000 code stream.

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -48,6 +48,51 @@
  * @author Ed Hartnett
  */
 int
+g2c_enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
+                 g2int ltype, g2int ratio, g2int retry, char *outjpc,
+                 g2int jpclen)
+{
+    return enc_jpeg2000(cin, width, height, nbits, ltype, ratio, retry, outjpc, jpclen);
+}
+
+/**
+ * This Function encodes a grayscale image into a JPEG2000 code stream
+ * specified in the JPEG2000 Part-1 standard (i.e., ISO/IEC 15444-1)
+ * using [JasPer Software](https://github.com/jasper-software/jasper).
+ *
+ * ### Program History Log
+ * Date | Programmer | Comments
+ * -----|------------|---------
+ * 2002-12-02 | Gilbert | Initial
+ * 2004-12-16 | Gilbert | Added retry argument allowing increased guard bits.
+ * 2022-04-15 | Hartnett | Converted to use jas_ instead of jpc_ functions.
+ *
+ * @param cin Packed matrix of Grayscale image values to encode.
+ * @param width width of image.
+ * @param height height of image.
+ * @param nbits depth (in bits) of image.  i.e number of bits used to
+ * hold each data value.
+ * @param ltype indicator of lossless or lossy compression.
+ * - 1, for lossy compression
+ * - != 1, for lossless compression
+ * @param ratio target compression ratio. (ratio:1) Used only when
+ * ltype == 1.
+ * @param retry If 1 try increasing number of guard bits.
+ * @param outjpc Output encoded JPEG2000 code stream.
+ * @param jpclen Number of bytes allocated for the output JPEG2000
+ * code stream in outjpc.
+ *
+ * @return
+ * - > 0 = Length in bytes of encoded JPEG2000 code stream
+ * - ::G2_JASPER_INIT Error initializing jasper library.
+ * - ::G2_JASPER_ENCODE Error encode jpeg2000 code stream.
+ *
+ * @note Requires JasPer Software version 1.500.4 or 1.700.2 or later.
+ *
+ * @author Stephen Gilbert @date 2002-12-02
+ * @author Ed Hartnett
+ */
+int
 enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
              g2int ltype, g2int ratio, g2int retry, char *outjpc,
              g2int jpclen)

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -50,7 +50,7 @@
 int
 g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,
                  int ltype, int ratio, int retry, char *outjpc,
-                 int jpclen)
+                 size_t jpclen)
 {
     g2int width8 = width, height8 = height, nbits8 = nbits, ltype8 = ltype;
     g2int ratio8 = ratio, retry8 = retry, jpclen8 = jpclen;

--- a/src/enc_jpeg2000.c
+++ b/src/enc_jpeg2000.c
@@ -48,11 +48,15 @@
  * @author Ed Hartnett
  */
 int
-g2c_enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
-                 g2int ltype, g2int ratio, g2int retry, char *outjpc,
-                 g2int jpclen)
+g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,
+                 int ltype, int ratio, int retry, char *outjpc,
+                 int jpclen)
 {
-    return enc_jpeg2000(cin, width, height, nbits, ltype, ratio, retry, outjpc, jpclen);
+    g2int width8 = width, height8 = height, nbits8 = nbits, ltype8 = ltype;
+    g2int ratio8 = ratio, retry8 = retry, jpclen8 = jpclen;
+    
+    return enc_jpeg2000(cin, width8, height8, nbits8, ltype8, ratio8, retry8,
+                        outjpc, jpclen8);
 }
 
 /**

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -290,13 +290,11 @@ int g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts
                    double *fld);
 int g2c_jpcpackf(float *fld, int width, int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-int g2c_jpcpackd(double *fld, int width, int height, g2int *idrstmpl,
-                 unsigned char *cpack, g2int *lcpack);
-int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-                 unsigned char *cpack, g2int *lcpack);
+int g2c_jpcpackd(double *fld, int width, int height, int *idrstmpl,
+                 unsigned char *cpack, size_t *lcpack);
 int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    float *fld);
-int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int g2c_jpcunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
                    double *fld);
 int g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,
                      int ltype, int ratio, int retry, char *outjpc,
@@ -306,6 +304,8 @@ int g2c_dec_jpeg2000(char *injpc, size_t bufsize, int *outfld);
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */
 #define G2C_SECTION1_LEN 13 /**< Length of section 1 array. */
+
+#define G2C_JPEG_DRS_TEMPLATE_LEN 7 /**< Length of the idrstmpl array. */
 
 #define G2C_MAX_GRIB_DESC_LEN 512 /**< Maximum length of code description. */
 #define G2C_MAX_GRIB_STATUS_LEN 40 /**< Maximum length of code status. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -296,9 +296,9 @@ int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts
                    float *fld);
 int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
-int g2c_enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
-                     g2int ltype, g2int ratio, g2int retry, char *outjpc,
-                     g2int jpclen);
+int g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,
+                     int ltype, int ratio, int retry, char *outjpc,
+                     int jpclen);
 
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -384,5 +384,6 @@ int g2c_dec_jpeg2000(char *injpc, size_t bufsize, int *outfld);
 #define G2C_ENOEND (-64) /**< Cannot find end of GRIB message. */
 #define G2C_EBADEND (-65) /**< End of message in wrong place. */
 #define G2C_EBADSECTION (-66) /**< Invalid section number. */
+#define G2C_EJPEG (-67) /**< Error encoding/decoding JPEG data. */
 
 #endif  /*  _grib2_H  */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -258,18 +258,11 @@ void pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack);
 g2int pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 float *fld);
-void pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack);
-g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                double *fld);
 void jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack);
 g2int jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 float *fld);
-void jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack);
-g2int jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                double *fld);
+
 
 /* Internal functions. */
 int g2c_xml_init();
@@ -285,6 +278,20 @@ int g2c_set_log_level(int new_level);
 
 /* Error handling. */
 const char *g2c_strerror(int g2cerr);
+
+/* Compression. */
+void pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+             unsigned char *cpack, g2int *lcpack);
+g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                double *fld);
+int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+                 unsigned char *cpack, g2int *lcpack);
+g2int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                   double *fld);
+g2int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
+                 unsigned char *cpack, g2int *lcpack);
+g2int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                   float *fld);
 
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -280,18 +280,22 @@ int g2c_set_log_level(int new_level);
 const char *g2c_strerror(int g2cerr);
 
 /* Compression. */
-void pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack);
-g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                double *fld);
-int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+int g2c_pngpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int g2c_pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+                 unsigned char *cpack, g2int *lcpack);
+int g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                   float *fld);
+int g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
 int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
+int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+                 unsigned char *cpack, g2int *lcpack);
 int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    float *fld);
+int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+                   double *fld);
 
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -298,7 +298,8 @@ int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts
                    double *fld);
 int g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,
                      int ltype, int ratio, int retry, char *outjpc,
-                     int jpclen);
+                     size_t jpclen);
+int g2c_dec_jpeg2000(char *injpc, size_t bufsize, int *outfld);
 
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -286,11 +286,11 @@ g2int pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                 double *fld);
 int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-g2int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
-g2int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
+int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-g2int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    float *fld);
 
 /* Useful constants. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -288,9 +288,9 @@ int g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts
                    float *fld);
 int g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
-int g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
+int g2c_jpcpackf(float *fld, int width, int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
-int g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+int g2c_jpcpackd(double *fld, int width, int height, g2int *idrstmpl,
                  unsigned char *cpack, g2int *lcpack);
 int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    float *fld);

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -288,12 +288,10 @@ int g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts
                    float *fld);
 int g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
-int g2c_jpcpackf(float *fld, int width, int height, g2int *idrstmpl,
-                 unsigned char *cpack, g2int *lcpack);
+int g2c_jpcpackf(float *fld, int width, int height, int *idrstmpl,
+		 unsigned char *cpack, size_t *lcpack);
 int g2c_jpcpackd(double *fld, int width, int height, int *idrstmpl,
                  unsigned char *cpack, size_t *lcpack);
-int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                   float *fld);
 int g2c_jpcunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
                    double *fld);
 int g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -385,5 +385,6 @@ int g2c_dec_jpeg2000(char *injpc, size_t bufsize, int *outfld);
 #define G2C_EBADEND (-65) /**< End of message in wrong place. */
 #define G2C_EBADSECTION (-66) /**< Invalid section number. */
 #define G2C_EJPEG (-67) /**< Error encoding/decoding JPEG data. */
+#define G2C_EPNG (-68) /**< Error encoding/decoding PNG data. */
 
 #endif  /*  _grib2_H  */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -280,18 +280,20 @@ int g2c_set_log_level(int new_level);
 const char *g2c_strerror(int g2cerr);
 
 /* Compression. */
-int g2c_pngpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
-                 unsigned char *cpack, g2int *lcpack);
-int g2c_pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
-                 unsigned char *cpack, g2int *lcpack);
-int g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                   float *fld);
-int g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                   double *fld);
+int g2c_pngpackf(float *fld, int width, int height, int *idrstmpl, 
+		 unsigned char *cpack, int *lcpack);
+int g2c_pngpackd(double *fld, int width, int height, int *idrstmpl, 
+		 unsigned char *cpack, int *lcpack);
+int g2c_pngunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
+		   float *fld);
+int g2c_pngunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
+		   double *fld);
 int g2c_jpcpackf(float *fld, int width, int height, int *idrstmpl,
 		 unsigned char *cpack, size_t *lcpack);
 int g2c_jpcpackd(double *fld, int width, int height, int *idrstmpl,
                  unsigned char *cpack, size_t *lcpack);
+int g2c_jpcunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
+		   float *fld);
 int g2c_jpcunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
                    double *fld);
 int g2c_enc_jpeg2000(unsigned char *cin, int width, int height, int nbits,

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -296,6 +296,9 @@ int g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts
                    float *fld);
 int g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                    double *fld);
+int g2c_enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
+                     g2int ltype, g2int ratio, g2int retry, char *outjpc,
+                     g2int jpclen);
 
 /* Useful constants. */
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -305,7 +305,8 @@ int g2c_dec_jpeg2000(char *injpc, size_t bufsize, int *outfld);
 #define G2C_SECTION0_LEN 3 /**< Length of section 0 array. */
 #define G2C_SECTION1_LEN 13 /**< Length of section 1 array. */
 
-#define G2C_JPEG_DRS_TEMPLATE_LEN 7 /**< Length of the idrstmpl array. */
+#define G2C_JPEG_DRS_TEMPLATE_LEN 7 /**< Length of the idrstmpl array for JPEG packing. */
+#define G2C_PNG_DRS_TEMPLATE_LEN 5 /**< Length of the idrstmpl array for PNG packing. */
 
 #define G2C_MAX_GRIB_DESC_LEN 512 /**< Maximum length of code description. */
 #define G2C_MAX_GRIB_STATUS_LEN 40 /**< Maximum length of code status. */

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -286,9 +286,11 @@ jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * cpack. This must be set by the calling function to the size
  * available in cpack.
  *
+ * @return 0 for success, error code otherwise.
+ *
  * @author Ed Hartnett
  */
-g2int
+int
 g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack)
 {
@@ -331,6 +333,8 @@ g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @param lcpack Pointer that gets the length of packed field in
  * cpack. This must be set by the calling function to the size
  * available in cpack.
+ *
+ * @return 0 for success, error code otherwise.
  *
  * @author Ed Hartnett
  */

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -55,7 +55,7 @@ jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     float *ffld = fld;
     double *dfld = fld;
 
-    LOG((2, "jpcpack_int() fld_is_double %d width %ld height %ld idrstmpl[1] %ld *lcpack %ld",
+    LOG((2, "jpcpack_int() fld_is_double %d width %ld height %ld idrstmpl[1] %d *lcpack %ld",
 	 fld_is_double, width, height, idrstmpl[1], *lcpack));
     
     ndpts = width * height;

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -35,7 +35,7 @@
  * allocated before this function is called. Pass the allocated size
  * in the lcpack parameter.
  * @param lcpack Pointer that gets the length of packed field in
- * cpack. This must be set by the calling function to the size
+ * cpack. This must also be set by the calling function to the size
  * available in cpack.
  *
  * @return 0 for success, error code otherwise
@@ -340,9 +340,23 @@ g2c_jpcpackf(float *fld, int width, int height, g2int *idrstmpl,
  * @author Ed Hartnett
  */
 int
-g2c_jpcpackd(double *fld, int width, int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack)
+g2c_jpcpackd(double *fld, int width, int height, int *idrstmpl,
+             unsigned char *cpack, size_t *lcpack)
 {
-    g2int width8 = width, height8 = height;
-    return jpcpack_int(fld, 1, width8, height8, idrstmpl, cpack, lcpack);
+    g2int width8 = width, height8 = height, lcpack8 = *lcpack;
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    int i, ret;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+
+    ret = jpcpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8);    
+
+    if (!ret)
+    {
+        for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+            idrstmpl[i] = (int)idrstmpl8[i];
+        *lcpack = (g2int)lcpack8;
+    }
+    return ret;
 }

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -291,11 +291,25 @@ jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @author Ed Hartnett
  */
 int
-g2c_jpcpackf(float *fld, int width, int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack)
+g2c_jpcpackf(float *fld, int width, int height, int *idrstmpl,
+             unsigned char *cpack, size_t *lcpack)
 {
-    g2int width8 = width, height8 = height;
-    return jpcpack_int(fld, 0, width8, height8, idrstmpl, cpack, lcpack);
+    g2int width8 = width, height8 = height, lcpack8 = *lcpack;
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    int i, ret;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+
+    ret = jpcpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8);
+
+    if (!ret)
+    {
+        for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+            idrstmpl[i] = (int)idrstmpl8[i];
+        *lcpack = (g2int)lcpack8;
+    }
+    return ret;
 }
 
 /**

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -291,10 +291,11 @@ jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @author Ed Hartnett
  */
 int
-g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
+g2c_jpcpackf(float *fld, int width, int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack)
 {
-    return jpcpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack);
+    g2int width8 = width, height8 = height;
+    return jpcpack_int(fld, 0, width8, height8, idrstmpl, cpack, lcpack);
 }
 
 /**
@@ -339,8 +340,9 @@ g2c_jpcpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @author Ed Hartnett
  */
 int
-g2c_jpcpackd(double *fld, g2int width, g2int height, g2int *idrstmpl,
+g2c_jpcpackd(double *fld, int width, int height, g2int *idrstmpl,
              unsigned char *cpack, g2int *lcpack)
 {
-    return jpcpack_int(fld, 1, width, height, idrstmpl, cpack, lcpack);
+    g2int width8 = width, height8 = height;
+    return jpcpack_int(fld, 1, width8, height8, idrstmpl, cpack, lcpack);
 }

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -37,13 +37,23 @@
  * @param lcpack Pointer that gets the length of packed field in
  * cpack. This must also be set by the calling function to the size
  * available in cpack.
+ * @param verbose If non-zero, error messages will be printed in case
+ * of error. Otherwise, error codes will be return but no error
+ * messages printed. Calls to the original g2c API may cause error
+ * messages to be printed in case of error. For the new g2c_ API, no
+ * error messages will be printed - instead an error code will be
+ * returned. Call g2c_strerror() to get the error message for any
+ * error code.
  *
- * @return 0 for success, error code otherwise
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_EJPEG Error encoding/decoding JPEG data.
+ *
  * @author Stephen Gilbert, Ed Hartnett 
  */
 static int
 jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrstmpl,
-	    unsigned char *cpack, g2int *lcpack)
+	    unsigned char *cpack, g2int *lcpack, int verbose)
 {
     g2int  *ifld = NULL;
     static float alog2 = ALOG2;       /*  ln(2.0) */
@@ -54,6 +64,7 @@ jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     unsigned char *ctemp;
     float *ffld = fld;
     double *dfld = fld;
+    int ret = G2C_NOERROR;
 
     LOG((2, "jpcpack_int() fld_is_double %d width %ld height %ld idrstmpl[1] %d *lcpack %ld",
 	 fld_is_double, width, height, idrstmpl[1], *lcpack));
@@ -172,15 +183,23 @@ jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
         if ((*lcpack = (g2int)enc_jpeg2000(ctemp, width, height, nbits, idrstmpl[5],
                                            idrstmpl[6], retry, (char *)cpack, nsize)) <= 0)
         {
-            printf("jpcpack: ERROR Packing JPC = %d\n", (int)*lcpack);
+	    if (verbose)
+		printf("jpcpack: ERROR Packing JPC = %d\n", (int)*lcpack);
             if (*lcpack == -3)
             {
                 retry = 1;
                 if ((*lcpack = (g2int)enc_jpeg2000(ctemp, width, height, nbits, idrstmpl[5],
                                                    idrstmpl[6], retry, (char *)cpack, nsize)) <= 0)
-                    printf("jpcpack: Retry Failed.\n");
+		{
+		    if (verbose)
+			printf("jpcpack: Retry Failed.\n");
+		    ret = G2C_EJPEG;
+		}
                 else
-                    printf("jpcpack: Retry Successful.\n");
+		{
+		    if (verbose)
+			printf("jpcpack: Retry Successful.\n");
+		}
             }
         }
         free(ctemp);
@@ -202,7 +221,7 @@ jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     if (ifld)
         free(ifld);
 
-    return G2C_NOERROR;
+    return ret;
 }
 
 /**
@@ -246,7 +265,7 @@ void
 jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
         unsigned char *cpack, g2int *lcpack)
 {
-    jpcpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack);
+    jpcpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack, 1);
 }
 
 /**
@@ -286,7 +305,9 @@ jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * cpack. This must be set by the calling function to the size
  * available in cpack.
  *
- * @return 0 for success, error code otherwise.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_EJPEG Error encoding/decoding JPEG data.
  *
  * @author Ed Hartnett
  */
@@ -301,7 +322,7 @@ g2c_jpcpackf(float *fld, int width, int height, int *idrstmpl,
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
 
-    ret = jpcpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8);
+    ret = jpcpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8, 0);
 
     if (!ret)
     {
@@ -349,7 +370,9 @@ g2c_jpcpackf(float *fld, int width, int height, int *idrstmpl,
  * cpack. This must be set by the calling function to the size
  * available in cpack.
  *
- * @return 0 for success, error code otherwise.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_EJPEG Error encoding/decoding JPEG data.
  *
  * @author Ed Hartnett
  */
@@ -364,7 +387,7 @@ g2c_jpcpackd(double *fld, int width, int height, int *idrstmpl,
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
 
-    ret = jpcpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8);    
+    ret = jpcpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8, 0);    
 
     if (!ret)
     {

--- a/src/jpcpack.c
+++ b/src/jpcpack.c
@@ -185,6 +185,7 @@ jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
         {
 	    if (verbose)
 		printf("jpcpack: ERROR Packing JPC = %d\n", (int)*lcpack);
+	    ret = G2C_EJPEG;
             if (*lcpack == -3)
             {
                 retry = 1;
@@ -199,6 +200,7 @@ jpcpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
 		{
 		    if (verbose)
 			printf("jpcpack: Retry Successful.\n");
+		    ret = G2C_NOERROR;
 		}
             }
         }

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -114,6 +114,33 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 }
 
 /**
+ * Unpack JPEG2000 compressed data into an array of floats, using info
+ * from the GRIB2 Data Representation [Template
+ * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
+ * or 5.40000.
+ *
+ * @param cpack The packed data.
+ * @param len The length of the packed data.
+ * @param idrstmpl Pointer to array of values for Data Representation
+ * [Template
+ * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
+ * or 5.40000.
+ * @param ndpts The number of data values to unpack.
+ * @param fld A pointer that gets the unpacked data values as an array
+ * of float.
+ *
+ * @return 0 for success, 1 for memory allocation error.
+ *
+ * @author Stephem Gilbert @date 2003-08-27
+ */
+int
+g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+               float *fld)
+{
+    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+}
+
+/**
  * Unpack JPEG2000 compressed data into an array of doubles, using info
  * from the GRIB2 Data Representation [Template
  * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -131,9 +131,11 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @param fld A pointer that gets the unpacked data values as an array
  * of float.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_ENOMEM Out of memory.
  *
- * @author Stephem Gilbert @date 2003-08-27
+ * @author Ed Hartnett @date 2022-09-08
  */
 int
 g2c_jpcunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
@@ -141,12 +143,17 @@ g2c_jpcunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 {
     g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
     g2int len8 = len, ndpts8 = ndpts;
-    int i;
+    int i, ret;
     
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
-    return jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0);
+    ret = jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0);
+    
+    if (ret == G2_JPCUNPACK_MEM)
+	ret = G2C_ENOMEM;
+
+    return ret;
 }
 
 /**
@@ -167,7 +174,9 @@ g2c_jpcunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
  * @param fld A pointer that gets the unpacked data values as an array
  * of double.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_ENOMEM Out of memory.
  *
  * @author Ed Hartnett @date 2022-08-12
  */
@@ -177,10 +186,15 @@ g2c_jpcunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 {
     g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
     g2int len8 = len, ndpts8 = ndpts;
-    int i;
+    int i, ret;
     
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
-    return jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1);
+    ret = jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1);
+
+    if (ret == G2_JPCUNPACK_MEM)
+	ret = G2C_ENOMEM;
+
+    return ret;
 }

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -165,8 +165,15 @@ g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @author Ed Hartnett @date 2022-08-12
  */
 int
-g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+g2c_jpcunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
                double *fld)
 {
-    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int len8 = len, ndpts8 = ndpts;
+    int i;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+    
+    return jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1);
 }

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -170,32 +170,3 @@ g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 {
     return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);
 }
-
-/**
- * Unpack JPEG2000 compressed data into an array of floats, using
- * info from the GRIB2 Data Representation [Template
- * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
- * or 5.40000.
- *
- * This function is the V2 API version of jpcunpack() for floats.
- *
- * @param cpack The packed data.
- * @param len The length of the packed data.
- * @param idrstmpl Pointer to array of values for Data Representation
- * [Template
- * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
- * or 5.40000.
- * @param ndpts The number of data values to unpack.
- * @param fld A pointer that gets the unpacked data values as an array
- * of double.
- *
- * @return 0 for success, 1 for memory allocation error.
- *
- * @author Ed Hartnett @date 2022-08-12
- */
-int
-g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-               float *fld)
-{
-    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
-}

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -27,14 +27,23 @@
  * @param fld A pointer that gets the unpacked data values.
  * @param fld_is_double Non-zero if the data are to be unpacked into a
  * double array, otherwise data will be unpacked into a float array.
+ * @param verbose If non-zero, error messages will be printed in case
+ * of error. Otherwise, error codes will be return but no error
+ * messages printed. Calls to the original g2c API may cause error
+ * messages to be printed in case of error. For the new g2c_ API, no
+ * error messages will be printed - instead an error code will be
+ * returned. Call g2c_strerror() to get the error message for any
+ * error code.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_ENOMEM Out of memory.
  *
  * @author Ed Hartnett @date 2022-09-06
  */
 static int
 jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-	      void *fld, int fld_is_double)
+	      void *fld, int fld_is_double, int verbose)
 {
     g2int *ifld;
     g2int j, nbits;
@@ -55,8 +64,9 @@ jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
     {
         if (!(ifld = calloc(ndpts, sizeof(g2int))))
         {
-            fprintf(stderr, "Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
-            return G2_JPCUNPACK_MEM;
+	    if (verbose)
+		fprintf(stderr, "Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
+            return G2C_ENOMEM;
         }
         dec_jpeg2000((char *)cpack, len, ifld);
 	if (fld_is_double)
@@ -85,7 +95,7 @@ jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 	}
     }
 
-    return G2_NO_ERROR;
+    return G2C_NOERROR;
 }
 
 /**
@@ -104,7 +114,9 @@ jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @param fld A pointer that gets the unpacked data values as an array
  * of float.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2_JPCUNPACK_MEM Out of memory.
  *
  * @author Stephem Gilbert @date 2003-08-27
  */
@@ -112,7 +124,12 @@ g2int
 jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
           float *fld)
 {
-    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+    int ret;
+    
+    if ((ret = jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0, 1)) == G2_JPCUNPACK_MEM)
+	return G2_JPCUNPACK_MEM;
+
+    return ret;
 }
 
 /**
@@ -143,17 +160,12 @@ g2c_jpcunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 {
     g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
     g2int len8 = len, ndpts8 = ndpts;
-    int i, ret;
+    int i;
     
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
-    ret = jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0);
-    
-    if (ret == G2_JPCUNPACK_MEM)
-	ret = G2C_ENOMEM;
-
-    return ret;
+    return jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0, 0);
 }
 
 /**
@@ -186,15 +198,10 @@ g2c_jpcunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 {
     g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
     g2int len8 = len, ndpts8 = ndpts;
-    int i, ret;
+    int i;
     
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
-    ret = jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1);
-
-    if (ret == G2_JPCUNPACK_MEM)
-	ret = G2C_ENOMEM;
-
-    return ret;
+    return jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1, 0);
 }

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -32,7 +32,7 @@
  *
  * @author Ed Hartnett @date 2022-09-06
  */
-static g2int
+static int
 jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 	      void *fld, int fld_is_double)
 {
@@ -135,7 +135,7 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  *
  * @author Ed Hartnett @date 2022-08-12
  */
-g2int
+int
 g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                double *fld)
 {
@@ -164,7 +164,7 @@ g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  *
  * @author Ed Hartnett @date 2022-08-12
  */
-g2int
+int
 g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
                float *fld)
 {

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -136,10 +136,17 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @author Stephem Gilbert @date 2003-08-27
  */
 int
-g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+g2c_jpcunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
                float *fld)
 {
-    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int len8 = len, ndpts8 = ndpts;
+    int i;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+    
+    return jpcunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0);
 }
 
 /**

--- a/src/jpcunpack.c
+++ b/src/jpcunpack.c
@@ -1,5 +1,5 @@
 /** @file
- * @brief Unpack a data field that was packed into a JPEG2000 code
+ * @brief Unpack a data field that was packed with JPEG2000.
  * stream
  * @author Stephem Gilbert @date 2003-08-27
  */
@@ -8,10 +8,14 @@
 #include "grib2_int.h"
 
 /**
- * Unpack JPEG2000 compressed data into an array of floats, using info
- * from the GRIB2 Data Representation [Template
+ * This internal function will unpack JPEG2000 compressed data into an
+ * array of floats or doubles, using info from the GRIB2 Data
+ * Representation [Template
  * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
  * or 5.40000.
+ *
+ * This function is used by jpcunpack(), g2c_jpcunpackf(), and
+ * g2c_jpcunpackd().
  *
  * @param cpack The packed data.
  * @param len The length of the packed data.
@@ -26,8 +30,7 @@
  *
  * @return 0 for success, 1 for memory allocation error.
  *
- * @author Stephem Gilbert @date 2003-08-27
- * @author Ed Hartnett
+ * @author Ed Hartnett @date 2022-09-06
  */
 static g2int
 jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
@@ -102,7 +105,6 @@ jpcunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @return 0 for success, 1 for memory allocation error.
  *
  * @author Stephem Gilbert @date 2003-08-27
- * @author Ed Hartnett
  */
 g2int
 jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
@@ -112,10 +114,12 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 }
 
 /**
- * Unpack JPEG2000 compressed data into an array of doubles, using
- * info from the GRIB2 Data Representation [Template
+ * Unpack JPEG2000 compressed data into an array of doubles, using info
+ * from the GRIB2 Data Representation [Template
  * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
  * or 5.40000.
+ *
+ * This function is the V2 API version of jpcunpack() for doubles.
  *
  * @param cpack The packed data.
  * @param len The length of the packed data.
@@ -132,8 +136,37 @@ jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @author Ed Hartnett @date 2022-08-12
  */
 g2int
-jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-	   double *fld)
+g2c_jpcunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+               double *fld)
 {
     return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);
+}
+
+/**
+ * Unpack JPEG2000 compressed data into an array of floats, using
+ * info from the GRIB2 Data Representation [Template
+ * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
+ * or 5.40000.
+ *
+ * This function is the V2 API version of jpcunpack() for floats.
+ *
+ * @param cpack The packed data.
+ * @param len The length of the packed data.
+ * @param idrstmpl Pointer to array of values for Data Representation
+ * [Template
+ * 5.40](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml)
+ * or 5.40000.
+ * @param ndpts The number of data values to unpack.
+ * @param fld A pointer that gets the unpacked data values as an array
+ * of double.
+ *
+ * @return 0 for success, 1 for memory allocation error.
+ *
+ * @author Ed Hartnett @date 2022-08-12
+ */
+g2int
+g2c_jpcunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+               float *fld)
+{
+    return jpcunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
 }

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -33,14 +33,23 @@
  output. Data values assumed to be reals.
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
+ * @param verbose If non-zero, error messages will be printed in case
+ * of error. Otherwise, error codes will be return but no error
+ * messages printed. Calls to the original g2c API may cause error
+ * messages to be printed in case of error. For the new g2c_ API, no
+ * error messages will be printed - instead an error code will be
+ * returned. Call g2c_strerror() to get the error message for any
+ * error code.
  *
- * @return ::G2C_NOERROR for success, error code otherwise.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_EPNG Error encoding/decoding PNG data.
  *
  * @author Ed Hartnett @date Aug 8, 2022
  */
 static int
 pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrstmpl, 
-	    unsigned char *cpack, g2int *lcpack)
+	    unsigned char *cpack, g2int *lcpack, int verbose)
 {
     g2int *ifld = NULL;
     static float alog2 = ALOG2;       /*  ln(2.0) */
@@ -171,8 +180,11 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
 
         /* Encode data into PNG Format. */
         if ((*lcpack = (g2int)enc_png(ctemp, width, height, nbits, cpack)) <= 0)
-            printf("pngpack: ERROR Packing PNG = %d\n", (int)*lcpack);
-        
+	{
+	    if (verbose)
+		printf("pngpack: ERROR Packing PNG = %d\n", (int)*lcpack);
+	    ret = G2C_EPNG;
+	}
         free(ctemp);
     }
     else
@@ -257,7 +269,9 @@ pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
  *
- * @return ::G2C_NOERROR for success, error code otherwise.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_EPNG Error encoding/decoding PNG data.
  *
  * @author Ed Hartnett
  */
@@ -309,7 +323,9 @@ g2c_pngpackf(float *fld, int width, int height, int *idrstmpl,
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
  *
- * @return ::G2C_NOERROR for success, error code otherwise.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2C_EPNG Error encoding/decoding PNG data.
  *
  * @author Ed Hartnett @date Aug 8, 2022
  */

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -60,6 +60,7 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     unsigned char *ctemp;
     float *ffld = fld;
     double *dfld = fld;
+    int ret = G2C_NOERROR;
 
     LOG((2, "pngpack_int fld_is_double %d width %ld height %ld idrstmpl[1] %d",
 	 fld_is_double, width, height, idrstmpl[1]));
@@ -203,7 +204,7 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     if (ifld)
         free(ifld);
 
-    return G2C_NOERROR;
+    return ret;
 }
 
 /**
@@ -240,7 +241,7 @@ pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
         unsigned char *cpack, g2int *lcpack)
 {
     /* Ignore the return value. */
-    pngpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack);
+    pngpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack, 1);
 }
 
 /**
@@ -286,7 +287,7 @@ g2c_pngpackf(float *fld, int width, int height, int *idrstmpl,
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
 
-    ret = pngpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8);
+    ret = pngpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8, 0);
 
     if (!ret)
     {
@@ -340,7 +341,7 @@ g2c_pngpackd(double *fld, int width, int height, int *idrstmpl,
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
 
-    ret = pngpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8);
+    ret = pngpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8, 0);
 
     if (!ret)
     {

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -262,10 +262,25 @@ pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @author Ed Hartnett
  */
 int
-g2c_pngpackf(float *fld, g2int width, g2int height, g2int *idrstmpl, 
-             unsigned char *cpack, g2int *lcpack)
+g2c_pngpackf(float *fld, int width, int height, int *idrstmpl, 
+             unsigned char *cpack, int *lcpack)
 {
-    return pngpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack);
+    g2int width8 = width, height8 = height, lcpack8 = *lcpack;
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    int i, ret;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+
+    ret = pngpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8);
+
+    if (!ret)
+    {
+        for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+            idrstmpl[i] = (int)idrstmpl8[i];
+        *lcpack = (g2int)lcpack8;
+    }
+    return ret;
 }
 
 /**
@@ -299,9 +314,24 @@ g2c_pngpackf(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @author Ed Hartnett @date Aug 8, 2022
  */
 int
-g2c_pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl, 
-             unsigned char *cpack, g2int *lcpack)
+g2c_pngpackd(double *fld, int width, int height, int *idrstmpl, 
+             unsigned char *cpack, int *lcpack)
 {
-    return pngpack_int(fld, 1, width, height, idrstmpl, cpack, lcpack);
+    g2int width8 = width, height8 = height, lcpack8 = *lcpack;
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    int i, ret;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+
+    ret = pngpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8);
+
+    if (!ret)
+    {
+        for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+            idrstmpl[i] = (int)idrstmpl8[i];
+        *lcpack = (g2int)lcpack8;
+    }
+    return ret;
 }
 

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -281,17 +281,17 @@ g2c_pngpackf(float *fld, int width, int height, int *idrstmpl,
              unsigned char *cpack, int *lcpack)
 {
     g2int width8 = width, height8 = height, lcpack8 = *lcpack;
-    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int idrstmpl8[G2C_PNG_DRS_TEMPLATE_LEN];
     int i, ret;
     
-    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+    for (i = 0; i < G2C_PNG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
 
     ret = pngpack_int(fld, 0, width8, height8, idrstmpl8, cpack, &lcpack8, 0);
 
     if (!ret)
     {
-        for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        for (i = 0; i < G2C_PNG_DRS_TEMPLATE_LEN; i++)
             idrstmpl[i] = (int)idrstmpl8[i];
         *lcpack = (g2int)lcpack8;
     }
@@ -335,17 +335,17 @@ g2c_pngpackd(double *fld, int width, int height, int *idrstmpl,
              unsigned char *cpack, int *lcpack)
 {
     g2int width8 = width, height8 = height, lcpack8 = *lcpack;
-    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int idrstmpl8[G2C_PNG_DRS_TEMPLATE_LEN];
     int i, ret;
     
-    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+    for (i = 0; i < G2C_PNG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
 
     ret = pngpack_int(fld, 1, width8, height8, idrstmpl8, cpack, &lcpack8, 0);
 
     if (!ret)
     {
-        for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        for (i = 0; i < G2C_PNG_DRS_TEMPLATE_LEN; i++)
             idrstmpl[i] = (int)idrstmpl8[i];
         *lcpack = (g2int)lcpack8;
     }

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -33,11 +33,12 @@
  output. Data values assumed to be reals.
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
- * @return void
+ *
+ * @return ::G2C_NOERROR for success, error code otherwise.
  *
  * @author Ed Hartnett @date Aug 8, 2022
  */
-static void
+static int
 pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrstmpl, 
 	    unsigned char *cpack, g2int *lcpack)
 {
@@ -189,6 +190,8 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
     
     if (ifld)
         free(ifld);
+
+    return G2C_NOERROR;
 }
 
 /**
@@ -224,7 +227,45 @@ void
 pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl, 
         unsigned char *cpack, g2int *lcpack)
 {
+    /* Ignore the return value. */
     pngpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack);
+}
+
+/**
+ * This subroutine packs up a float data field into PNG image format. 
+ *
+ * After the data field is scaled, and the reference value is
+ * subtracted out, it is treated as a grayscale image and passed to a
+ * PNG encoder. It also fills in GRIB2 Data Representation Template
+ * 5.41 or 5.40010 with the appropriate values.
+ *
+ * @param fld Pointer to array of float that contains the data values
+ * to pack.
+ * @param width Number of points in the x direction.
+ * @param height Number of points in the y direction.
+ * @param idrstmpl Contains the array of values for Data
+ * Representation
+ * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml)
+ * or 5.40010.
+ * - 0 Reference value - ignored on input, set by pngpack routine.
+ * - 1 Binary Scale Factor - used on input.
+ * - 2 Decimal Scale Factor - used on input.
+ * - 3 number of bits for each grayscale pixel value - ignored on
+ input.
+ * - 4 Original field type - currently ignored on input, set = 0 on
+ output. Data values assumed to be reals.
+ * @param cpack The packed data field.
+ * @param lcpack length of packed field cpack.
+ *
+ * @return ::G2C_NOERROR for success, error code otherwise.
+ *
+ * @author Ed Hartnett
+ */
+int
+g2c_pngpackf(float *fld, g2int width, g2int height, g2int *idrstmpl, 
+             unsigned char *cpack, g2int *lcpack)
+{
+    return pngpack_int(fld, 0, width, height, idrstmpl, cpack, lcpack);
 }
 
 /**
@@ -253,12 +294,14 @@ pngpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
  * @param cpack The packed data field.
  * @param lcpack length of packed field cpack.
  *
+ * @return ::G2C_NOERROR for success, error code otherwise.
+ *
  * @author Ed Hartnett @date Aug 8, 2022
  */
-void
-pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl, 
-	 unsigned char *cpack, g2int *lcpack)
+int
+g2c_pngpackd(double *fld, g2int width, g2int height, g2int *idrstmpl, 
+             unsigned char *cpack, g2int *lcpack)
 {
-    pngpack_int(fld, 1, width, height, idrstmpl, cpack, lcpack);
+    return pngpack_int(fld, 1, width, height, idrstmpl, cpack, lcpack);
 }
 

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -125,10 +125,17 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @author Ed Hartnett
  */
 int
-g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-              float *fld)
+g2c_pngunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
+	       float *fld)
 {
-    return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int len8 = len, ndpts8 = ndpts;
+    int i;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+    
+    return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0);
 }
 
 /**
@@ -148,8 +155,15 @@ g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @author Ed Hartnett @date Aug 8, 2022
  */
 int
-g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-	   double *fld)
+g2c_pngunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
+	       double *fld)
 {
-    return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);
+    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int len8 = len, ndpts8 = ndpts;
+    int i;
+    
+    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+        idrstmpl8[i] = idrstmpl[i];
+    
+    return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1);
 }

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -23,14 +23,23 @@
  * @param fld Pointer that will get the unpacked data values.
  * @param fld_is_double If non-zero, then fld will get data as double,
  * otherwise float.
+ * @param verbose If non-zero, error messages will be printed in case
+ * of error. Otherwise, error codes will be return but no error
+ * messages printed. Calls to the original g2c API may cause error
+ * messages to be printed in case of error. For the new g2c_ API, no
+ * error messages will be printed - instead an error code will be
+ * returned. Call g2c_strerror() to get the error message for any
+ * error code.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No Error.
+ * - ::G2C_ENOMEM Out of memory.
  *
  * @author Stephen Gilbert, Ed Hartnett @date Aug 8, 2022
  */
 static int
 pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-	      void *fld, int fld_is_double)
+	      void *fld, int fld_is_double, int verbose)
 {
     g2int *ifld;
     g2int j, nbits, width, height;
@@ -55,8 +64,9 @@ pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
         ctemp = calloc(ndpts * 4, 1);
         if (!ifld || !ctemp)
         {
-            fprintf(stderr,"Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
-            return G2_JPCUNPACK_MEM;
+	    if (verbose)
+		fprintf(stderr,"Could not allocate space in jpcunpack.\n  Data field NOT upacked.\n");
+            return G2C_ENOMEM;
         }
         dec_png(cpack, &width, &height, ctemp);
         gbits(ctemp, ifld, 0, nbits, 0, ndpts);
@@ -96,7 +106,9 @@ pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @param ndpts The number of data values to unpack.
  * @param fld Contains the unpacked data values.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No error.
+ * - ::G2_JPCUNPACK_MEM Out of memory.
  *
  * @author Stephen Gilbert @date 2003-08-27
  * @author Ed Hartnett
@@ -105,7 +117,12 @@ g2int
 pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
           float *fld)
 {
-    return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+    int ret;
+    
+    if ((ret = pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 0, 1)) == G2C_ENOMEM)
+	return G2_JPCUNPACK_MEM;
+
+    return ret;
 }
 
 /**
@@ -120,10 +137,12 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  * @param ndpts The number of data values to unpack.
  * @param fld Contains the unpacked data values.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No Error.
+ * - ::G2C_ENOMEM Out of memory.
  *
- * @author Ed Hartnett
- */
+ * @author Ed Hartnett @date Sep 8, 2022 
+*/
 int
 g2c_pngunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 	       float *fld)
@@ -135,7 +154,7 @@ g2c_pngunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
-    return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0);
+    return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0, 0);
 }
 
 /**
@@ -150,7 +169,9 @@ g2c_pngunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
  * @param ndpts The number of data values to unpack.
  * @param fld Contains the unpacked data values.
  *
- * @return 0 for success, 1 for memory allocation error.
+ * @return
+ * - ::G2C_NOERROR No Error.
+ * - ::G2C_ENOMEM Out of memory.
  *
  * @author Ed Hartnett @date Aug 8, 2022
  */
@@ -165,5 +186,5 @@ g2c_pngunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
     for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
-    return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1);
+    return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1, 0);
 }

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -28,7 +28,7 @@
  *
  * @author Stephen Gilbert, Ed Hartnett @date Aug 8, 2022
  */
-static g2int
+static int
 pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 	      void *fld, int fld_is_double)
 {
@@ -122,10 +122,33 @@ pngunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
  *
  * @return 0 for success, 1 for memory allocation error.
  *
+ * @author Ed Hartnett
+ */
+int
+g2c_pngunpackf(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+              float *fld)
+{
+    return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 0);
+}
+
+/**
+ * This subroutine unpacks a data field that was packed into a PNG
+ * image format using info from the GRIB2 Data Representation Template
+ * 5.41 or 5.40010.
+ *
+ * @param cpack The packed data field (character*1 array).
+ * @param len length of packed field cpack().
+ * @param idrstmpl Pointer to array of values for Data Representation
+ * [Template 5.41](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml) or 5.40010.
+ * @param ndpts The number of data values to unpack.
+ * @param fld Contains the unpacked data values.
+ *
+ * @return 0 for success, 1 for memory allocation error.
+ *
  * @author Ed Hartnett @date Aug 8, 2022
  */
-g2int
-pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
+int
+g2c_pngunpackd(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 	   double *fld)
 {
     return pngunpack_int(cpack, len, idrstmpl, ndpts, fld, 1);

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -147,11 +147,11 @@ int
 g2c_pngunpackf(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 	       float *fld)
 {
-    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int idrstmpl8[G2C_PNG_DRS_TEMPLATE_LEN];
     g2int len8 = len, ndpts8 = ndpts;
     int i;
     
-    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+    for (i = 0; i < G2C_PNG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
     return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 0, 0);
@@ -179,11 +179,11 @@ int
 g2c_pngunpackd(unsigned char *cpack, size_t len, int *idrstmpl, size_t ndpts,
 	       double *fld)
 {
-    g2int idrstmpl8[G2C_JPEG_DRS_TEMPLATE_LEN];
+    g2int idrstmpl8[G2C_PNG_DRS_TEMPLATE_LEN];
     g2int len8 = len, ndpts8 = ndpts;
     int i;
     
-    for (i = 0; i < G2C_JPEG_DRS_TEMPLATE_LEN; i++)
+    for (i = 0; i < G2C_PNG_DRS_TEMPLATE_LEN; i++)
         idrstmpl8[i] = idrstmpl[i];
     
     return pngunpack_int(cpack, len8, idrstmpl8, ndpts8, fld, 1, 0);

--- a/src/rdieee.c
+++ b/src/rdieee.c
@@ -27,9 +27,9 @@ rdieee(g2int *rieee, float *a, g2int num)
     float  sign,temp;
     static float  two23,two126;
     static g2int test = 0;
-    uint64_t msk1 = 0x80000000;        // 10000000000000000000000000000000 binary
-    g2int msk2 = 0x7F800000;         // 01111111100000000000000000000000 binary
-    g2int msk3 = 0x007FFFFF;         // 00000000011111111111111111111111 binary
+    uint64_t msk1 = 0x80000000;        /* 10000000000000000000000000000000 binary */
+    g2int msk2 = 0x7F800000;         /* 01111111100000000000000000000000 binary */
+    g2int msk3 = 0x007FFFFF;         /* 00000000011111111111111111111111 binary */
 
     if (test == 0)
     {
@@ -40,12 +40,11 @@ rdieee(g2int *rieee, float *a, g2int num)
 
     for (j = 0; j < num; j++)
     {
-
-        //  Extract sign bit, exponent, and mantissa
+        /*  Extract sign bit, exponent, and mantissa */
         isign = (rieee[j]&msk1)>>31;
         iexp = (rieee[j]&msk2)>>23;
         imant = (rieee[j]&msk3);
-        //printf("SAGieee= %ld %ld %ld\n",isign,iexp,imant);
+        /*printf("SAGieee= %ld %ld %ld\n",isign,iexp,imant); */
 
         sign = 1.0;
         if (isign == 1)

--- a/src/rdieee.c
+++ b/src/rdieee.c
@@ -26,44 +26,46 @@ rdieee(g2int *rieee, float *a, g2int num)
 
     float  sign,temp;
     static float  two23,two126;
-    static g2int test=0;
-    uint64_t msk1=0x80000000;        // 10000000000000000000000000000000 binary
-    g2int msk2=0x7F800000;         // 01111111100000000000000000000000 binary
-    g2int msk3=0x007FFFFF;         // 00000000011111111111111111111111 binary
+    static g2int test = 0;
+    uint64_t msk1 = 0x80000000;        // 10000000000000000000000000000000 binary
+    g2int msk2 = 0x7F800000;         // 01111111100000000000000000000000 binary
+    g2int msk3 = 0x007FFFFF;         // 00000000011111111111111111111111 binary
 
-    if ( test == 0 ) {
-        two23=(float)int_power(2.0,-23);
-        two126=(float)int_power(2.0,-126);
-        test=1;
+    if (test == 0)
+    {
+        two23 = (float)int_power(2.0,-23);
+        two126 = (float)int_power(2.0,-126);
+        test = 1;
     }
 
-    for (j=0;j<num;j++) {
-//
-//  Extract sign bit, exponent, and mantissa
-//
-        isign=(rieee[j]&msk1)>>31;
-        iexp=(rieee[j]&msk2)>>23;
-        imant=(rieee[j]&msk3);
+    for (j = 0; j < num; j++)
+    {
+
+        //  Extract sign bit, exponent, and mantissa
+        isign = (rieee[j]&msk1)>>31;
+        iexp = (rieee[j]&msk2)>>23;
+        imant = (rieee[j]&msk3);
         //printf("SAGieee= %ld %ld %ld\n",isign,iexp,imant);
 
-        sign=1.0;
-        if (isign == 1) sign=-1.0;
+        sign = 1.0;
+        if (isign == 1)
+            sign = -1.0;
 
-        if ( (iexp > 0) && (iexp < 255) ) {
-            temp=(float)int_power(2.0,(iexp-127));
-            a[j]=sign*temp*(1.0+(two23*(float)imant));
+        if ((iexp > 0) && (iexp < 255))
+        {
+            temp = (float)int_power(2.0, (iexp - 127));
+            a[j] = sign * temp * (1.0 + (two23 * (float)imant));
         }
-        else if ( iexp == 0 ) {
-            if ( imant != 0 )
-                a[j]=sign*two126*two23*(float)imant;
+        else if (iexp == 0)
+        {
+            if (imant != 0)
+                a[j] = sign * two126 * two23 * (float)imant;
             else
-                a[j]=sign*0.0;
+                a[j] = sign * 0.0;
 
         }
-        else if ( iexp == 255 )
-            a[j]=sign*(1E+37);
-
+        else if (iexp == 255)
+            a[j] = sign * (1E+37);
 
     }
-
 }

--- a/src/util.c
+++ b/src/util.c
@@ -186,6 +186,8 @@ g2c_strerror(int g2cerr)
 	return "End of message in wrong place";
     case G2C_EBADSECTION:
 	return "Invalid section number";
+    case G2C_EJPEG:
+	return "Error encoding/decoding JPEG data";
 
     default:
 	 return "Unknown Error";	

--- a/src/util.c
+++ b/src/util.c
@@ -188,6 +188,8 @@ g2c_strerror(int g2cerr)
 	return "Invalid section number";
     case G2C_EJPEG:
 	return "Error encoding/decoding JPEG data";
+    case G2C_EPNG:
+	return "Error encoding/decoding PNG data";
 
     default:
 	 return "Unknown Error";	

--- a/tests/tst_error.c
+++ b/tests/tst_error.c
@@ -52,6 +52,8 @@ int main()
 	return G2C_ERROR;
     if (strncmp(g2c_strerror(-67), "Error encoding/decoding JPEG data", MAX_LEN))
 	return G2C_ERROR;
+    if (strncmp(g2c_strerror(-68), "Error encoding/decoding PNG data", MAX_LEN))
+	return G2C_ERROR;
     if (strncmp(g2c_strerror(999), "Unknown Error", MAX_LEN))
 	return G2C_ERROR;
 

--- a/tests/tst_error.c
+++ b/tests/tst_error.c
@@ -50,6 +50,8 @@ int main()
 	return G2C_ERROR;
     if (strncmp(g2c_strerror(-66), "Invalid section number", MAX_LEN))
 	return G2C_ERROR;
+    if (strncmp(g2c_strerror(-67), "Error encoding/decoding JPEG data", MAX_LEN))
+	return G2C_ERROR;
     if (strncmp(g2c_strerror(999), "Unknown Error", MAX_LEN))
 	return G2C_ERROR;
 

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -79,7 +79,7 @@ main()
         }
     }
     printf("ok!\n");
-    printf("Testing jpcpackd()/jpcunpackd() call...");
+    printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call...");
     {
         g2int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
@@ -91,10 +91,10 @@ main()
         int i;
 
         /* Pack the data. */
-        jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+        g2c_jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
         /* Unpack the data. */
-        if (jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+        if (g2c_jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)
@@ -141,7 +141,7 @@ main()
         }
     }
     printf("ok!\n");
-    printf("Testing jpcpackd()/jpcunpackd() call with different drstmpl values...");
+    printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call with different drstmpl values...");
     {
         g2int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
@@ -163,10 +163,10 @@ main()
         int i;
 
         /* Pack the data. */
-        jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+        g2c_jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
         /* Unpack the data. */
-        if (jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+        if (g2c_jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)
@@ -213,7 +213,7 @@ main()
         }
     }
     printf("ok!\n");
-    printf("Testing jpcpackd()/jpcunpackd() call with constant data field...");
+    printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call with constant data field...");
     {
         g2int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
@@ -235,10 +235,10 @@ main()
         int i;
 
         /* Pack the data. */
-        jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+        g2c_jpcpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
         /* Unpack the data. */
-        if (jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+        if (g2c_jpcunpackd(cpack, len, idrstmpl, ndpts, fld_in))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -122,6 +122,32 @@ main()
         }
     }
     printf("ok!\n");
+    printf("Testing g2c_jpcpackf()/g2c_jpcunpackf() call...");
+    {
+        int height = 2, width = 2;
+        size_t len = PACKED_LEN, ndpts = DATA_LEN;
+	float fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
+        float fld_in[DATA_LEN];
+        unsigned char cpack[PACKED_LEN];
+        size_t lcpack = PACKED_LEN;
+        int idrstmpl[7] = {0, 1, 1, 16, 0, 0, 0};
+        int i;
+
+        /* Pack the data. */
+        g2c_jpcpackf(fld, width, height, idrstmpl, cpack, &lcpack);
+
+        /* Unpack the data. */
+        if (g2c_jpcunpackf(cpack, len, idrstmpl, ndpts, fld_in))
+            return G2C_ERROR;
+
+        for (i = 0; i < DATA_LEN; i++)
+        {
+            /* printf("%g %g\n", fld[i], fld_in[i]); */
+            if (fld[i] != fld_in[i])
+        	return G2C_ERROR;
+        }
+    }
+    printf("ok!\n");
     printf("Testing jpcpack()/jpcunpack() call with different drstmpl values...");
     {
         g2int height = 2, width = 2;

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -160,15 +160,15 @@ main()
     printf("ok!\n");
     printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call with different drstmpl values...");
     {
-        g2int height = 2, width = 2;
-        g2int len = PACKED_LEN, ndpts = DATA_LEN;
+        int height = 2, width = 2;
+        size_t len = PACKED_LEN, ndpts = DATA_LEN;
         double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
         double fld_in[DATA_LEN];
         unsigned char cpack[PACKED_LEN];
-        g2int lcpack = PACKED_LEN;
+        size_t lcpack = PACKED_LEN;
         /* See
          * https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml */
-        g2int idrstmpl[7] = {
+        int idrstmpl[7] = {
             0, /* Reference value (R) (IEEE 32-bit floating-point value) */
             0, /* Binary scale factor (E) */
             1, /* Decimal scale factor (D) */
@@ -232,15 +232,15 @@ main()
     printf("ok!\n");
     printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call with constant data field...");
     {
-        g2int height = 2, width = 2;
-        g2int len = PACKED_LEN, ndpts = DATA_LEN;
+        int height = 2, width = 2;
+        size_t len = PACKED_LEN, ndpts = DATA_LEN;
         double fld[DATA_LEN] = {1.0, 1.0, 1.0, 1.0};
         double fld_in[DATA_LEN];
         unsigned char cpack[PACKED_LEN];
-        g2int lcpack = PACKED_LEN;
+        size_t lcpack = PACKED_LEN;
         /* See
          * https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-40.shtml */
-        g2int idrstmpl[7] = {
+        int idrstmpl[7] = {
             0, /* Reference value (R) (IEEE 32-bit floating-point value) */
             0, /* Binary scale factor (E) */
             1, /* Decimal scale factor (D) */

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -96,7 +96,7 @@ main()
     printf("ok!\n");
     printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call...");
     {
-        g2int height = 2, width = 2;
+        int height = 2, width = 2;
         g2int len = PACKED_LEN, ndpts = DATA_LEN;
         double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
         double fld_in[DATA_LEN];

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -44,8 +44,9 @@ main()
     printf("Testing g2c_enc_jpeg2000()/g2c_dec_jpeg2000() call...");
     {
         unsigned char data[DATA_LEN] = {1, 2, 3, 4};
-        g2int width = 2, height = 2, nbits = 4;
-        g2int ltype = 0, ratio = 0, retry = 0, jpclen = PACKED_LEN;
+        int width = 2, height = 2, nbits = 4;
+        int ltype = 0, ratio = 0, retry = 0, jpclen = PACKED_LEN;
+        g2int jpclen8;
         char outjpc[PACKED_LEN];
         g2int outfld[DATA_LEN];
         int i;
@@ -57,7 +58,8 @@ main()
             return G2C_ERROR;
 
         /* Now decode it. */
-        if ((ret = dec_jpeg2000(outjpc, jpclen, outfld)))
+        jpclen8 = jpclen;
+        if ((ret = dec_jpeg2000(outjpc, jpclen8, outfld)))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -99,12 +99,12 @@ main()
     printf("Testing g2c_jpcpackd()/g2c_jpcunpackd() call...");
     {
         int height = 2, width = 2;
-        g2int len = PACKED_LEN, ndpts = DATA_LEN;
+        size_t len = PACKED_LEN, ndpts = DATA_LEN;
         double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
         double fld_in[DATA_LEN];
         unsigned char cpack[PACKED_LEN];
-        g2int lcpack = PACKED_LEN;
-        g2int idrstmpl[7] = {0, 1, 1, 16, 0, 0, 0};
+        size_t lcpack = PACKED_LEN;
+        int idrstmpl[7] = {0, 1, 1, 16, 0, 0, 0};
         int i;
 
         /* Pack the data. */

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -15,6 +15,7 @@ int
 main()
 {
     printf("Testing JPEG functions.\n");
+#ifdef USE_JPEG2000
     printf("Testing enc_jpeg2000()/dec_jpeg2000() call...");
     {
         unsigned char data[DATA_LEN] = {1, 2, 3, 4};
@@ -68,6 +69,7 @@ main()
         }
     }
     printf("ok!\n");
+#endif
     printf("Testing jpcpack()/jpcunpack() call...");
     {
         g2int height = 2, width = 2;

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -11,16 +11,6 @@
 #define DATA_LEN 4
 #define PACKED_LEN 200
 
-/* Prototypes we are testing. */
-int enc_jpeg2000(unsigned char *cin, g2int width, g2int height, g2int nbits,
-                 g2int ltype, g2int ratio, g2int retry, char *outjpc,
-                 g2int jpclen);
-int dec_jpeg2000(char *injpc, g2int bufsize, g2int *outfld);
-void jpcpack(float *fld, g2int width, g2int height, g2int *idrstmpl,
-             unsigned char *cpack, g2int *lcpack);
-g2int jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
-                float *fld);
-
 int
 main()
 {
@@ -38,9 +28,33 @@ main()
         /* Encode some data. */
         if ((ret = enc_jpeg2000(data, width, height, nbits, ltype,
                                 ratio, retry, outjpc, jpclen)) < 0)
-        {
             return G2C_ERROR;
+
+        /* Now decode it. */
+        if ((ret = dec_jpeg2000(outjpc, jpclen, outfld)))
+            return G2C_ERROR;
+
+        for (i = 0; i < DATA_LEN; i++)
+        {
+            if (outfld[i] != data[i])
+                return G2C_ERROR;
         }
+    }
+    printf("ok!\n");
+    printf("Testing g2c_enc_jpeg2000()/g2c_dec_jpeg2000() call...");
+    {
+        unsigned char data[DATA_LEN] = {1, 2, 3, 4};
+        g2int width = 2, height = 2, nbits = 4;
+        g2int ltype = 0, ratio = 0, retry = 0, jpclen = PACKED_LEN;
+        char outjpc[PACKED_LEN];
+        g2int outfld[DATA_LEN];
+        int i;
+        int ret;
+
+        /* Encode some data. */
+        if ((ret = g2c_enc_jpeg2000(data, width, height, nbits, ltype,
+                                    ratio, retry, outjpc, jpclen)) < 0)
+            return G2C_ERROR;
 
         /* Now decode it. */
         if ((ret = dec_jpeg2000(outjpc, jpclen, outfld)))

--- a/tests/tst_jpeg.c
+++ b/tests/tst_jpeg.c
@@ -45,10 +45,10 @@ main()
     {
         unsigned char data[DATA_LEN] = {1, 2, 3, 4};
         int width = 2, height = 2, nbits = 4;
-        int ltype = 0, ratio = 0, retry = 0, jpclen = PACKED_LEN;
-        g2int jpclen8;
+        int ltype = 0, ratio = 0, retry = 0;
+        size_t jpclen = PACKED_LEN;
         char outjpc[PACKED_LEN];
-        g2int outfld[DATA_LEN];
+        int outfld[DATA_LEN];
         int i;
         int ret;
 
@@ -58,8 +58,7 @@ main()
             return G2C_ERROR;
 
         /* Now decode it. */
-        jpclen8 = jpclen;
-        if ((ret = dec_jpeg2000(outjpc, jpclen8, outfld)))
+        if ((ret = g2c_dec_jpeg2000(outjpc, jpclen, outfld)))
             return G2C_ERROR;
 
         for (i = 0; i < DATA_LEN; i++)

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -69,7 +69,7 @@ main()
 	}
     }
     printf("ok!\n");
-    printf("Testing pngpackd()/pngunpackd() calls...");
+    printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls...");
     {
 	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
 	double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
@@ -80,10 +80,10 @@ main()
 	int i;
 
 	/* Pack the data. */
-	pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+	g2c_pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
 	/* Unpack the data. */
-	if (pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+	if (g2c_pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
 	    return G2C_ERROR;
 
 	for (i = 0; i < DATA_LEN; i++)
@@ -126,7 +126,7 @@ main()
 	}
     }
     printf("ok!\n");
-    printf("Testing pngpackd()/pngunpackd() calls with different settings...");
+    printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls with different settings...");
     {
 	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
 	double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
@@ -144,10 +144,10 @@ main()
 	int i;
 
 	/* Pack the data. */
-	pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+	g2c_pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
 	/* Unpack the data. */
-	if (pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+	if (g2c_pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
 	    return G2C_ERROR;
 
 	for (i = 0; i < DATA_LEN; i++)
@@ -190,7 +190,7 @@ main()
 	}
     }
     printf("ok!\n");
-    printf("Testing pngpackd()/pngunpackd() calls with constant data...");
+    printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls with constant data...");
     {
 	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
 	double fld[DATA_LEN] = {1.0, 1.0, 1.0, 1.0};
@@ -208,10 +208,10 @@ main()
 	int i;
 
 	/* Pack the data. */
-	pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
+	g2c_pngpackd(fld, width, height, idrstmpl, cpack, &lcpack);
 
 	/* Unpack the data. */
-	if (pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
+	if (g2c_pngunpackd(cpack, len, idrstmpl, ndpts, fld_in))
 	    return G2C_ERROR;
 
 	for (i = 0; i < DATA_LEN; i++)

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -71,12 +71,13 @@ main()
     printf("ok!\n");
     printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls...");
     {
-	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
+	int height = 2, width = 2;
+	size_t ndpts = DATA_LEN, len = PACKED_LEN; 	
 	double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
 	double fld_in[DATA_LEN];
 	unsigned char cpack[PACKED_LEN];
-	g2int lcpack;
-        g2int idrstmpl[5] = {0, 1, 1, 16, 0};
+	int lcpack;
+        int idrstmpl[5] = {0, 1, 1, 16, 0};
 	int i;
 
 	/* Pack the data. */
@@ -128,13 +129,14 @@ main()
     printf("ok!\n");
     printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls with different settings...");
     {
-	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
+	int height = 2, width = 2;
+	size_t ndpts = DATA_LEN, len = PACKED_LEN; 	
 	double fld[DATA_LEN] = {1.0, 2.0, 3.0, 0.0};
 	double fld_in[DATA_LEN];
 	unsigned char cpack[PACKED_LEN];
-	g2int lcpack;
+	int lcpack;
         /* See https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml */
-        g2int idrstmpl[5] = {
+        int idrstmpl[5] = {
             0, /* Reference value (R) (IEEE 32-bit floating-point value) */
             0, /* Binary scale factor (E) */
             1, /* Decimal scale factor (D) */
@@ -192,13 +194,14 @@ main()
     printf("ok!\n");
     printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls with constant data...");
     {
-	g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN; 	
+	int height = 2, width = 2;
+	size_t ndpts = DATA_LEN, len = PACKED_LEN; 	
 	double fld[DATA_LEN] = {1.0, 1.0, 1.0, 1.0};
 	double fld_in[DATA_LEN];
 	unsigned char cpack[PACKED_LEN];
-	g2int lcpack;
+	int lcpack;
         /* See https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_temp5-41.shtml */
-        g2int idrstmpl[5] = {
+        int idrstmpl[5] = {
             0, /* Reference value (R) (IEEE 32-bit floating-point value) */
             0, /* Binary scale factor (E) */
             1, /* Decimal scale factor (D) */


### PR DESCRIPTION
Removing g2int from new g2c_ function parameters.

Also now return error codes from jpcpack/jpcunpack and pngpack/pngunpack instead of just printing error messages.

Fixes #303 
Part of #209
Part of #173