### PR TITLE
silenced some tests in the CI runs

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -51,11 +51,11 @@ jobs:
         mkdir build
         cd build
         # Windows CI fails when building with shared libs, turn off
-        cmake -DUSE_OpenJPEG=ON -DUSE_Jasper=OFF -DBUILD_SHARED_LIBS=OFF ..
+        cmake -DUSE_OpenJPEG=ON -DUSE_Jasper=OFF -DBUILD_SHARED_LIBS=OFF -DLOGGING=ON ..
         cmake --build .
 
     - name: test
       run: |
         cd g2c/build
-        ctest  --output-on-failure --rerun-failed
+        ctest  --output-on-failure --rerun-failed --extra-verbose
 

--- a/tests/tst_decode.c
+++ b/tests/tst_decode.c
@@ -58,7 +58,7 @@ int main()
         g2int ndpts = 121;
         float *fld;
 
-        g2c_set_log_level(10);
+        /* g2c_set_log_level(10); */
 
         /* Call g2_unpack7() on our message. */
         if ((ret = g2_unpack7(cgrib, &iofst, igdsnum, igdstmpl, idrsnum, idrstmpl, ndpts, &fld)))
@@ -82,7 +82,7 @@ int main()
         int ndpts = 121;
         float *fld;
 
-        g2c_set_log_level(10);
+        /* g2c_set_log_level(10); */
 
         /* Allocate memory to hold data. */
         if (!(fld = malloc(sizeof(float) * ndpts)))
@@ -111,7 +111,7 @@ int main()
         gribfield* gfld = NULL;
 
         /* Call g2_info() on our message. */
-        g2c_set_log_level(10);
+        /* g2c_set_log_level(10); */
         if ((ret = g2_info(cgrib, listsec0, listsec1, &numfields, &numlocal)))
             return ret;
 

--- a/tests/tst_files.c
+++ b/tests/tst_files.c
@@ -95,9 +95,9 @@ main()
 	    if ((ret = g2c_get_msg(g2cid, 0, test_buf_size[i], &bytes_to_msg, &bytes_in_msg,
 				   &cbuf)))
 		return ret;
-	    for (i = 0; i < 10; i++)
-		printf("cbuf[%d] = %2x\n", i, cbuf[i]);
-	    printf("bytes_to_msg %ld bytes_in_msg %ld\n", bytes_to_msg, bytes_in_msg);
+	    /* for (i = 0; i < 10; i++) */
+	    /*     printf("cbuf[%d] = %2x\n", i, cbuf[i]); */
+	    /* printf("bytes_to_msg %ld bytes_in_msg %ld\n", bytes_to_msg, bytes_in_msg); */
 	    if (bytes_to_msg != 0 || bytes_in_msg != 15254)
 		return G2C_ERROR;
 

--- a/tests/tst_params2.c
+++ b/tests/tst_params2.c
@@ -15,7 +15,7 @@ main()
         int g1num, g1ver;
         int ret;
 
-        g2c_set_log_level(5);
+        /* g2c_set_log_level(5); */
         /* This will work. */
         if ((ret = g2c_param_g2tog1(0, 3, 0, &g1num, &g1ver)))
             return ret;

--- a/tests/tst_pdstemplates.c
+++ b/tests/tst_pdstemplates.c
@@ -581,10 +581,10 @@ main()
                         /* Get extension. */
                         if ((ret = g2c_get_pds_template_extension(number[t], template, &extlen, ext)))
                             return ret;
-                        printf("extlen %d {", extlen);
-                        for (e = 0; e < extlen; e++)
-                            printf("%d%s", ext[e], e < extlen - 1 ? ", " : "");
-                        printf("}\n");
+                        /* printf("extlen %d {", extlen); */
+                        /* for (e = 0; e < extlen; e++) */
+                        /*     printf("%d%s", ext[e], e < extlen - 1 ? ", " : ""); */
+                        /* printf("}\n"); */
 
                         /* Check results. */
                         if (extlen != expected_extlen[ext_t])


### PR DESCRIPTION
Part of #320 

Turn of stderr output for some tests to get cleaner output in the CI runs.