### PR TITLE
reduce the number of mac CI runs

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -12,24 +12,12 @@ jobs:
       matrix:
         config:
         - {
-            name: "png_off jasper_off openjpeg_off",
-            options: "-DUSE_PNG=OFF -DUSE_Jasper=OFF -DUSE_OpenJPEG=OFF"
-          }
-        - {
             name: "png_on jasper_off openjpeg_off",
             options: "-DUSE_PNG=ON  -DUSE_Jasper=OFF -DUSE_OpenJPEG=OFF"
           }
         - {
-            name: "png_off jasper_on openjpeg_off",
-            options: "-DUSE_PNG=OFF -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
-          }
-        - {
             name: "png_on jasper_on openjpeg_off",
             options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
-          }
-        - {
-            name: "png_off jasper_off openjpeg_on",
-            options: "-DUSE_PNG=OFF -DUSE_Jasper=OFF -DUSE_OpenJPEG=ON "
           }
         - {
             name: "png_on jasper_off openjpeg_on",


### PR DESCRIPTION
Mac CI runs are really slow.

I'm going to reduce the number of them to make PR go thought CI faster. These combinations are already tested on Linux, which is faster.