### PR TITLE
changing GRIB2 read/write macros to functions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -85,7 +85,7 @@ jobs:
       run: |
         set -e          
         cd $GITHUB_WORKSPACE/g2c/build
-        ctest --verbose --output-on-failure
+        ctest --verbose 
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
         ls -l
           

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,7 +92,7 @@ src/getpoly.c src/gridtemplates.c src/int_power.c src/misspack.c
 src/mkieee.c src/pack_gp.c src/pdstemplates.c src/rdieee.c
 src/reduce.c src/seekgb.c src/simpack.c src/simunpack.c src/specpack.c
 src/specunpack.c src/util.c src/g2cxml.c src/g2cparams.c src/g2cfile.c
-src/g2cdegrib2.c src/g2cprod.c src/g2cinq.c src/g2cindex.c)
+src/g2cdegrib2.c src/g2cprod.c src/g2cinq.c src/g2cindex.c src/g2cio.c)
 
 set_property(TARGET ${lib_name} PROPERTY C_STANDARD 11)
 

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -333,7 +333,7 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 
     /* Read or write section 3. */
     FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def);
-    if ((ret = g2c_file_be_uint4(f, rw_flag, &sec3_info->num_data_points)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, &sec3_info->num_data_points)))
         return ret;
     FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
     FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
@@ -370,7 +370,7 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            if ((ret = g2c_file_template_int4(f, rw_flag, (map[t] < 0 ? 1 : 0),
+            if ((ret = g2c_file_template_int(f, rw_flag, (map[t] < 0 ? 1 : 0),
                                               &sec->template[t])))
                 return ret;
             break;
@@ -479,7 +479,7 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            if ((ret = g2c_file_template_int4(f, rw_flag, (map[t] < 0 ? 1 : 0),
+            if ((ret = g2c_file_template_int(f, rw_flag, (map[t] < 0 ? 1 : 0),
                                               &sec->template[t])))
                 return ret;
             break;
@@ -544,7 +544,7 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         sec5_info = sec->sec_info;
 
     /* Read section 5. */
-    if ((ret = g2c_file_be_uint4(f, rw_flag, &sec5_info->num_data_points)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, &sec5_info->num_data_points)))
         return ret;
     FILE_BE_INT2P(f, rw_flag, &sec5_info->data_def);
     LOG((5, "g2c_rw_section5_metadata num_data_points %d data_def %d",
@@ -579,7 +579,7 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            if ((ret = g2c_file_template_int4(f, rw_flag, (map[t] < 0 ? 1 : 0),
+            if ((ret = g2c_file_template_int(f, rw_flag, (map[t] < 0 ? 1 : 0),
                                               &sec->template[t])))
                 return ret;
             break;
@@ -699,7 +699,7 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
     LOG((2, "g2c_rw_section1_metadata rw_flag %d", rw_flag));
 
     /* Read the section. */
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)&msg->sec1_len)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)&msg->sec1_len)))
         return ret;
     
     FILE_BE_INT1P(f, rw_flag, &sec_num);
@@ -772,7 +772,7 @@ read_msg_metadata(G2C_MESSAGE_INFO_T *msg)
         LOG((4, "reading new section at file position %ld", ftell(msg->file->f)));
 
         /* Read section length. */
-        if ((ret = g2c_file_be_uint4(msg->file->f, G2C_FILE_READ, &sec_len)))
+        if ((ret = g2c_file_be_uint(msg->file->f, G2C_FILE_READ, &sec_len)))
             return ret;
 
         /* A section length of 926365495 indicates we've reached

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -49,7 +49,7 @@ MUTEX(m);
  * @author Ed Hartnett 11/7/22
  */
 int
-g2c_file_be_int4p(FILE *f, int write, int neg, int *var)
+g2c_file_be_int4(FILE *f, int write, int neg, int *var)
 {
     unsigned int int_be, tmp_1;
 
@@ -74,11 +74,11 @@ g2c_file_be_int4p(FILE *f, int write, int neg, int *var)
             return G2C_EFILE;
 
         /* Did we read a negative number? Check the sign bit... */
-        if (neg && (int_be & 1<<31))
-        {
-            int_be &= ~(1UL<<31); /* Clear sign bit. */
-            int_be *= -1; /* Make rest of int_be negative. */
-        }
+        /* if (neg && (int_be & 1<<0)) */
+        /* { */
+        /*     int_be &= ~(1UL<<0); /\* Clear sign bit. *\/ */
+        /*     int_be *= -1; /\* Make rest of int_be negative. *\/ */
+        /* } */
         *var = htonl(int_be);
     }
 
@@ -368,7 +368,6 @@ find_available_g2cid(int *g2cid)
 int
 g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 {
-    int int_be;
     short short_be;
     G2C_SECTION3_INFO_T *sec3_info = NULL;
     int maplen, needsext, map[G2C_MAX_GDS_TEMPLATE_MAPLEN];
@@ -395,7 +394,7 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 
     /* Read or write section 3. */
     FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def);
-    if ((ret = g2c_file_be_int4p(f, rw_flag, 0, (int *)&sec3_info->num_data_points)))
+    if ((ret = g2c_file_be_int4(f, rw_flag, 0, (int *)&sec3_info->num_data_points)))
         return ret;
     FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
     FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
@@ -419,6 +418,9 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     /* Read or write the template info. */
     for (t = 0; t < maplen; t++)
     {
+        /* if (t == 14) */
+        /*     printf("here\n"); */
+        /* int int_be; */
         /* Take the absolute value of map[t] because some of the
          * numbers are negative - used to indicate that the
          * cooresponding fields can contain negative data (needed for
@@ -432,7 +434,25 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            FILE_BE_INT4P(f, rw_flag, &sec->template[t]);
+            LOG((6, "file position %ld", ftell(f)));
+
+            /* FILE_BE_INT4P(f, rw_flag, &sec->template[t]); */
+            /* if (rw_flag) */
+            /* { */
+            /*     int_be = ntohl(sec->template[t]); */
+            /*     if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1) */
+            /*         return G2C_EFILE; */
+            /* } */
+            /* else */
+            /* { */
+            /*     if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1) */
+            /*         return G2C_EFILE; */
+            /*     if (t == 11) */
+            /*         printf("int_be 0x%8x\n", int_be); */
+            /*     sec->template[t] = htonl(int_be); */
+            /* } */
+            if ((ret = g2c_file_be_int4(f, rw_flag, (map[t] < 0 ? 1 : 0), &sec->template[t])))
+                return ret;
             break;
         default:
             return G2C_EBADTEMPLATE;

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -331,11 +331,17 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         sec3_info = sec->sec_info;
 
     /* Read or write section 3. */
-    FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def);
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec3_info->source_grid_def)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def); */
     if ((ret = g2c_file_io_uint(f, rw_flag, &sec3_info->num_data_points)))
         return ret;
-    FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
-    FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec3_info->num_opt)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec3_info->interp_list)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt); */
+    /* FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list); */
     if ((ret = g2c_file_io_ushort(f, rw_flag, &sec3_info->grid_def)))
         return ret;
     LOG((5, "rw_section3_metadata source_grid_def %d num_data_points %d num_opt %d interp_list %d grid_def %d",
@@ -640,7 +646,7 @@ add_section(FILE *f, G2C_MESSAGE_INFO_T *msg, int sec_id, unsigned int sec_len,
 int
 g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
 {
-    char sec_num = 1;
+    unsigned char sec_num = 1;
     int ret;
 
     LOG((2, "g2c_rw_section1_metadata rw_flag %d", rw_flag));
@@ -649,7 +655,9 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
     if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)&msg->sec1_len)))
         return ret;
     
-    FILE_BE_INT1P(f, rw_flag, &sec_num);
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec_num)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, &sec_num); */
     if (!rw_flag && sec_num != 1) /* When reading sec num must be 1. */
         return G2C_ENOSECTION;
     if ((ret = g2c_file_io_short(f, rw_flag, &msg->center)))
@@ -658,19 +666,39 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
         return ret;
     /* FILE_BE_INT2P(f, rw_flag, &msg->center); */
     /* FILE_BE_INT2P(f, rw_flag, &msg->subcenter); */
-    FILE_BE_INT1P(f, rw_flag, &msg->master_version);
-    FILE_BE_INT1P(f, rw_flag, &msg->local_version);
-    FILE_BE_INT1P(f, rw_flag, &msg->sig_ref_time);
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->master_version)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->local_version)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->sig_ref_time)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, &msg->master_version); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->local_version); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->sig_ref_time); */
     /* FILE_BE_INT2P(f, rw_flag, &msg->year); */
     if ((ret = g2c_file_io_short(f, rw_flag, &msg->year)))
         return ret;
-    FILE_BE_INT1P(f, rw_flag, &msg->month);
-    FILE_BE_INT1P(f, rw_flag, &msg->day);
-    FILE_BE_INT1P(f, rw_flag, &msg->hour);
-    FILE_BE_INT1P(f, rw_flag, &msg->minute);
-    FILE_BE_INT1P(f, rw_flag, &msg->second);
-    FILE_BE_INT1P(f, rw_flag, &msg->status);
-    FILE_BE_INT1P(f, rw_flag, &msg->type);
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->month)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->day)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->hour)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->minute)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->second)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->status)))
+        return ret;
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->type)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, &msg->month); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->day); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->hour); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->minute); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->second); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->status); */
+    /* FILE_BE_INT1P(f, rw_flag, &msg->type); */
 
     /* Section 1 may contain optional numbers at the end of the
      * section. The sec1_len tells us if there are extra values. If
@@ -733,7 +761,9 @@ read_msg_metadata(G2C_MESSAGE_INFO_T *msg)
         if (sec_len != 926365495)
         {
             /* Read section number. */
-            FILE_BE_INT1P(msg->file->f, G2C_FILE_READ, &sec_num);
+            if ((ret = g2c_file_io_ubyte(msg->file->f, G2C_FILE_READ, &sec_num)))
+                return ret;
+            /* FILE_BE_INT1P(msg->file->f, G2C_FILE_READ, &sec_num); */
             LOG((4, "sec_len %d sec_num %d", sec_len, sec_num));
 
             /* Add a new section to our list of sections. */

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -73,13 +73,13 @@ g2c_file_be_int4(FILE *f, int write, int neg, int *var)
         if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)
             return G2C_EFILE;
 
-        /* Did we read a negative number? Check the sign bit... */
-        /* if (neg && (int_be & 1<<0)) */
-        /* { */
-        /*     int_be &= ~(1UL<<0); /\* Clear sign bit. *\/ */
-        /*     int_be *= -1; /\* Make rest of int_be negative. *\/ */
-        /* } */
         *var = htonl(int_be);
+        /* Did we read a negative number? Check the sign bit... */
+        if (neg && (*var & 1<<31))
+        {
+            *var &= ~(1UL<<31); /* Clear sign bit. */
+            *var *= -1; /* Make it negative. */
+        }
     }
 
     return G2C_NOERROR;

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -333,7 +333,7 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 
     /* Read or write section 3. */
     FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def);
-    if ((ret = g2c_file_be_int4(f, rw_flag, 0, (int *)&sec3_info->num_data_points)))
+    if ((ret = g2c_file_be_uint4(f, rw_flag, &sec3_info->num_data_points)))
         return ret;
     FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
     FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
@@ -370,7 +370,8 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            if ((ret = g2c_file_be_int4(f, rw_flag, (map[t] < 0 ? 1 : 0), &sec->template[t])))
+            if ((ret = g2c_file_template_int4(f, rw_flag, (map[t] < 0 ? 1 : 0),
+                                              &sec->template[t])))
                 return ret;
             break;
         default:
@@ -478,7 +479,8 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            if ((ret = g2c_file_be_int4(f, rw_flag, (map[t] < 0 ? 1 : 0), &sec->template[t])))
+            if ((ret = g2c_file_template_int4(f, rw_flag, (map[t] < 0 ? 1 : 0),
+                                              &sec->template[t])))
                 return ret;
             break;
         default:
@@ -543,7 +545,7 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         sec5_info = sec->sec_info;
 
     /* Read section 5. */
-    if ((ret = g2c_file_be_int4(f, rw_flag, 0, (int *)&sec5_info->num_data_points)))
+    if ((ret = g2c_file_be_uint4(f, rw_flag, &sec5_info->num_data_points)))
         return ret;
     FILE_BE_INT2P(f, rw_flag, &sec5_info->data_def);
     LOG((5, "g2c_rw_section5_metadata num_data_points %d data_def %d",
@@ -578,9 +580,9 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
             FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
             break;
         case FOUR_BYTES:
-            if ((ret = g2c_file_be_int4(f, rw_flag, (map[t] < 0 ? 1 : 0), &sec->template[t])))
+            if ((ret = g2c_file_template_int4(f, rw_flag, (map[t] < 0 ? 1 : 0),
+                                              &sec->template[t])))
                 return ret;
-            /* FILE_BE_INT4P(f, rw_flag, &sec->template[t]); */
             break;
         default:
             return G2C_EBADTEMPLATE;

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -307,7 +307,6 @@ find_available_g2cid(int *g2cid)
 int
 g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 {
-    short short_be;
     G2C_SECTION3_INFO_T *sec3_info = NULL;
     int maplen, needsext, map[G2C_MAX_GDS_TEMPLATE_MAPLEN];
     int t;
@@ -358,26 +357,8 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     /* Read or write the template info. */
     for (t = 0; t < maplen; t++)
     {
-        /* Take the absolute value of map[t] because some of the
-         * numbers are negative - used to indicate that the
-         * cooresponding fields can contain negative data (needed for
-         * unpacking). */
-        switch(abs(map[t]))
-        {
-        case ONE_BYTE:
-            FILE_BE_INT1P(f, rw_flag, &sec->template[t]);
-            break;
-        case TWO_BYTES:
-            FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
-            break;
-        case FOUR_BYTES:
-            if ((ret = g2c_file_template_int(f, rw_flag, (map[t] < 0 ? 1 : 0),
-                                              &sec->template[t])))
-                return ret;
-            break;
-        default:
-            return G2C_EBADTEMPLATE;
-        }
+        if ((ret = g2c_file_io_template(f, rw_flag, map[t], &sec->template[t])))
+            return ret;
         LOG((7, "template[%d] %d", t, sec->template[t]));
     }
 
@@ -468,28 +449,8 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     /* Read or write the template info. */
     for (t = 0; t < maplen; t++)
     {
-        short short_be;
-
-        /* Take the absolute value of map[t] because some of the
-         * numbers are negative - used to indicate that the
-         * cooresponding fields can contain negative data (needed for
-         * unpacking). */
-        switch(abs(map[t]))
-        {
-        case ONE_BYTE:
-            FILE_BE_INT1P(f, rw_flag, &sec->template[t]);
-            break;
-        case TWO_BYTES:
-            FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
-            break;
-        case FOUR_BYTES:
-            if ((ret = g2c_file_template_int(f, rw_flag, (map[t] < 0 ? 1 : 0),
-                                              &sec->template[t])))
-                return ret;
-            break;
-        default:
-            return G2C_EBADTEMPLATE;
-        }
+        if ((ret = g2c_file_io_template(f, rw_flag, map[t], &sec->template[t])))
+            return ret;
         LOG((7, "template[%d] %d", t, sec->template[t]));
     }
 
@@ -525,7 +486,6 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 int
 g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 {
-    short short_be;
     G2C_SECTION5_INFO_T *sec5_info;
     int maplen, needsext, map[G2C_MAX_PDS_TEMPLATE_MAPLEN];
     int t;
@@ -572,26 +532,8 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     /* Read or write the template info. */
     for (t = 0; t < maplen; t++)
     {
-        /* Take the absolute value of map[t] because some of the
-         * numbers are negative - used to indicate that the
-         * cooresponding fields can contain negative data (needed for
-         * unpacking). */
-        switch(abs(map[t]))
-        {
-        case ONE_BYTE:
-            FILE_BE_INT1P(f, rw_flag, &sec->template[t]);
-            break;
-        case TWO_BYTES:
-            FILE_BE_INT2P(f, rw_flag, &sec->template[t]);
-            break;
-        case FOUR_BYTES:
-            if ((ret = g2c_file_template_int(f, rw_flag, (map[t] < 0 ? 1 : 0),
-                                              &sec->template[t])))
-                return ret;
-            break;
-        default:
-            return G2C_EBADTEMPLATE;
-        }
+        if ((ret = g2c_file_io_template(f, rw_flag, map[t], &sec->template[t])))
+            return ret;
         LOG((7, "template[%d] %d", t, sec->template[t]));
     }
 

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -333,7 +333,7 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 
     /* Read or write section 3. */
     FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def);
-    if ((ret = g2c_file_be_uint(f, rw_flag, &sec3_info->num_data_points)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, &sec3_info->num_data_points)))
         return ret;
     FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
     FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
@@ -544,7 +544,7 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         sec5_info = sec->sec_info;
 
     /* Read section 5. */
-    if ((ret = g2c_file_be_uint(f, rw_flag, &sec5_info->num_data_points)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, &sec5_info->num_data_points)))
         return ret;
     FILE_BE_INT2P(f, rw_flag, &sec5_info->data_def);
     LOG((5, "g2c_rw_section5_metadata num_data_points %d data_def %d",
@@ -699,7 +699,7 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
     LOG((2, "g2c_rw_section1_metadata rw_flag %d", rw_flag));
 
     /* Read the section. */
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)&msg->sec1_len)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)&msg->sec1_len)))
         return ret;
     
     FILE_BE_INT1P(f, rw_flag, &sec_num);
@@ -772,7 +772,7 @@ read_msg_metadata(G2C_MESSAGE_INFO_T *msg)
         LOG((4, "reading new section at file position %ld", ftell(msg->file->f)));
 
         /* Read section length. */
-        if ((ret = g2c_file_be_uint(msg->file->f, G2C_FILE_READ, &sec_len)))
+        if ((ret = g2c_file_io_uint(msg->file->f, G2C_FILE_READ, &sec_len)))
             return ret;
 
         /* A section length of 926365495 indicates we've reached

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -337,7 +337,8 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         return ret;
     FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
     FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
-    FILE_BE_INT2P(f, rw_flag, &sec3_info->grid_def);
+    if ((ret = g2c_file_io_ushort(f, rw_flag, &sec3_info->grid_def)))
+        return ret;
     LOG((5, "rw_section3_metadata source_grid_def %d num_data_points %d num_opt %d interp_list %d grid_def %d",
          sec3_info->source_grid_def, sec3_info->num_data_points, sec3_info->num_opt, sec3_info->interp_list,
          sec3_info->grid_def));
@@ -413,7 +414,6 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 int
 g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 {
-    short short_be;
     G2C_SECTION4_INFO_T *sec4_info;
     int maplen, needsext, map[G2C_MAX_PDS_TEMPLATE_MAPLEN];
     int t;
@@ -444,8 +444,12 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     LOG((6, "reading section 4 starting at file position %ld", ftell(f)));
 
     /* Read section 4. */
-    FILE_BE_INT2P(f, rw_flag, &sec4_info->num_coord);
-    FILE_BE_INT2P(f, rw_flag, &sec4_info->prod_def);
+    if ((ret = g2c_file_io_ushort(f, rw_flag, &sec4_info->num_coord)))
+        return ret;
+    if ((ret = g2c_file_io_ushort(f, rw_flag, &sec4_info->prod_def)))
+        return ret;
+    /* FILE_BE_INT2P(f, rw_flag, &sec4_info->num_coord); */
+    /* FILE_BE_INT2P(f, rw_flag, &sec4_info->prod_def); */
     LOG((5, "read_section4_metadata num_coord %d prod_def %d", sec4_info->num_coord, sec4_info->prod_def));
 
     /* Look up the information about this grid. */
@@ -546,7 +550,9 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     /* Read section 5. */
     if ((ret = g2c_file_io_uint(f, rw_flag, &sec5_info->num_data_points)))
         return ret;
-    FILE_BE_INT2P(f, rw_flag, &sec5_info->data_def);
+    if ((ret = g2c_file_io_ushort(f, rw_flag, &sec5_info->data_def)))
+        return ret;
+    /* FILE_BE_INT2P(f, rw_flag, &sec5_info->data_def); */
     LOG((5, "g2c_rw_section5_metadata num_data_points %d data_def %d",
          sec5_info->num_data_points, sec5_info->data_def));
 
@@ -692,7 +698,6 @@ add_section(FILE *f, G2C_MESSAGE_INFO_T *msg, int sec_id, unsigned int sec_len,
 int
 g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
 {
-    short short_be;
     char sec_num = 1;
     int ret;
 
@@ -705,12 +710,18 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
     FILE_BE_INT1P(f, rw_flag, &sec_num);
     if (!rw_flag && sec_num != 1) /* When reading sec num must be 1. */
         return G2C_ENOSECTION;
-    FILE_BE_INT2P(f, rw_flag, &msg->center);
-    FILE_BE_INT2P(f, rw_flag, &msg->subcenter);
+    if ((ret = g2c_file_io_short(f, rw_flag, &msg->center)))
+        return ret;
+    if ((ret = g2c_file_io_short(f, rw_flag, &msg->subcenter)))
+        return ret;
+    /* FILE_BE_INT2P(f, rw_flag, &msg->center); */
+    /* FILE_BE_INT2P(f, rw_flag, &msg->subcenter); */
     FILE_BE_INT1P(f, rw_flag, &msg->master_version);
     FILE_BE_INT1P(f, rw_flag, &msg->local_version);
     FILE_BE_INT1P(f, rw_flag, &msg->sig_ref_time);
-    FILE_BE_INT2P(f, rw_flag, &msg->year);
+    /* FILE_BE_INT2P(f, rw_flag, &msg->year); */
+    if ((ret = g2c_file_io_short(f, rw_flag, &msg->year)))
+        return ret;
     FILE_BE_INT1P(f, rw_flag, &msg->month);
     FILE_BE_INT1P(f, rw_flag, &msg->day);
     FILE_BE_INT1P(f, rw_flag, &msg->hour);

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -333,15 +333,12 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     /* Read or write section 3. */
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec3_info->source_grid_def)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def); */
     if ((ret = g2c_file_io_uint(f, rw_flag, &sec3_info->num_data_points)))
         return ret;
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec3_info->num_opt)))
         return ret;
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec3_info->interp_list)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt); */
-    /* FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list); */
     if ((ret = g2c_file_io_ushort(f, rw_flag, &sec3_info->grid_def)))
         return ret;
     LOG((5, "rw_section3_metadata source_grid_def %d num_data_points %d num_opt %d interp_list %d grid_def %d",
@@ -435,8 +432,6 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         return ret;
     if ((ret = g2c_file_io_ushort(f, rw_flag, &sec4_info->prod_def)))
         return ret;
-    /* FILE_BE_INT2P(f, rw_flag, &sec4_info->num_coord); */
-    /* FILE_BE_INT2P(f, rw_flag, &sec4_info->prod_def); */
     LOG((5, "read_section4_metadata num_coord %d prod_def %d", sec4_info->num_coord, sec4_info->prod_def));
 
     /* Look up the information about this grid. */
@@ -518,7 +513,6 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
         return ret;
     if ((ret = g2c_file_io_ushort(f, rw_flag, &sec5_info->data_def)))
         return ret;
-    /* FILE_BE_INT2P(f, rw_flag, &sec5_info->data_def); */
     LOG((5, "g2c_rw_section5_metadata num_data_points %d data_def %d",
          sec5_info->num_data_points, sec5_info->data_def));
 
@@ -657,25 +651,18 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
     
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &sec_num)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, &sec_num); */
     if (!rw_flag && sec_num != 1) /* When reading sec num must be 1. */
         return G2C_ENOSECTION;
     if ((ret = g2c_file_io_short(f, rw_flag, &msg->center)))
         return ret;
     if ((ret = g2c_file_io_short(f, rw_flag, &msg->subcenter)))
         return ret;
-    /* FILE_BE_INT2P(f, rw_flag, &msg->center); */
-    /* FILE_BE_INT2P(f, rw_flag, &msg->subcenter); */
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->master_version)))
         return ret;
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->local_version)))
         return ret;
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->sig_ref_time)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, &msg->master_version); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->local_version); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->sig_ref_time); */
-    /* FILE_BE_INT2P(f, rw_flag, &msg->year); */
     if ((ret = g2c_file_io_short(f, rw_flag, &msg->year)))
         return ret;
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->month)))
@@ -692,13 +679,6 @@ g2c_rw_section1_metadata(FILE *f, int rw_flag, G2C_MESSAGE_INFO_T *msg)
         return ret;
     if ((ret = g2c_file_io_ubyte(f, rw_flag, &msg->type)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, &msg->month); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->day); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->hour); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->minute); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->second); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->status); */
-    /* FILE_BE_INT1P(f, rw_flag, &msg->type); */
 
     /* Section 1 may contain optional numbers at the end of the
      * section. The sec1_len tells us if there are extra values. If
@@ -763,7 +743,6 @@ read_msg_metadata(G2C_MESSAGE_INFO_T *msg)
             /* Read section number. */
             if ((ret = g2c_file_io_ubyte(msg->file->f, G2C_FILE_READ, &sec_num)))
                 return ret;
-            /* FILE_BE_INT1P(msg->file->f, G2C_FILE_READ, &sec_num); */
             LOG((4, "sec_len %d sec_num %d", sec_len, sec_num));
 
             /* Add a new section to our list of sections. */

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -24,6 +24,67 @@ int g2c_next_g2cid = 1;
 /** Define mutex for thread-safety. */
 MUTEX(m);
 
+/**
+ * Read or write a big-endian 4-byte int to an open file, with
+ * conversion between native and big-endian format.
+ *
+ * GRIB2 handles negative numbers in a special way. Instead of storing
+ * two-compliments, like every other programmer and computing
+ * organization in the world, GRIB2 flips the first bit, then stores
+ * the rest of the int as an unsigned number in the remaining 31
+ * bits. How exciting!
+ *
+ * This function takes the excitement out of GRIB2 negative numbers.
+ *
+ * @param f Pointer to the open FILE.
+ * @param write Non-zero if function should write, otherwise function
+ * will read.
+ * @param neg Non-zero if the number may be negative.
+ * @param var Pointer to the int to be written, or pointer to the
+ * storage that gets the int read.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ *
+ * @author Ed Hartnett 11/7/22
+ */
+int
+g2c_file_be_int4p(FILE *f, int write, int neg, int *var)
+{
+    unsigned int int_be, tmp_1;
+
+    if (write)
+    {
+        /* Are we writing a negative number? */
+        if (neg && *var < 0)
+        {
+            tmp_1 = -1 * *var; /* Store as positive. */
+            tmp_1 |= 1UL << 31; /* Set sign bit. */
+        }
+        else
+            tmp_1 = *var;
+        int_be = ntohl(tmp_1);
+        if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)
+            return G2C_EFILE;
+    }
+    else
+    {
+        /* Read from the file. */
+        if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)
+            return G2C_EFILE;
+
+        /* Did we read a negative number? Check the sign bit... */
+        if (neg && (int_be & 1<<31))
+        {
+            int_be &= ~(1UL<<31); /* Clear sign bit. */
+            int_be *= -1; /* Make rest of int_be negative. */
+        }
+        *var = htonl(int_be);
+    }
+
+    return G2C_NOERROR;
+}
+
 /** Search a file for the next GRIB1 or GRIB2 message.
  *
  * A grib message is identified by its indicator section,
@@ -334,7 +395,8 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
 
     /* Read or write section 3. */
     FILE_BE_INT1P(f, rw_flag, &sec3_info->source_grid_def);
-    FILE_BE_INT4P(f, rw_flag, &sec3_info->num_data_points);
+    if ((ret = g2c_file_be_int4p(f, rw_flag, 0, (int *)&sec3_info->num_data_points)))
+        return ret;
     FILE_BE_INT1P(f, rw_flag, &sec3_info->num_opt);
     FILE_BE_INT1P(f, rw_flag, &sec3_info->interp_list);
     FILE_BE_INT2P(f, rw_flag, &sec3_info->grid_def);
@@ -1162,7 +1224,7 @@ g2c_close(int g2cid)
     if (!ret)
         if (fclose(g2c_file[g2cid].f))
             ret = G2C_EFILE;
-    
+
     /* Reset the file data. */
     if (!ret)
     {

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -92,16 +92,12 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
         return ret;
     if ((ret = g2c_file_io_ulonglong(f, rw_flag, (unsigned long long *)msglen)))
         return ret;
-    /* FILE_BE_INT8P(f, rw_flag, msglen); */
     if ((ret = g2c_file_io_ubyte(f, rw_flag, version)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, version); */
     if ((ret = g2c_file_io_ubyte(f, rw_flag, discipline)))
         return ret;
-    /* FILE_BE_INT1P(f, rw_flag, discipline); */
     if ((ret = g2c_file_io_short(f, rw_flag, &fieldnum1)))
         return ret;
-    /* FILE_BE_INT2P(f, rw_flag, &fieldnum1); */
 
     /* When reading, translate the 1-based fieldnum1 into the 0-based
      * fieldnum that C programmers will expect and love. */
@@ -407,7 +403,6 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                     return ret;
                 if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sec_num)))
                     return ret;
-                /* FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num); */
                 if ((ret = g2c_rw_section4_metadata(f, G2C_FILE_WRITE, sec4)))
                     break;
 
@@ -417,7 +412,6 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                     return ret;
                 if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sec_num)))
                     return ret;
-                /* FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num); */
                 if ((ret = g2c_rw_section5_metadata(f, G2C_FILE_WRITE, sec5)))
                     break;
 
@@ -444,7 +438,6 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                     for (b = 0; b < G2C_INDEX_BITMAP_BYTES; b++)
                         if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sample[b])))
                             return ret;
-                        /* FILE_BE_INT1P(f, G2C_FILE_WRITE, &sample[b]); */
                 }
             } /* next product */
 
@@ -607,7 +600,6 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                             return ret;
                         if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &sec_num)))
                             return ret;
-                        /* FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num); */
                     }
                     else
                     {
@@ -625,7 +617,6 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                             return ret;
                         if ((ret = g2c_file_io_ubyte(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num)))
                             return ret;
-                        /* FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num); */
                         LOG((4, "read section 7 info from data file. sec_len %d sec_num %d",
                              sec_len, sec_num));
                     }

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -352,7 +352,6 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                 int bytes_to_msg = (int)msg->bytes_to_msg;
                 int bs3, bs4, bs5, bs6, bs7; /* bytes to each section, as ints. */
                 int sec_num;
-                int int_be;
                 int ret;
 
                 if ((ret = g2c_get_prod_sections(msg, fieldnum, &sec3, &sec4, &sec5, &sec6, &sec7)))
@@ -380,21 +379,24 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 3, grid definition section. */
                 sec_num = 3;
-                FILE_BE_INT4P(f, G2C_FILE_WRITE, &sec3->sec_len);
+                if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &sec3->sec_len)))
+                    return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section3_metadata(f, G2C_FILE_WRITE, sec3)))
                     break;
 
                 /* Write the section 4, product definition section. */
                 sec_num = 4;
-                FILE_BE_INT4P(f, G2C_FILE_WRITE, &sec4->sec_len);
+                if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &sec4->sec_len)))
+                    return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section4_metadata(f, G2C_FILE_WRITE, sec4)))
                     break;
 
                 /* Write the section 5, data representation section. */
                 sec_num = 5;
-                FILE_BE_INT4P(f, G2C_FILE_WRITE, &sec5->sec_len);
+                if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &sec5->sec_len)))
+                    return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section5_metadata(f, G2C_FILE_WRITE, sec5)))
                     break;
@@ -548,7 +550,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
             /* Read the metadata for sections 3, 4, and 5 from
              * the index record. */
             {
-                int sec_len;
+                unsigned int sec_len;
                 char sec_num;
                 int s;
                 G2C_MESSAGE_INFO_T *msgp;
@@ -580,7 +582,9 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                      * and number from the index record. */
                     if (s < 6)
                     {
-                        FILE_BE_INT4P(f, G2C_FILE_READ, &sec_len);
+                        if ((ret = g2c_file_be_uint4(f, G2C_FILE_READ, &sec_len)))
+                            return ret;
+                        /* FILE_BE_INT4P(f, G2C_FILE_READ, &sec_len); */
                         FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num);
                     }
                     else

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -91,8 +91,12 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
     if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)data)))
         return ret;
     FILE_BE_INT8P(f, rw_flag, msglen);
-    FILE_BE_INT1P(f, rw_flag, version);
-    FILE_BE_INT1P(f, rw_flag, discipline);
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, version)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, version); */
+    if ((ret = g2c_file_io_ubyte(f, rw_flag, discipline)))
+        return ret;
+    /* FILE_BE_INT1P(f, rw_flag, discipline); */
     if ((ret = g2c_file_io_short(f, rw_flag, &fieldnum1)))
         return ret;
     /* FILE_BE_INT2P(f, rw_flag, &fieldnum1); */
@@ -360,7 +364,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                 G2C_SECTION_INFO_T *sec3, *sec4, *sec5, *sec6, *sec7;
                 int bytes_to_msg = (int)msg->bytes_to_msg;
                 int bs3, bs4, bs5, bs6, bs7; /* bytes to each section, as ints. */
-                int sec_num;
+                unsigned char sec_num;
                 int ret;
 
                 if ((ret = g2c_get_prod_sections(msg, fieldnum, &sec3, &sec4, &sec5, &sec6, &sec7)))
@@ -390,7 +394,8 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                 sec_num = 3;
                 if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &sec3->sec_len)))
                     return ret;
-                FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
+                if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sec_num)))
+                    return ret;
                 if ((ret = g2c_rw_section3_metadata(f, G2C_FILE_WRITE, sec3)))
                     break;
 
@@ -398,7 +403,9 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                 sec_num = 4;
                 if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &sec4->sec_len)))
                     return ret;
-                FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
+                if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sec_num)))
+                    return ret;
+                /* FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num); */
                 if ((ret = g2c_rw_section4_metadata(f, G2C_FILE_WRITE, sec4)))
                     break;
 
@@ -406,7 +413,9 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
                 sec_num = 5;
                 if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &sec5->sec_len)))
                     return ret;
-                FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
+                if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sec_num)))
+                    return ret;
+                /* FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num); */
                 if ((ret = g2c_rw_section5_metadata(f, G2C_FILE_WRITE, sec5)))
                     break;
 
@@ -431,7 +440,9 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                     /* Now write these bytes to the end of the index record. */
                     for (b = 0; b < G2C_INDEX_BITMAP_BYTES; b++)
-                        FILE_BE_INT1P(f, G2C_FILE_WRITE, &sample[b]);
+                        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &sample[b])))
+                            return ret;
+                        /* FILE_BE_INT1P(f, G2C_FILE_WRITE, &sample[b]); */
                 }
             } /* next product */
 
@@ -559,7 +570,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
              * the index record. */
             {
                 unsigned int sec_len;
-                char sec_num;
+                unsigned char sec_num;
                 int s;
                 G2C_MESSAGE_INFO_T *msgp;
                 int sec_id = 0;
@@ -592,7 +603,9 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                     {
                         if ((ret = g2c_file_io_uint(f, G2C_FILE_READ, &sec_len)))
                             return ret;
-                        FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num);
+                        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &sec_num)))
+                            return ret;
+                        /* FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num); */
                     }
                     else
                     {
@@ -608,7 +621,9 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                         }
                         if ((ret = g2c_file_io_uint(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
                             return ret;
-                        FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num);
+                        if ((ret = g2c_file_io_ubyte(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num)))
+                            return ret;
+                        /* FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num); */
                         LOG((4, "read section 7 info from data file. sec_len %d sec_num %d",
                              sec_len, sec_num));
                     }

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -58,10 +58,10 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
                        int *pds, int *drs, int *bms, int *data, size_t *msglen,
                        unsigned char *version, unsigned char *discipline, short *fieldnum)
 {
-    int int_be;
     short short_be;
     size_t size_t_be;
     short fieldnum1; /* This is for the 1-based fieldnum in the index file. */
+    int ret;
 
     /* All pointers must be provided. */
     if (!f || !reclen || !msg || !local || !gds || !pds || !drs || !bms || !data
@@ -75,14 +75,30 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
 
     /* Read or write the values at the beginning of each index
      * record. */
-    FILE_BE_INT4P(f, rw_flag, reclen);
-    FILE_BE_INT4P(f, rw_flag, msg);
-    FILE_BE_INT4P(f, rw_flag, local);
-    FILE_BE_INT4P(f, rw_flag, gds);
-    FILE_BE_INT4P(f, rw_flag, pds);
-    FILE_BE_INT4P(f, rw_flag, drs);
-    FILE_BE_INT4P(f, rw_flag, bms);
-    FILE_BE_INT4P(f, rw_flag, data);
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)reclen)))
+        return ret;
+    /* FILE_BE_INT4P(f, rw_flag, reclen); */
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)msg)))
+        return ret;
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)local)))
+        return ret;
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)gds)))
+        return ret;
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)pds)))
+        return ret;
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)drs)))
+        return ret;
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)bms)))
+        return ret;
+    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)data)))
+        return ret;
+    /* FILE_BE_INT4P(f, rw_flag, msg); */
+    /* FILE_BE_INT4P(f, rw_flag, local); */
+    /* FILE_BE_INT4P(f, rw_flag, gds); */
+    /* FILE_BE_INT4P(f, rw_flag, pds); */
+    /* FILE_BE_INT4P(f, rw_flag, drs); */
+    /* FILE_BE_INT4P(f, rw_flag, bms); */
+    /* FILE_BE_INT4P(f, rw_flag, data); */
     FILE_BE_INT8P(f, rw_flag, msglen);
     FILE_BE_INT1P(f, rw_flag, version);
     FILE_BE_INT1P(f, rw_flag, discipline);
@@ -519,7 +535,6 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
         /* Read each index record. */
         for (rec = 0; rec < num_rec; rec++)
         {
-            /* int int_be; */
             int reclen, msg, local, gds, pds, drs, bms, data;
             size_t msglen;
             unsigned char version, discipline;
@@ -600,7 +615,6 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                         }
                         if ((ret = g2c_file_be_uint4(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
                             return ret;
-                        /* FILE_BE_INT4P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len); */
                         FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num);
                         LOG((4, "read section 7 info from data file. sec_len %d sec_num %d",
                              sec_len, sec_num));

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -77,7 +77,6 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
      * record. */
     if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)reclen)))
         return ret;
-    /* FILE_BE_INT4P(f, rw_flag, reclen); */
     if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)msg)))
         return ret;
     if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)local)))
@@ -92,13 +91,6 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
         return ret;
     if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)data)))
         return ret;
-    /* FILE_BE_INT4P(f, rw_flag, msg); */
-    /* FILE_BE_INT4P(f, rw_flag, local); */
-    /* FILE_BE_INT4P(f, rw_flag, gds); */
-    /* FILE_BE_INT4P(f, rw_flag, pds); */
-    /* FILE_BE_INT4P(f, rw_flag, drs); */
-    /* FILE_BE_INT4P(f, rw_flag, bms); */
-    /* FILE_BE_INT4P(f, rw_flag, data); */
     FILE_BE_INT8P(f, rw_flag, msglen);
     FILE_BE_INT1P(f, rw_flag, version);
     FILE_BE_INT1P(f, rw_flag, discipline);

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -519,7 +519,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
         /* Read each index record. */
         for (rec = 0; rec < num_rec; rec++)
         {
-            int int_be;
+            /* int int_be; */
             int reclen, msg, local, gds, pds, drs, bms, data;
             size_t msglen;
             unsigned char version, discipline;
@@ -584,7 +584,6 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                     {
                         if ((ret = g2c_file_be_uint4(f, G2C_FILE_READ, &sec_len)))
                             return ret;
-                        /* FILE_BE_INT4P(f, G2C_FILE_READ, &sec_len); */
                         FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num);
                     }
                     else
@@ -599,7 +598,9 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                             ret = G2C_EFILE;
                             break;
                         }
-                        FILE_BE_INT4P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len);
+                        if ((ret = g2c_file_be_uint4(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
+                            return ret;
+                        /* FILE_BE_INT4P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len); */
                         FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num);
                         LOG((4, "read section 7 info from data file. sec_len %d sec_num %d",
                              sec_len, sec_num));

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -58,7 +58,7 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
                        int *pds, int *drs, int *bms, int *data, size_t *msglen,
                        unsigned char *version, unsigned char *discipline, short *fieldnum)
 {
-    size_t size_t_be;
+    /* size_t size_t_be; */
     short fieldnum1; /* This is for the 1-based fieldnum in the index file. */
     int ret;
 
@@ -90,7 +90,9 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
         return ret;
     if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)data)))
         return ret;
-    FILE_BE_INT8P(f, rw_flag, msglen);
+    if ((ret = g2c_file_io_ulonglong(f, rw_flag, (unsigned long long *)msglen)))
+        return ret;
+    /* FILE_BE_INT8P(f, rw_flag, msglen); */
     if ((ret = g2c_file_io_ubyte(f, rw_flag, version)))
         return ret;
     /* FILE_BE_INT1P(f, rw_flag, version); */

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -58,7 +58,6 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
                        int *pds, int *drs, int *bms, int *data, size_t *msglen,
                        unsigned char *version, unsigned char *discipline, short *fieldnum)
 {
-    short short_be;
     size_t size_t_be;
     short fieldnum1; /* This is for the 1-based fieldnum in the index file. */
     int ret;
@@ -94,7 +93,9 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
     FILE_BE_INT8P(f, rw_flag, msglen);
     FILE_BE_INT1P(f, rw_flag, version);
     FILE_BE_INT1P(f, rw_flag, discipline);
-    FILE_BE_INT2P(f, rw_flag, &fieldnum1);
+    if ((ret = g2c_file_io_short(f, rw_flag, &fieldnum1)))
+        return ret;
+    /* FILE_BE_INT2P(f, rw_flag, &fieldnum1); */
 
     /* When reading, translate the 1-based fieldnum1 into the 0-based
      * fieldnum that C programmers will expect and love. */

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -75,21 +75,21 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
 
     /* Read or write the values at the beginning of each index
      * record. */
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)reclen)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)reclen)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)msg)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)msg)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)local)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)local)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)gds)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)gds)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)pds)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)pds)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)drs)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)drs)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)bms)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)bms)))
         return ret;
-    if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)data)))
+    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)data)))
         return ret;
     FILE_BE_INT8P(f, rw_flag, msglen);
     FILE_BE_INT1P(f, rw_flag, version);
@@ -387,7 +387,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 3, grid definition section. */
                 sec_num = 3;
-                if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &sec3->sec_len)))
+                if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &sec3->sec_len)))
                     return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section3_metadata(f, G2C_FILE_WRITE, sec3)))
@@ -395,7 +395,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 4, product definition section. */
                 sec_num = 4;
-                if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &sec4->sec_len)))
+                if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &sec4->sec_len)))
                     return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section4_metadata(f, G2C_FILE_WRITE, sec4)))
@@ -403,7 +403,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 5, data representation section. */
                 sec_num = 5;
-                if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &sec5->sec_len)))
+                if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &sec5->sec_len)))
                     return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section5_metadata(f, G2C_FILE_WRITE, sec5)))
@@ -589,7 +589,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                      * and number from the index record. */
                     if (s < 6)
                     {
-                        if ((ret = g2c_file_be_uint4(f, G2C_FILE_READ, &sec_len)))
+                        if ((ret = g2c_file_be_uint(f, G2C_FILE_READ, &sec_len)))
                             return ret;
                         FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num);
                     }
@@ -605,7 +605,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                             ret = G2C_EFILE;
                             break;
                         }
-                        if ((ret = g2c_file_be_uint4(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
+                        if ((ret = g2c_file_be_uint(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
                             return ret;
                         FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num);
                         LOG((4, "read section 7 info from data file. sec_len %d sec_num %d",

--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -75,21 +75,21 @@ g2c_start_index_record(FILE *f, int rw_flag, int *reclen, int *msg, int *local, 
 
     /* Read or write the values at the beginning of each index
      * record. */
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)reclen)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)reclen)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)msg)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)msg)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)local)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)local)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)gds)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)gds)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)pds)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)pds)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)drs)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)drs)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)bms)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)bms)))
         return ret;
-    if ((ret = g2c_file_be_uint(f, rw_flag, (unsigned int *)data)))
+    if ((ret = g2c_file_io_uint(f, rw_flag, (unsigned int *)data)))
         return ret;
     FILE_BE_INT8P(f, rw_flag, msglen);
     FILE_BE_INT1P(f, rw_flag, version);
@@ -387,7 +387,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 3, grid definition section. */
                 sec_num = 3;
-                if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &sec3->sec_len)))
+                if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &sec3->sec_len)))
                     return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section3_metadata(f, G2C_FILE_WRITE, sec3)))
@@ -395,7 +395,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 4, product definition section. */
                 sec_num = 4;
-                if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &sec4->sec_len)))
+                if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &sec4->sec_len)))
                     return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section4_metadata(f, G2C_FILE_WRITE, sec4)))
@@ -403,7 +403,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
 
                 /* Write the section 5, data representation section. */
                 sec_num = 5;
-                if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &sec5->sec_len)))
+                if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &sec5->sec_len)))
                     return ret;
                 FILE_BE_INT1P(f, G2C_FILE_WRITE, &sec_num);
                 if ((ret = g2c_rw_section5_metadata(f, G2C_FILE_WRITE, sec5)))
@@ -589,7 +589,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                      * and number from the index record. */
                     if (s < 6)
                     {
-                        if ((ret = g2c_file_be_uint(f, G2C_FILE_READ, &sec_len)))
+                        if ((ret = g2c_file_io_uint(f, G2C_FILE_READ, &sec_len)))
                             return ret;
                         FILE_BE_INT1P(f, G2C_FILE_READ, &sec_num);
                     }
@@ -605,7 +605,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
                             ret = G2C_EFILE;
                             break;
                         }
-                        if ((ret = g2c_file_be_uint(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
+                        if ((ret = g2c_file_io_uint(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_len)))
                             return ret;
                         FILE_BE_INT1P(g2c_file[*g2cid].f, G2C_FILE_READ, &sec_num);
                         LOG((4, "read section 7 info from data file. sec_len %d sec_num %d",

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -21,6 +21,104 @@
  * @param f Pointer to the open FILE.
  * @param write Non-zero if function should write, otherwise function
  * will read.
+ * @param g2ctype The type to be read or written.
+ * @param var Pointer to the int to be written, or pointer to the
+ * storage that gets the int read.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ * - :: G2C_EINVAL Invalid input.
+ * - :: G2C_EFILE Error reading/writing file.
+ *
+ * @author Ed Hartnett 11/7/22
+ */
+int
+g2c_file_rw(FILE *f, int write, int g2ctype, void *var)
+{
+    unsigned int int_be, tmp_1;
+    void *void_be;
+    int neg;
+    int *ivar;
+    int type_len;
+    int bitshift;
+
+    /* Check inputs. */
+    if (!f || !var || g2ctype < G2C_BYTE || g2ctype > G2C_UINT64)
+        return G2C_EINVAL;
+
+    switch (g2ctype)
+    {
+    case G2C_INT:
+    case G2C_UINT:
+        type_len = FOUR_BYTES;
+        ivar = var;
+        void_be = &int_be;
+        bitshift = 31;
+        if (write)
+        {
+            neg = *ivar < 0 ? 1 : 0;
+        }
+        break;
+    default:
+        return G2C_EBADTYPE;
+    }
+
+    if (write)
+    {
+        /* Are we writing a negative number? */
+        if (neg)
+        {
+            tmp_1 = -1 * *ivar; /* Store as positive. */
+            tmp_1 |= 1UL << bitshift; /* Set sign bit. */
+        }
+        else
+            tmp_1 = *ivar;
+        int_be = ntohl(tmp_1);
+        if ((fwrite(&int_be, type_len, 1, f)) != 1)
+            return G2C_EFILE;
+    }
+    else
+    {
+        /* Read from the file. */
+        if ((fread(void_be, type_len, 1, f)) != 1)
+            return G2C_EFILE;
+
+        switch (g2ctype)
+        {
+        case G2C_INT:
+        case G2C_UINT:
+            *ivar = htonl(int_be);
+            break;
+        default:
+            return G2C_EBADTYPE;
+        }
+
+        /* Did we read a negative number? Check the sign bit... */
+        if (*ivar & 1 << bitshift)
+        {
+            *ivar &= ~(1UL << bitshift); /* Clear sign bit. */
+            *ivar *= -1; /* Make it negative. */
+        }
+    }
+
+    return G2C_NOERROR;
+}
+
+/**
+ * Read or write a big-endian 4-byte int to an open file, with
+ * conversion between native and big-endian format.
+ *
+ * GRIB2 handles negative numbers in a special way. Instead of storing
+ * two-compliments, like every other programmer and computing
+ * organization in the world, GRIB2 flips the first bit, then stores
+ * the rest of the int as an unsigned number in the remaining 31
+ * bits. How exciting!
+ *
+ * This function takes the excitement out of GRIB2 negative numbers.
+ *
+ * @param f Pointer to the open FILE.
+ * @param write Non-zero if function should write, otherwise function
+ * will read.
  * @param var Pointer to the int to be written, or pointer to the
  * storage that gets the int read.
  *
@@ -34,42 +132,7 @@
 int
 g2c_file_be_int4(FILE *f, int write, int *var)
 {
-    unsigned int int_be, tmp_1;
-
-    /* Check inputs. */
-    if (!f || !var)
-        return G2C_EINVAL;
-
-    if (write)
-    {
-        /* Are we writing a negative number? */
-        if (*var < 0)
-        {
-            tmp_1 = -1 * *var; /* Store as positive. */
-            tmp_1 |= 1UL << 31; /* Set sign bit. */
-        }
-        else
-            tmp_1 = *var;
-        int_be = ntohl(tmp_1);
-        if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)
-            return G2C_EFILE;
-    }
-    else
-    {
-        /* Read from the file. */
-        if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)
-            return G2C_EFILE;
-
-        *var = htonl(int_be);
-        /* Did we read a negative number? Check the sign bit... */
-        if (*var & 1<<31)
-        {
-            *var &= ~(1UL<<31); /* Clear sign bit. */
-            *var *= -1; /* Make it negative. */
-        }
-    }
-
-    return G2C_NOERROR;
+    return g2c_file_rw(f, write, G2C_INT, var);
 }
 
 /**

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -393,8 +393,7 @@ g2c_file_io_ulonglong(FILE *f, int write, unsigned long long *var)
  * @param f Pointer to the open FILE.
  * @param rw_flag Non-zero if function should write, otherwise function
  * will read.
- * @param neg Non-zero if this may be a negative number, zero for
- * unsigned ints.
+ * @param map The map value for this template item.
  * @param template_value Pointer to the template value to be written,
  * or pointer to the storage that gets the templage value read.
  *

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -216,6 +216,49 @@ g2c_file_io_uint(FILE *f, int write, unsigned int *var)
 }
 
 /**
+ * Read or write a big-endian 4-byte signed short to an open GRIB2 file,
+ * with conversion between native and big-endian format, and special
+ * GRIB2 handling of negative numbers.
+ *
+ * @param f Pointer to the open GRIB2 FILE.
+ * @param write Non-zero to write, zero to read.
+ * @param var Pointer to the short.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ * - :: G2C_EINVAL Invalid input.
+ * - :: G2C_EFILE Error reading/writing file.
+ *
+ * @author Ed Hartnett 11/13/22
+ */
+int
+g2c_file_io_short(FILE *f, int write, short *var)
+{
+    return g2c_file_io(f, write, G2C_SHORT, var);
+}
+
+/**
+ * Read or write a big-endian 4-byte unsigned short to an open GRIB2
+ * file, with conversion between native and big-endian format.
+ *
+ * @param f Pointer to the open GRIB2 FILE.
+ * @param write Non-zero to write, zero to read.
+ * @param var Pointer to the unsigned short.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ * - :: G2C_EINVAL Invalid input.
+ * - :: G2C_EFILE Error reading/writing file.
+ *
+ * @author Ed Hartnett 11/13/22
+ */
+int
+g2c_file_io_ushort(FILE *f, int write, unsigned short *var)
+{
+    return g2c_file_io(f, write, G2C_USHORT, var);
+}
+
+/**
  * Read or write a big-endian 4-byte int or unsigned int from or to an
  * open file, with conversion between native and big-endian format,
  * and handling of GRIB negative numbers. This is for template values.

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -120,6 +120,9 @@ g2c_file_be_uint4(FILE *f, int write, unsigned int *var)
  * open file, with conversion between native and big-endian format,
  * and handling of GRIB negative numbers. This is for template values.
  *
+ * With template values, if the map value is negative, then the
+ * template value may be negative.
+ *
  * @param f Pointer to the open FILE.
  * @param rw_flag Non-zero if function should write, otherwise function
  * will read.

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -40,9 +40,9 @@ int
 g2c_file_io(FILE *f, int write, int g2ctype, void *var)
 {
     void *void_be;
-    char *bvar;
-    short *svar;
-    int *ivar;
+    char *bvar = NULL;
+    short *svar = NULL;
+    int *ivar = NULL;
     unsigned int int_be, int_tmp;
     unsigned short short_be, short_tmp;
     unsigned char byte_be, byte_tmp;

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -21,24 +21,29 @@
  * @param f Pointer to the open FILE.
  * @param write Non-zero if function should write, otherwise function
  * will read.
- * @param neg Non-zero if the number may be negative.
  * @param var Pointer to the int to be written, or pointer to the
  * storage that gets the int read.
  *
  * @return
  * - :: G2C_NOERROR No error.
+ * - :: G2C_EINVAL Invalid input.
+ * - :: G2C_EFILE Error reading/writing file.
  *
  * @author Ed Hartnett 11/7/22
  */
 int
-g2c_file_be_int4(FILE *f, int write, int neg, int *var)
+g2c_file_be_int4(FILE *f, int write, int *var)
 {
     unsigned int int_be, tmp_1;
+
+    /* Check inputs. */
+    if (!f || !var)
+        return G2C_EINVAL;
 
     if (write)
     {
         /* Are we writing a negative number? */
-        if (neg && *var < 0)
+        if (*var < 0)
         {
             tmp_1 = -1 * *var; /* Store as positive. */
             tmp_1 |= 1UL << 31; /* Set sign bit. */
@@ -57,7 +62,7 @@ g2c_file_be_int4(FILE *f, int write, int neg, int *var)
 
         *var = htonl(int_be);
         /* Did we read a negative number? Check the sign bit... */
-        if (neg && (*var & 1<<31))
+        if (*var & 1<<31)
         {
             *var &= ~(1UL<<31); /* Clear sign bit. */
             *var *= -1; /* Make it negative. */
@@ -67,3 +72,84 @@ g2c_file_be_int4(FILE *f, int write, int neg, int *var)
     return G2C_NOERROR;
 }
 
+/**
+ * Read or write a big-endian 4-byte unsigned int to an open file,
+ * with conversion between native and big-endian format.
+ *
+ * @param f Pointer to the open FILE.
+ * @param write Non-zero if function should write, otherwise function
+ * will read.
+ * @param var Pointer to the unsigned int to be written, or pointer to
+ * the storage that gets the unsigned int read.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ * - :: G2C_EINVAL Invalid input.
+ * - :: G2C_EFILE Error reading/writing file.
+ *
+ * @author Ed Hartnett 11/11/22
+ */
+int
+g2c_file_be_uint4(FILE *f, int write, unsigned int *var)
+{
+    unsigned int int_be;
+
+    /* Check inputs. */
+    if (!f || !var)
+        return G2C_EINVAL;
+
+    if (write)
+    {
+        int_be = ntohl(*var);
+        if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)
+            return G2C_EFILE;
+    }
+    else
+    {
+        /* Read from the file. */
+        if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)
+            return G2C_EFILE;
+        *var = htonl(int_be);
+    }
+
+    return G2C_NOERROR;
+}
+
+/**
+ * Read or write a big-endian 4-byte int or unsigned int from or to an
+ * open file, with conversion between native and big-endian format,
+ * and handling of GRIB negative numbers. This is for template values.
+ *
+ * @param f Pointer to the open FILE.
+ * @param rw_flag Non-zero if function should write, otherwise function
+ * will read.
+ * @param neg Non-zero if this may be a negative number, zero for
+ * unsigned ints.
+ * @param template_value Pointer to the template value to be written,
+ * or pointer to the storage that gets the templage value read.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ * - :: G2C_EINVAL Invalid input.
+ * - :: G2C_EFILE Error reading/writing file.
+ *
+ * @author Ed Hartnett 11/7/22
+ */
+int
+g2c_file_template_int4(FILE *f, int rw_flag, int neg, int *template_value)
+{
+    int ret;
+    
+    if (neg)
+    {
+        if ((ret = g2c_file_be_int4(f, rw_flag, template_value)))
+            return ret;
+    }
+    else
+    {
+        if ((ret = g2c_file_be_uint4(f, rw_flag, (unsigned int *)template_value)))
+            return ret;
+    }
+    
+    return G2C_NOERROR;
+}

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -128,7 +128,7 @@ g2c_file_io(FILE *f, int write, int g2ctype, void *var)
             if (g2ctype == G2C_INT64 && *i64var < 0)
             {
                 int64_tmp = -1 * *i64var; /* Store as positive. */
-                int64_tmp |= 1UL << BITSHIFT_63; /* Set sign bit. */
+                int64_tmp |= 1ULL << BITSHIFT_63; /* Set sign bit. */
             }
             else
                 int64_tmp = *i64var;

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * @brief File I/O functions for the g2c library.
+ * @author Ed Hartnett @date Nov 11, 2022
+ */
+
+#include "grib2_int.h"
+
+/**
+ * Read or write a big-endian 4-byte int to an open file, with
+ * conversion between native and big-endian format.
+ *
+ * GRIB2 handles negative numbers in a special way. Instead of storing
+ * two-compliments, like every other programmer and computing
+ * organization in the world, GRIB2 flips the first bit, then stores
+ * the rest of the int as an unsigned number in the remaining 31
+ * bits. How exciting!
+ *
+ * This function takes the excitement out of GRIB2 negative numbers.
+ *
+ * @param f Pointer to the open FILE.
+ * @param write Non-zero if function should write, otherwise function
+ * will read.
+ * @param neg Non-zero if the number may be negative.
+ * @param var Pointer to the int to be written, or pointer to the
+ * storage that gets the int read.
+ *
+ * @return
+ * - :: G2C_NOERROR No error.
+ *
+ * @author Ed Hartnett 11/7/22
+ */
+int
+g2c_file_be_int4(FILE *f, int write, int neg, int *var)
+{
+    unsigned int int_be, tmp_1;
+
+    if (write)
+    {
+        /* Are we writing a negative number? */
+        if (neg && *var < 0)
+        {
+            tmp_1 = -1 * *var; /* Store as positive. */
+            tmp_1 |= 1UL << 31; /* Set sign bit. */
+        }
+        else
+            tmp_1 = *var;
+        int_be = ntohl(tmp_1);
+        if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)
+            return G2C_EFILE;
+    }
+    else
+    {
+        /* Read from the file. */
+        if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)
+            return G2C_EFILE;
+
+        *var = htonl(int_be);
+        /* Did we read a negative number? Check the sign bit... */
+        if (neg && (*var & 1<<31))
+        {
+            *var &= ~(1UL<<31); /* Clear sign bit. */
+            *var *= -1; /* Make it negative. */
+        }
+    }
+
+    return G2C_NOERROR;
+}
+

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -198,7 +198,7 @@ g2c_file_io(FILE *f, int write, int g2ctype, void *var)
             /* Did we read a negative number? Check the sign bit... */
             if (g2ctype == G2C_INT64 && *i64var & 1ULL << BITSHIFT_63)
             {
-                *i64var &= ~(1UL << BITSHIFT_63); /* Clear sign bit. */
+                *i64var &= ~(1ULL << BITSHIFT_63); /* Clear sign bit. */
                 *i64var *= -1; /* Make it negative. */
             }
             break;

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -503,5 +503,6 @@ int g2c_param_all(int param_idx, int *g1ver, int *g1val, int *g2disc, int *g2cat
 #define G2C_EBADTEMPLATE (-70) /**< Template problem. */
 #define G2C_ENOPARAM (-71) /**< Parameter not found. */
 #define G2C_ENOPRODUCT (-72) /**< Product not found. */
+#define G2C_EBADTYPE (-73) /**< Type not found. */
 
 #endif  /*  _grib2_H  */

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -266,6 +266,19 @@ g2int jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 
 /* The new g2c API is being introduced in version 2.0 of the library. */
 
+/* Data types. */
+#define G2C_BYTE         1       /**< signed 1 byte integer */
+#define G2C_CHAR         2       /**< ISO/ASCII character */
+#define G2C_SHORT        3       /**< signed 2 byte integer */
+#define G2C_INT          4       /**< signed 4 byte integer */
+#define G2C_FLOAT        5       /**< single precision floating point number */
+#define G2C_DOUBLE       6       /**< double precision floating point number */
+#define G2C_UBYTE        7       /**< unsigned 1 byte int */
+#define G2C_USHORT       8       /**< unsigned 2-byte int */
+#define G2C_UINT         9       /**< unsigned 4-byte int */
+#define G2C_INT64        10      /**< signed 8-byte int */
+#define G2C_UINT64       11      /**< unsigned 8-byte int */
+
 /* Defines for file handling. */
 #define G2C_MAX_FILES 3 /**< Maximum number of open files. */
 #define G2C_MAX_NAME 1024 /**< Maximum length of a name. */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -407,6 +407,9 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 /* Check the message header and check for message termination. */
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
+/* Basic file I/O. */
+int g2c_file_be_int4(FILE *f, int write, int neg, int *var);
+
 /* Read and remember file, message, and section metadata. */
 int g2c_add_file(const char *path, int mode, int *g2cid);
 int add_msg(G2C_FILE_INFO_T *file, int msg_num, size_t bytes_to_msg, size_t bytes_in_msg,

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -408,7 +408,9 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
-int g2c_file_be_int4(FILE *f, int write, int neg, int *var);
+int g2c_file_be_int4(FILE *f, int write, int *var);
+int g2c_file_be_uint4(FILE *f, int write, unsigned int *var);
+int g2c_file_template_int4(FILE *f, int rw_flag, int neg, int *template_value);
 
 /* Read and remember file, message, and section metadata. */
 int g2c_add_file(const char *path, int mode, int *g2cid);

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -388,6 +388,8 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
+int g2c_file_io_short(FILE *f, int write, short *var);
+int g2c_file_io_ushort(FILE *f, int write, unsigned short *var);
 int g2c_file_io_int(FILE *f, int write, int *var);
 int g2c_file_io_uint(FILE *f, int write, unsigned int *var);
 int g2c_file_template_int(FILE *f, int rw_flag, int neg, int *template_value);

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -388,11 +388,15 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
+int g2c_file_io_byte(FILE *f, int write, char *var);
+int g2c_file_io_ubyte(FILE *f, int write, unsigned char *var);
 int g2c_file_io_short(FILE *f, int write, short *var);
 int g2c_file_io_ushort(FILE *f, int write, unsigned short *var);
 int g2c_file_io_int(FILE *f, int write, int *var);
 int g2c_file_io_uint(FILE *f, int write, unsigned int *var);
-int g2c_file_template_int(FILE *f, int rw_flag, int neg, int *template_value);
+int g2c_file_io_longlong(FILE *f, int write, long long *var);
+int g2c_file_io_ulonglong(FILE *f, int write, unsigned long long *var);
+int g2c_file_io_template(FILE *f, int rw_flag, int map, int *template_value);
 
 /* Read and remember file, message, and section metadata. */
 int g2c_add_file(const char *path, int mode, int *g2cid);

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -108,63 +108,6 @@
 #define G2C_FILE_READ 0 /**< Read. */
 #define G2C_FILE_WRITE 1 /**< Write. */
 
-/**
- * Read or write a big-endian 1-byte int to an open file.
- */
-#define FILE_BE_INT1P(f, write, var)            \
-    do {                                        \
-        if (write)                              \
-        {                                       \
-            if ((fwrite(var, 1, 1, f)) != 1)    \
-                return G2C_EFILE;               \
-        }                                       \
-        else                                    \
-        {                                       \
-            if ((fread(var, 1, 1, f)) != 1)     \
-                return G2C_EFILE;               \
-        }                                       \
-    } while(0)
-
-/**
- * Read or write a big-endian 2-byte int to an open file, with
- * conversion between native and big-endian format. The integer
- * short_be must be declared before this macro is used. */
-#define FILE_BE_INT2P(f, write, var)                            \
-    do {                                                        \
-        if (write)                                              \
-        {                                                       \
-            short_be = ntohs(*var);                             \
-            if ((fwrite(&short_be, TWO_BYTES, 1, f)) != 1)      \
-                return G2C_EFILE;                               \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            if ((fread(&short_be, TWO_BYTES, 1, f)) != 1)       \
-                return G2C_EFILE;                               \
-            *var = htons(short_be);                             \
-        }                                                       \
-    } while(0)
-
-/**
- * Read or write a big-endian 8-byte int to an open file, with
- * conversion between native and big-endian format. The integer
- * size_t_be must be declared before this macro is used. */
-#define FILE_BE_INT8P(f, write, var)                            \
-    do {                                                        \
-        if (write)                                              \
-        {                                                       \
-            size_t_be = ntoh64(*var);                           \
-            if ((fwrite(&size_t_be, EIGHT_BYTES, 1, f)) != 1)   \
-                return G2C_EFILE;                               \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            if ((fread(&size_t_be, EIGHT_BYTES, 1, f)) != 1)    \
-                return G2C_EFILE;                               \
-            *var = hton64(size_t_be);                           \
-        }                                                       \
-    } while(0)
-
 /** This is the information about each message. */
 typedef struct g2c_message_info
 {

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -388,9 +388,9 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
-int g2c_file_be_int4(FILE *f, int write, int *var);
-int g2c_file_be_uint4(FILE *f, int write, unsigned int *var);
-int g2c_file_template_int4(FILE *f, int rw_flag, int neg, int *template_value);
+int g2c_file_be_int(FILE *f, int write, int *var);
+int g2c_file_be_uint(FILE *f, int write, unsigned int *var);
+int g2c_file_template_int(FILE *f, int rw_flag, int neg, int *template_value);
 
 /* Read and remember file, message, and section metadata. */
 int g2c_add_file(const char *path, int mode, int *g2cid);

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -149,21 +149,21 @@
  * Read or write a big-endian 4-byte int to an open file, with
  * conversion between native and big-endian format. The integer int_be
  * must be declared before this macro is used. */
-#define FILE_BE_INT4P(f, write, var)                            \
-    do {                                                        \
-        if (write)                                              \
-        {                                                       \
-            int_be = ntohl(*var);                               \
-            if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)       \
-                return G2C_EFILE;                               \
-        }                                                       \
-        else                                                    \
-        {                                                       \
-            if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)        \
-                return G2C_EFILE;                               \
-            *var = htonl(int_be);                               \
-        }                                                       \
-    } while(0)
+/* #define FILE_BE_INT4P(f, write, var)                            \ */
+/*     do {                                                        \ */
+/*         if (write)                                              \ */
+/*         {                                                       \ */
+/*             int_be = ntohl(*var);                               \ */
+/*             if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)       \ */
+/*                 return G2C_EFILE;                               \ */
+/*         }                                                       \ */
+/*         else                                                    \ */
+/*         {                                                       \ */
+/*             if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)        \ */
+/*                 return G2C_EFILE;                               \ */
+/*             *var = htonl(int_be);                               \ */
+/*         }                                                       \ */
+/*     } while(0) */
 
 /**
  * Read or write a big-endian 8-byte int to an open file, with

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -388,8 +388,8 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
-int g2c_file_be_int(FILE *f, int write, int *var);
-int g2c_file_be_uint(FILE *f, int write, unsigned int *var);
+int g2c_file_io_int(FILE *f, int write, int *var);
+int g2c_file_io_uint(FILE *f, int write, unsigned int *var);
 int g2c_file_template_int(FILE *f, int rw_flag, int neg, int *template_value);
 
 /* Read and remember file, message, and section metadata. */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -146,26 +146,6 @@
     } while(0)
 
 /**
- * Read or write a big-endian 4-byte int to an open file, with
- * conversion between native and big-endian format. The integer int_be
- * must be declared before this macro is used. */
-/* #define FILE_BE_INT4P(f, write, var)                            \ */
-/*     do {                                                        \ */
-/*         if (write)                                              \ */
-/*         {                                                       \ */
-/*             int_be = ntohl(*var);                               \ */
-/*             if ((fwrite(&int_be, FOUR_BYTES, 1, f)) != 1)       \ */
-/*                 return G2C_EFILE;                               \ */
-/*         }                                                       \ */
-/*         else                                                    \ */
-/*         {                                                       \ */
-/*             if ((fread(&int_be, FOUR_BYTES, 1, f)) != 1)        \ */
-/*                 return G2C_EFILE;                               \ */
-/*             *var = htonl(int_be);                               \ */
-/*         }                                                       \ */
-/*     } while(0) */
-
-/**
  * Read or write a big-endian 8-byte int to an open file, with
  * conversion between native and big-endian format. The integer
  * size_t_be must be declared before this macro is used. */

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -331,6 +331,7 @@ int pack_gp(g2int *kfildo, g2int *ic, g2int *nxy,
 int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
+int g2c_file_io(FILE *f, int write, int g2ctype, void *var);
 int g2c_file_io_byte(FILE *f, int write, char *var);
 int g2c_file_io_ubyte(FILE *f, int write, unsigned char *var);
 int g2c_file_io_short(FILE *f, int write, short *var);

--- a/src/util.c
+++ b/src/util.c
@@ -201,6 +201,8 @@ g2c_strerror(int g2cerr)
 	return "Parameter not found";
     case G2C_ENOPRODUCT:
 	return "Product not found";
+    case G2C_EBADTYPE:
+	return "Bad type";
 
     default:
 	 return "Unknown Error";	

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -92,7 +92,6 @@ if(FTP_TEST_FILES)
 endif()
 
 # Always run these tests.
-g2c_ptest(tst_files)
 g2c_test(tst_g2_create)
 g2c_test(tst_g2_addgrid)
 g2c_test(tst_g2_addfield)
@@ -115,9 +114,11 @@ g2c_test(tst_error)
 g2c_test(tst_params)
 g2c_test(tst_params2)
 g2c_test(tst_params3)
-g2c_test(tst_degrib2)
+g2c_test(tst_io)
 g2c_test(tst_inq)
+g2c_test(tst_degrib2)
 g2c_test(tst_index)
+g2c_ptest(tst_files)
 
 # Run these tests only if libpng is linked.
 if(USE_PNG)

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -133,7 +133,7 @@ main()
         int num_msg;
         int ret;
 
-        g2c_set_log_level(10);
+        /* g2c_set_log_level(10); */
         /* Open the data file using the index file. */
         if ((ret = g2c_read_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid)))
             return ret;

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -62,6 +62,8 @@ degrib2_lines_not_equal(char *l1, char *l2)
         if (strncmp(cmax1, cmax2, NUM_MATCHING))
             return G2C_ERROR;
     }
+    else
+        return G2C_ERROR;
 
     return G2C_NOERROR;
 }

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -111,96 +111,95 @@ main()
 {
     printf("Testing g2c degrib2 function.\n");
 #ifdef JPEG
-    /* printf("Testing g2c_degrib2() on file %s...", WAVE_FILE); */
-    /* { */
-    /*     int g2cid; */
-    /*     int ret; */
+    printf("Testing g2c_degrib2() on file %s...", WAVE_FILE);
+    {
+        int g2cid;
+        int ret;
 
-    /*     if ((ret = g2c_open(WAVE_FILE, 0, &g2cid))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_degrib2(g2cid, FILE_NAME))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_close(g2cid))) */
-    /*         return ret; */
+        if ((ret = g2c_open(WAVE_FILE, 0, &g2cid)))
+            return ret;
+        if ((ret = g2c_degrib2(g2cid, FILE_NAME)))
+            return ret;
+        if ((ret = g2c_close(g2cid)))
+            return ret;
         
-    /*     if ((ret = compare_files2(FILE_NAME, REF_FILE))) */
-    /*         return ret; */
-    /* } */
-    /* printf("ok!\n"); */
-    /* printf("Testing g2c_read_index() to make a degrib2 file..."); */
-    /* { */
-    /*     int g2cid; */
-    /*     int num_msg; */
-    /*     int ret; */
+        if ((ret = compare_files2(FILE_NAME, REF_FILE)))
+            return ret;
+    }
+    printf("ok!\n");
+    printf("Testing g2c_read_index() to make a degrib2 file...");
+    {
+        int g2cid;
+        int num_msg;
+        int ret;
 
-    /*     g2c_set_log_level(10); */
-    /*     /\* Open the data file using the index file. *\/ */
-    /*     if ((ret = g2c_read_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid))) */
-    /*         return ret; */
+        g2c_set_log_level(10);
+        /* Open the data file using the index file. */
+        if ((ret = g2c_read_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid)))
+            return ret;
 
-    /*     /\* Check some stuff. *\/ */
-    /*     if ((ret = g2c_inq(g2cid, &num_msg))) */
-    /*         return ret; */
-    /*     if (num_msg != 19) */
-    /*         return G2C_ERROR; */
+        /* Check some stuff. */
+        if ((ret = g2c_inq(g2cid, &num_msg)))
+            return ret;
+        if (num_msg != 19)
+            return G2C_ERROR;
 
-    /*     /\* Output a degrib2 file. *\/ */
-    /*     if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE))) */
-    /*         return ret; */
+        /* Output a degrib2 file. */
+        if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE)))
+            return ret;
 
-    /*     /\* Close the data file. *\/ */
-    /*     if ((ret = g2c_close(g2cid))) */
-    /*         return ret; */
+        /* Close the data file. */
+        if ((ret = g2c_close(g2cid)))
+            return ret;
 
-    /*     /\* Compare the degrib2 output to our reference file. *\/ */
-    /*     if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE))) */
-    /*         return ret; */
-    /* } */
-    /* printf("ok!\n"); */
-    /* printf("Testing g2c_write_index() make an index and then to make a degrib2 file from it..."); */
-    /* { */
-    /*     int g2cid; */
-    /*     int num_msg; */
-    /*     int ret; */
+        /* Compare the degrib2 output to our reference file. */
+        if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE)))
+            return ret;
+    }
+    printf("ok!\n");
+    printf("Testing g2c_write_index() make an index and then to make a degrib2 file from it...");
+    {
+        int g2cid;
+        int num_msg;
+        int ret;
 
-    /*     /\* g2c_set_log_level(10); *\/ */
-    /*     /\* Open the data file using the index file. *\/ */
-    /*     if ((ret = g2c_open(WAVE_FILE, 0, &g2cid))) */
-    /*         return ret; */
+        /* g2c_set_log_level(10); */
+        /* Open the data file using the index file. */
+        if ((ret = g2c_open(WAVE_FILE, 0, &g2cid)))
+            return ret;
 
-    /*     /\* Check some stuff. *\/ */
-    /*     if ((ret = g2c_inq(g2cid, &num_msg))) */
-    /*         return ret; */
-    /*     if (num_msg != 19) */
-    /*         return G2C_ERROR; */
+        /* Check some stuff. */
+        if ((ret = g2c_inq(g2cid, &num_msg)))
+            return ret;
+        if (num_msg != 19)
+            return G2C_ERROR;
 
-    /*     /\* Write an index file. *\/ */
-    /*     if ((ret = g2c_write_index(g2cid, G2C_CLOBBER, TEST_INDEX_FILE))) */
-    /*         return ret; */
+        /* Write an index file. */
+        if ((ret = g2c_write_index(g2cid, G2C_CLOBBER, TEST_INDEX_FILE)))
+            return ret;
 
-    /*     /\* Close the data file. *\/ */
-    /*     if ((ret = g2c_close(g2cid))) */
-    /*         return ret; */
+        /* Close the data file. */
+        if ((ret = g2c_close(g2cid)))
+            return ret;
 
-    /*     /\* Reopen the data file, using the index we just generated. *\/ */
-    /*     if ((ret = g2c_read_index(WAVE_FILE, TEST_INDEX_FILE, 0, &g2cid))) */
-    /*         return ret; */
+        /* Reopen the data file, using the index we just generated. */
+        if ((ret = g2c_read_index(WAVE_FILE, TEST_INDEX_FILE, 0, &g2cid)))
+            return ret;
 
-    /*     /\* Output a degrib2 file. *\/ */
-    /*     if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE))) */
-    /*         return ret; */
+        /* Output a degrib2 file. */
+        if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE)))
+            return ret;
 
-    /*     /\* Close the data file. *\/ */
-    /*     if ((ret = g2c_close(g2cid))) */
-    /*         return ret; */
+        /* Close the data file. */
+        if ((ret = g2c_close(g2cid)))
+            return ret;
 
-    /*     /\* Compare the degrib2 output to our reference file. *\/ */
-    /*     if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE))) */
-    /*         return ret; */
-    /* } */
-    /* printf("ok!\n"); */
-/* #endif */
-/* #ifdef FTP_TEST_FILES */
+        /* Compare the degrib2 output to our reference file. */
+        if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE)))
+            return ret;
+    }
+    printf("ok!\n");
+#ifdef FTP_TEST_FILES
 #define NUM_TESTS 2
     printf("Testing degrib2 on file %s downloaded via FTP...\n", FTP_FILE);
     {
@@ -328,6 +327,7 @@ main()
     }
     printf("ok!\n");
 #endif /* FTP_TEST_FILES */
+#endif /* JPEG */
     printf("SUCCESS!\n");
     return 0;
 }

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -63,7 +63,11 @@ degrib2_lines_not_equal(char *l1, char *l2)
             return G2C_ERROR;
     }
     else
+    {
+        printf("\n%s\n", l1);
+        printf("%s\n", l2);
         return G2C_ERROR;
+    }
 
     return G2C_NOERROR;
 }
@@ -107,96 +111,96 @@ main()
 {
     printf("Testing g2c degrib2 function.\n");
 #ifdef JPEG
-    printf("Testing g2c_degrib2() on file %s...", WAVE_FILE);
-    {
-	int g2cid;
-	int ret;
+    /* printf("Testing g2c_degrib2() on file %s...", WAVE_FILE); */
+    /* { */
+    /*     int g2cid; */
+    /*     int ret; */
 
-	if ((ret = g2c_open(WAVE_FILE, 0, &g2cid)))
-	    return ret;
-        if ((ret = g2c_degrib2(g2cid, FILE_NAME)))
-            return ret;
-	if ((ret = g2c_close(g2cid)))
-	    return ret;
+    /*     if ((ret = g2c_open(WAVE_FILE, 0, &g2cid))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_degrib2(g2cid, FILE_NAME))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_close(g2cid))) */
+    /*         return ret; */
         
-        if ((ret = compare_files2(FILE_NAME, REF_FILE)))
-            return ret;
-    }
-    printf("ok!\n");
-    printf("Testing g2c_read_index() to make a degrib2 file...");
-    {
-	int g2cid;
-        int num_msg;
-	int ret;
+    /*     if ((ret = compare_files2(FILE_NAME, REF_FILE))) */
+    /*         return ret; */
+    /* } */
+    /* printf("ok!\n"); */
+    /* printf("Testing g2c_read_index() to make a degrib2 file..."); */
+    /* { */
+    /*     int g2cid; */
+    /*     int num_msg; */
+    /*     int ret; */
 
-	/* g2c_set_log_level(10); */
-	/* Open the data file using the index file. */
-	if ((ret = g2c_read_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid)))
-	    return ret;
+    /*     g2c_set_log_level(10); */
+    /*     /\* Open the data file using the index file. *\/ */
+    /*     if ((ret = g2c_read_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid))) */
+    /*         return ret; */
 
-        /* Check some stuff. */
-        if ((ret = g2c_inq(g2cid, &num_msg)))
-            return ret;
-        if (num_msg != 19)
-            return G2C_ERROR;
+    /*     /\* Check some stuff. *\/ */
+    /*     if ((ret = g2c_inq(g2cid, &num_msg))) */
+    /*         return ret; */
+    /*     if (num_msg != 19) */
+    /*         return G2C_ERROR; */
 
-        /* Output a degrib2 file. */
-        if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE)))
-            return ret;
+    /*     /\* Output a degrib2 file. *\/ */
+    /*     if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE))) */
+    /*         return ret; */
 
-        /* Close the data file. */
-	if ((ret = g2c_close(g2cid)))
-	    return ret;
+    /*     /\* Close the data file. *\/ */
+    /*     if ((ret = g2c_close(g2cid))) */
+    /*         return ret; */
 
-        /* Compare the degrib2 output to our reference file. */
-        if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE)))
-            return ret;
-    }
-    printf("ok!\n");
-    printf("Testing g2c_write_index() make an index and then to make a degrib2 file from it...");
-    {
-	int g2cid;
-        int num_msg;
-	int ret;
+    /*     /\* Compare the degrib2 output to our reference file. *\/ */
+    /*     if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE))) */
+    /*         return ret; */
+    /* } */
+    /* printf("ok!\n"); */
+    /* printf("Testing g2c_write_index() make an index and then to make a degrib2 file from it..."); */
+    /* { */
+    /*     int g2cid; */
+    /*     int num_msg; */
+    /*     int ret; */
 
-	/* g2c_set_log_level(10); */
-	/* Open the data file using the index file. */
-	if ((ret = g2c_open(WAVE_FILE, 0, &g2cid)))
-	    return ret;
+    /*     /\* g2c_set_log_level(10); *\/ */
+    /*     /\* Open the data file using the index file. *\/ */
+    /*     if ((ret = g2c_open(WAVE_FILE, 0, &g2cid))) */
+    /*         return ret; */
 
-        /* Check some stuff. */
-        if ((ret = g2c_inq(g2cid, &num_msg)))
-            return ret;
-        if (num_msg != 19)
-            return G2C_ERROR;
+    /*     /\* Check some stuff. *\/ */
+    /*     if ((ret = g2c_inq(g2cid, &num_msg))) */
+    /*         return ret; */
+    /*     if (num_msg != 19) */
+    /*         return G2C_ERROR; */
 
-        /* Write an index file. */
-        if ((ret = g2c_write_index(g2cid, G2C_CLOBBER, TEST_INDEX_FILE)))
-            return ret;
+    /*     /\* Write an index file. *\/ */
+    /*     if ((ret = g2c_write_index(g2cid, G2C_CLOBBER, TEST_INDEX_FILE))) */
+    /*         return ret; */
 
-        /* Close the data file. */
-	if ((ret = g2c_close(g2cid)))
-	    return ret;
+    /*     /\* Close the data file. *\/ */
+    /*     if ((ret = g2c_close(g2cid))) */
+    /*         return ret; */
 
-        /* Reopen the data file, using the index we just generated. */
-	if ((ret = g2c_read_index(WAVE_FILE, TEST_INDEX_FILE, 0, &g2cid)))
-	    return ret;
+    /*     /\* Reopen the data file, using the index we just generated. *\/ */
+    /*     if ((ret = g2c_read_index(WAVE_FILE, TEST_INDEX_FILE, 0, &g2cid))) */
+    /*         return ret; */
 
-        /* Output a degrib2 file. */
-        if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE)))
-            return ret;
+    /*     /\* Output a degrib2 file. *\/ */
+    /*     if ((ret = g2c_degrib2(g2cid, DEGRIB2_FILE))) */
+    /*         return ret; */
 
-        /* Close the data file. */
-	if ((ret = g2c_close(g2cid)))
-	    return ret;
+    /*     /\* Close the data file. *\/ */
+    /*     if ((ret = g2c_close(g2cid))) */
+    /*         return ret; */
 
-        /* Compare the degrib2 output to our reference file. */
-        if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE)))
-            return ret;
-    }
-    printf("ok!\n");
-#endif
-#ifdef FTP_TEST_FILES
+    /*     /\* Compare the degrib2 output to our reference file. *\/ */
+    /*     if ((ret = compare_files2(DEGRIB2_FILE, REF_FILE))) */
+    /*         return ret; */
+    /* } */
+    /* printf("ok!\n"); */
+/* #endif */
+/* #ifdef FTP_TEST_FILES */
 #define NUM_TESTS 2
     printf("Testing degrib2 on file %s downloaded via FTP...\n", FTP_FILE);
     {

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -1,4 +1,4 @@
-/* This is a test for the NCEPLIBS-g2c project. 
+/* This is a test for the NCEPLIBS-g2c project.
  *
  * This test is for the g2c_degrib2() function, which prints a summary
  * of the GRIB2 file.
@@ -23,8 +23,8 @@
 #define NUM_MATCHING 5
 #define FTP_NUM_MSG 688
 
-/* Return 0 if two lines of the DEGRIB2 output are euqal. 
- * 
+/* Return 0 if two lines of the DEGRIB2 output are euqal.
+ *
  * For most lines this means they must be exactly equal. Lines that
  * show the min, avg, and max values may be slightly different from
  * the reference file, because the intel compiler produces slight
@@ -39,7 +39,7 @@ degrib2_lines_not_equal(char *l1, char *l2)
     char abbrev2[G2C_MAX_NOAA_ABBREV_LEN + 1];
     char cmin1[MAX_VALUE_LEN + 1], cavg1[MAX_VALUE_LEN + 1], cmax1[MAX_VALUE_LEN + 1];
     char cmin2[MAX_VALUE_LEN + 1], cavg2[MAX_VALUE_LEN + 1], cmax2[MAX_VALUE_LEN + 1];
-    
+
     /* If the lines are the same, we're done. */
     if (!strcmp(l1, l2))
         return 0;
@@ -72,38 +72,38 @@ degrib2_lines_not_equal(char *l1, char *l2)
     return G2C_NOERROR;
 }
 
-/* Return 0 if two files are the same. 
+/* Return 0 if two files are the same.
  *
  * Ed Hartnett 10/6/22
  */
 int
 compare_files2(char *fname1, char *fname2)
 {
-   FILE *fp1, *fp2;
-   char l1[MAX_LINE_LEN], l2[MAX_LINE_LEN];
+    FILE *fp1, *fp2;
+    char l1[MAX_LINE_LEN], l2[MAX_LINE_LEN];
 
-   /* Open the two files. */
-   if (!(fp1 = fopen(fname1, "r")))
-       return G2C_ERROR;
-   if (!(fp2 = fopen(fname2, "r")))
-       return G2C_ERROR;
+    /* Open the two files. */
+    if (!(fp1 = fopen(fname1, "r")))
+        return G2C_ERROR;
+    if (!(fp2 = fopen(fname2, "r")))
+        return G2C_ERROR;
 
-   /* Check each line in the file. */
-   while (fgets(l1, MAX_LINE_LEN, fp1))
-   {
-       if (!fgets(l2, MAX_LINE_LEN, fp2))
-           return G2C_ERROR;
-       /* printf("l1: %s\n", l1); */
-       /* printf("l2: %s\n", l2); */
-       if (degrib2_lines_not_equal(l1, l2))
-           return G2C_ERROR;
+    /* Check each line in the file. */
+    while (fgets(l1, MAX_LINE_LEN, fp1))
+    {
+        if (!fgets(l2, MAX_LINE_LEN, fp2))
+            return G2C_ERROR;
+        /* printf("l1: %s\n", l1); */
+        /* printf("l2: %s\n", l2); */
+        if (degrib2_lines_not_equal(l1, l2))
+            return G2C_ERROR;
     }
 
-   /* Close files. */
-   fclose(fp1);
-   fclose(fp2);
+    /* Close files. */
+    fclose(fp1);
+    fclose(fp2);
 
-   return G2C_NOERROR;
+    return G2C_NOERROR;
 }
 
 int
@@ -122,7 +122,7 @@ main()
             return ret;
         if ((ret = g2c_close(g2cid)))
             return ret;
-        
+
         if ((ret = compare_files2(FILE_NAME, REF_FILE)))
             return ret;
     }
@@ -203,7 +203,7 @@ main()
 #define NUM_TESTS 2
     printf("Testing degrib2 on file %s downloaded via FTP...\n", FTP_FILE);
     {
-	int g2cid;
+        int g2cid;
         int num_msg;
         unsigned char sig_ref_time, month, day, hour, minute, second;
         short year;
@@ -252,7 +252,7 @@ main()
              10, 10, 10, 10, 10, 10, 10, 10, 0, 0, 10, 10, 10, 10, 0, 10, 10,
              10, 0, 10, 10, 10, 0, 10, 10, 10, 0, 10, 10, 10, 10};
         int t, m;
-	int ret;
+        int ret;
 
         for (t = 0; t < NUM_TESTS; t++)
         {
@@ -270,7 +270,7 @@ main()
                 if ((ret = g2c_open(FTP_FILE, 0, &g2cid)))
                     return ret;
             }
-            
+
             /* Check some stuff. */
             if ((ret = g2c_inq(g2cid, &num_msg)))
                 return ret;
@@ -290,7 +290,7 @@ main()
                 if (discipline != expected_discipline[m])
                     return G2C_ERROR;
             }
-            
+
             /* Check some stuff about the last message. */
             if ((ret = g2c_inq_msg(g2cid, 687, &discipline, &num_fields, &num_local,
                                    &center, &subcenter, &master_version, &local_version)))
@@ -299,17 +299,17 @@ main()
                 return G2C_ERROR;
             if (num_local || num_fields != 1 || discipline != 10)
                 return G2C_ERROR;
-            
+
             /* Inquire about the date/time. */
             if ((ret = g2c_inq_msg_time(g2cid, 687, &sig_ref_time, &year, &month, &day, &hour,
                                         &minute, &second)))
                 return ret;
-            
+
             /* Check date/time. */
             if (sig_ref_time != 1 || year != 2022 || month != 7 || day != 18 ||
                 hour != 0 || minute != 0 || second != 0)
                 return G2C_ERROR;
-            
+
             /* Output a degrib2 file. */
             if ((ret = g2c_degrib2(g2cid, FTP_DEGRIB2_FILE)))
                 return ret;
@@ -321,7 +321,7 @@ main()
             /* Compare the degrib2 output to our reference file. */
             if ((ret = compare_files2(FTP_DEGRIB2_FILE, REF_FTP_DEGRIB2_FILE)))
                 return ret;
-            
+
             printf("\tok!\n");
         }
     }
@@ -331,4 +331,3 @@ main()
     printf("SUCCESS!\n");
     return 0;
 }
-

--- a/tests/tst_error.c
+++ b/tests/tst_error.c
@@ -62,10 +62,15 @@ int main()
 	return G2C_ERROR;
     if (strncmp(g2c_strerror(-72), "Product not found", MAX_LEN))
 	return G2C_ERROR;
+    if (strncmp(g2c_strerror(-73), "Bad type", MAX_LEN))
+	return G2C_ERROR;
     if (strncmp(g2c_strerror(999), "Unknown Error", MAX_LEN))
 	return G2C_ERROR;
 
     printf("SUCCESS!\n");
     return 0;
 }
+
+
+
 

--- a/tests/tst_index.c
+++ b/tests/tst_index.c
@@ -66,7 +66,7 @@ main()
             return G2C_ERROR;
 
         /* Open the data file using the index file. */
-        g2c_set_log_level(10);
+        /* g2c_set_log_level(10); */
         if ((ret = g2c_read_index(WAVE_FILE, REF_FILE, 0, &g2cid)))
             return ret;
 
@@ -134,7 +134,7 @@ main()
         int ret;
 
 	/* Open the data file. */
-        g2c_set_log_level(20);
+        /* g2c_set_log_level(20); */
 	if ((ret = g2c_open(WAVE_FILE, 0, &g2cid)))
 	    return ret;
 

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -7,6 +7,7 @@
 #include "grib2_int.h"
 
 #define WAVE_FILE "gdaswave.t00z.wcoast.0p16.f000.grib2"
+#define TEST_FILE "tst_io.bin"
 
 int
 main()
@@ -14,6 +15,20 @@ main()
     printf("Testing g2c I/O functions.\n");
     printf("Testing simple calls...\n");
     {
+        FILE *f;
+        int val = 42;
+        int ret;
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
+
+        /* Write 4 bytes. */
+        if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &val)))
+            return ret;
+
+        /* Close file. */
+        fclose(f);
     }
     printf("ok!\n");
     printf("SUCCESS!\n");

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -217,8 +217,10 @@ main()
     printf("Testing template calls with 8-byte ints...");
     {
         FILE *f;
-        unsigned long long val = 18446744073709551615ULL;
-        long long neg_val = -9223372036854775807LL;
+        /* unsigned long long val = 18446744073709551615ULL; */
+        /* long long neg_val = -9223372036854775807LL; */
+        unsigned long long val = 1844674407370955161ULL;
+        long long neg_val = -922337203685477580LL;
         long long val_in;
         unsigned long long uval_in;
         int ret;

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -26,6 +26,16 @@ main()
         if (!(f = fopen(TEST_FILE, "wb")))
             return G2C_EFILE;
 
+        /* These won't work due to invalid input. */
+        if (g2c_file_io_int(NULL, G2C_FILE_WRITE, &val) != G2C_EINVAL)
+            return G2C_ERROR;
+        if (g2c_file_io_int(f, G2C_FILE_WRITE, NULL) != G2C_EINVAL)
+            return G2C_ERROR;
+        if (g2c_file_io(f, G2C_FILE_WRITE, 0, &val) != G2C_EINVAL)
+            return G2C_ERROR;
+        if (g2c_file_io(f, G2C_FILE_WRITE, G2C_UINT64 + 1, &val) != G2C_EINVAL)
+            return G2C_ERROR;
+
         /* Write 4 bytes, thrice. */
         if ((ret = g2c_file_io_int(f, G2C_FILE_WRITE, &val)))
             return ret;
@@ -122,146 +132,146 @@ main()
         fclose(f);
     }
     printf("ok!\n");
-    printf("Testing template calls with 1-byte ints...");
-    {
-        FILE *f;
-        unsigned char val = 250;
-        char neg_val = -120;
-        char val_in;
-        unsigned char uval_in;
-        int ret;
+    /* printf("Testing template calls with 1-byte ints..."); */
+    /* { */
+    /*     FILE *f; */
+    /*     unsigned char val = 250; */
+    /*     char neg_val = -120; */
+    /*     char val_in; */
+    /*     unsigned char uval_in; */
+    /*     int ret; */
 
-        /* Open the test file. */
-        if (!(f = fopen(TEST_FILE, "wb")))
-            return G2C_EFILE;
+    /*     /\* Open the test file. *\/ */
+    /*     if (!(f = fopen(TEST_FILE, "wb"))) */
+    /*         return G2C_EFILE; */
 
-        /* Write 1-byte ints, thrice. */
-        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
-            return ret;
-        if ((ret = g2c_file_io_byte(f, G2C_FILE_WRITE, &neg_val)))
-            return ret;
-        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
-            return ret;
+    /*     /\* Write 1-byte ints, thrice. *\/ */
+    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_file_io_byte(f, G2C_FILE_WRITE, &neg_val))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val))) */
+    /*         return ret; */
 
-        /* Close file. */
-        fclose(f);
+    /*     /\* Close file. *\/ */
+    /*     fclose(f); */
 
-        /* Open the test file. */
-        if (!(f = fopen(TEST_FILE, "rb")))
-            return G2C_EFILE;
+    /*     /\* Open the test file. *\/ */
+    /*     if (!(f = fopen(TEST_FILE, "rb"))) */
+    /*         return G2C_EFILE; */
 
-        /* Read three values. */
-        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
-            return ret;
-        if (uval_in != val)
-            return G2C_ERROR;
-        if ((ret = g2c_file_io_byte(f, G2C_FILE_READ, &val_in)))
-            return ret;
-        if (val_in != neg_val)
-            return G2C_ERROR;
-        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
-            return ret;
-        if (uval_in != val)
-            return G2C_ERROR;
+    /*     /\* Read three values. *\/ */
+    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in))) */
+    /*         return ret; */
+    /*     if (uval_in != val) */
+    /*         return G2C_ERROR; */
+    /*     if ((ret = g2c_file_io_byte(f, G2C_FILE_READ, &val_in))) */
+    /*         return ret; */
+    /*     if (val_in != neg_val) */
+    /*         return G2C_ERROR; */
+    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in))) */
+    /*         return ret; */
+    /*     if (uval_in != val) */
+    /*         return G2C_ERROR; */
 
-        /* Close file. */
-        fclose(f);
-    }
-    printf("ok!\n");
-    printf("Testing template calls with 2-byte ints...");
-    {
-        FILE *f;
-        unsigned short val = 65530;
-        short neg_val = -32760;
-        short val_in;
-        unsigned short uval_in;
-        int ret;
+    /*     /\* Close file. *\/ */
+    /*     fclose(f); */
+    /* } */
+    /* printf("ok!\n"); */
+    /* printf("Testing template calls with 2-byte ints..."); */
+    /* { */
+    /*     FILE *f; */
+    /*     unsigned short val = 65530; */
+    /*     short neg_val = -32760; */
+    /*     short val_in; */
+    /*     unsigned short uval_in; */
+    /*     int ret; */
 
-        /* Open the test file. */
-        if (!(f = fopen(TEST_FILE, "wb")))
-            return G2C_EFILE;
+    /*     /\* Open the test file. *\/ */
+    /*     if (!(f = fopen(TEST_FILE, "wb"))) */
+    /*         return G2C_EFILE; */
 
-        /* Write 1-byte ints, thrice. */
-        if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val)))
-            return ret;
-        if ((ret = g2c_file_io_short(f, G2C_FILE_WRITE, &neg_val)))
-            return ret;
-        if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val)))
-            return ret;
+    /*     /\* Write 1-byte ints, thrice. *\/ */
+    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_file_io_short(f, G2C_FILE_WRITE, &neg_val))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val))) */
+    /*         return ret; */
 
-        /* Close file. */
-        fclose(f);
+    /*     /\* Close file. *\/ */
+    /*     fclose(f); */
 
-        /* Open the test file. */
-        if (!(f = fopen(TEST_FILE, "rb")))
-            return G2C_EFILE;
+    /*     /\* Open the test file. *\/ */
+    /*     if (!(f = fopen(TEST_FILE, "rb"))) */
+    /*         return G2C_EFILE; */
 
-        /* Read three values. */
-        if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in)))
-            return ret;
-        if (uval_in != val)
-            return G2C_ERROR;
-        if ((ret = g2c_file_io_short(f, G2C_FILE_READ, &val_in)))
-            return ret;
-        if (val_in != neg_val)
-            return G2C_ERROR;
-        if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in)))
-            return ret;
-        if (uval_in != val)
-            return G2C_ERROR;
+    /*     /\* Read three values. *\/ */
+    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in))) */
+    /*         return ret; */
+    /*     if (uval_in != val) */
+    /*         return G2C_ERROR; */
+    /*     if ((ret = g2c_file_io_short(f, G2C_FILE_READ, &val_in))) */
+    /*         return ret; */
+    /*     if (val_in != neg_val) */
+    /*         return G2C_ERROR; */
+    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in))) */
+    /*         return ret; */
+    /*     if (uval_in != val) */
+    /*         return G2C_ERROR; */
 
-        /* Close file. */
-        fclose(f);
-    }
-    printf("ok!\n");
-    printf("Testing template calls with 8-byte ints...");
-    {
-        FILE *f;
-        /* unsigned long long val = 18446744073709551615ULL; */
-        /* long long neg_val = -9223372036854775807LL; */
-        unsigned long long val = 1844674407370955161ULL;
-        long long neg_val = -922337203685477580LL;
-        long long val_in;
-        unsigned long long uval_in;
-        int ret;
+    /*     /\* Close file. *\/ */
+    /*     fclose(f); */
+    /* } */
+    /* printf("ok!\n"); */
+    /* printf("Testing template calls with 8-byte ints..."); */
+    /* { */
+    /*     FILE *f; */
+    /*     /\* unsigned long long val = 18446744073709551615ULL; *\/ */
+    /*     /\* long long neg_val = -9223372036854775807LL; *\/ */
+    /*     unsigned long long val = 1844674407370955161ULL; */
+    /*     long long neg_val = -922337203685477580LL; */
+    /*     long long val_in; */
+    /*     unsigned long long uval_in; */
+    /*     int ret; */
 
-        /* Open the test file. */
-        if (!(f = fopen(TEST_FILE, "wb")))
-            return G2C_EFILE;
+    /*     /\* Open the test file. *\/ */
+    /*     if (!(f = fopen(TEST_FILE, "wb"))) */
+    /*         return G2C_EFILE; */
 
-        /* Write 1-byte ints, thrice. */
-        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val)))
-            return ret;
-        if ((ret = g2c_file_io_longlong(f, G2C_FILE_WRITE, &neg_val)))
-            return ret;
-        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val)))
-            return ret;
+    /*     /\* Write 1-byte ints, thrice. *\/ */
+    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_file_io_longlong(f, G2C_FILE_WRITE, &neg_val))) */
+    /*         return ret; */
+    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val))) */
+    /*         return ret; */
 
-        /* Close file. */
-        fclose(f);
+    /*     /\* Close file. *\/ */
+    /*     fclose(f); */
 
-        /* Open the test file. */
-        if (!(f = fopen(TEST_FILE, "rb")))
-            return G2C_EFILE;
+    /*     /\* Open the test file. *\/ */
+    /*     if (!(f = fopen(TEST_FILE, "rb"))) */
+    /*         return G2C_EFILE; */
 
-        /* Read three values. */
-        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in)))
-            return ret;
-        if (uval_in != val)
-            return G2C_ERROR;
-        if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in)))
-            return ret;
-        if (val_in != neg_val)
-            return G2C_ERROR;
-        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in)))
-            return ret;
-        if (uval_in != val)
-            return G2C_ERROR;
+    /*     /\* Read three values. *\/ */
+    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
+    /*         return ret; */
+    /*     if (uval_in != val) */
+    /*         return G2C_ERROR; */
+    /*     if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in))) */
+    /*         return ret; */
+    /*     if (val_in != neg_val) */
+    /*         return G2C_ERROR; */
+    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
+    /*         return ret; */
+    /*     if (uval_in != val) */
+    /*         return G2C_ERROR; */
 
-        /* Close file. */
-        fclose(f);
-    }
-    printf("ok!\n");
+    /*     /\* Close file. *\/ */
+    /*     fclose(f); */
+    /* } */
+    /* printf("ok!\n"); */
     printf("SUCCESS!\n");
     return 0;
 }

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -125,8 +125,8 @@ main()
     printf("Testing template calls with 1-byte ints...");
     {
         FILE *f;
-        unsigned char val = 42;
-        char neg_val = -42;
+        unsigned char val = 250;
+        char neg_val = -120;
         char val_in;
         unsigned char uval_in;
         int ret;
@@ -171,8 +171,8 @@ main()
     printf("Testing template calls with 2-byte ints...");
     {
         FILE *f;
-        unsigned short val = 42;
-        short neg_val = -42;
+        unsigned short val = 65530;
+        short neg_val = -32760;
         short val_in;
         unsigned short uval_in;
         int ret;
@@ -217,8 +217,8 @@ main()
     printf("Testing template calls with 8-byte ints...");
     {
         FILE *f;
-        unsigned long long val = 42;
-        long long neg_val = -42;
+        unsigned long long val = 18446744073709551615ULL;
+        long long neg_val = -9223372036854775807LL;
         long long val_in;
         unsigned long long uval_in;
         int ret;

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -1,0 +1,21 @@
+/* This is a test for the NCEPLIBS-g2c project. This test is for
+ * the g2c I/O functions.
+ *
+ * Ed Hartnett 11/11/22
+ */
+
+#include "grib2_int.h"
+
+#define WAVE_FILE "gdaswave.t00z.wcoast.0p16.f000.grib2"
+
+int
+main()
+{
+    printf("Testing g2c I/O functions.\n");
+    printf("Testing simple calls...\n");
+    {
+    }
+    printf("ok!\n");
+    printf("SUCCESS!\n");
+    return 0;
+}

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -122,6 +122,144 @@ main()
         fclose(f);
     }
     printf("ok!\n");
+    printf("Testing template calls with 1-byte ints...");
+    {
+        FILE *f;
+        unsigned char val = 42;
+        char neg_val = -42;
+        char val_in;
+        unsigned char uval_in;
+        int ret;
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
+
+        /* Write 1-byte ints, thrice. */
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        if ((ret = g2c_file_io_byte(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
+            return ret;
+
+        /* Close file. */
+        fclose(f);
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
+
+        /* Read three values. */
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_byte(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+
+        /* Close file. */
+        fclose(f);
+    }
+    printf("ok!\n");
+    printf("Testing template calls with 2-byte ints...");
+    {
+        FILE *f;
+        unsigned short val = 42;
+        short neg_val = -42;
+        short val_in;
+        unsigned short uval_in;
+        int ret;
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
+
+        /* Write 1-byte ints, thrice. */
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        if ((ret = g2c_file_io_short(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val)))
+            return ret;
+
+        /* Close file. */
+        fclose(f);
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
+
+        /* Read three values. */
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_short(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+
+        /* Close file. */
+        fclose(f);
+    }
+    printf("ok!\n");
+    printf("Testing template calls with 8-byte ints...");
+    {
+        FILE *f;
+        unsigned long long val = 42;
+        long long neg_val = -42;
+        long long val_in;
+        unsigned long long uval_in;
+        int ret;
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
+
+        /* Write 1-byte ints, thrice. */
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        if ((ret = g2c_file_io_longlong(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val)))
+            return ret;
+
+        /* Close file. */
+        fclose(f);
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
+
+        /* Read three values. */
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+
+        /* Close file. */
+        fclose(f);
+    }
+    printf("ok!\n");
     printf("SUCCESS!\n");
     return 0;
 }

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -27,11 +27,11 @@ main()
             return G2C_EFILE;
 
         /* Write 4 bytes, thrice. */
-        if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &val)))
+        if ((ret = g2c_file_be_int(f, G2C_FILE_WRITE, &val)))
             return ret;
-        if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &neg_val)))
+        if ((ret = g2c_file_be_int(f, G2C_FILE_WRITE, &neg_val)))
             return ret;
-        if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &uval)))
+        if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &uval)))
             return ret;
 
         /* Close file. */
@@ -42,15 +42,15 @@ main()
             return G2C_EFILE;
 
         /* Read three values. */
-        if ((ret = g2c_file_be_int4(f, G2C_FILE_READ, &val_in)))
+        if ((ret = g2c_file_be_int(f, G2C_FILE_READ, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_be_int4(f, G2C_FILE_READ, &val_in)))
+        if ((ret = g2c_file_be_int(f, G2C_FILE_READ, &val_in)))
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_be_uint4(f, G2C_FILE_READ, &uval_in)))
+        if ((ret = g2c_file_be_uint(f, G2C_FILE_READ, &uval_in)))
             return ret;
         if (uval_in != uval)
             return G2C_ERROR;
@@ -60,15 +60,15 @@ main()
             return G2C_EFILE;
 
         /* Read as template values. */
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 1, &val_in)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 1, &val_in)))
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
@@ -90,11 +90,11 @@ main()
             return G2C_EFILE;
 
         /* Write 4 bytes, thrice. */
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_WRITE, 0, &val)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_WRITE, 0, &val)))
             return ret;
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_WRITE, 1, &neg_val)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_WRITE, 1, &neg_val)))
             return ret;
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_WRITE, 0, &val)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_WRITE, 0, &val)))
             return ret;
 
         /* Close file. */
@@ -105,15 +105,15 @@ main()
             return G2C_EFILE;
 
         /* Read as template values. */
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 1, &val_in)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 1, &val_in)))
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -231,8 +231,8 @@ main()
         /* long long neg_val = -9223372036854775807LL; */
         unsigned long long val = 1844674407370955161ULL;
         long long neg_val = -922337203685477580LL;
-        long long val_in;
-        unsigned long long uval_in;
+        /* long long val_in; */
+        /* unsigned long long uval_in; */
         int ret;
 
         /* Open the test file. */

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -224,54 +224,54 @@ main()
         fclose(f);
     }
     printf("ok!\n");
-    /* printf("Testing template calls with 8-byte ints..."); */
-    /* { */
-    /*     FILE *f; */
-    /*     /\* unsigned long long val = 18446744073709551615ULL; *\/ */
-    /*     /\* long long neg_val = -9223372036854775807LL; *\/ */
-    /*     unsigned long long val = 1844674407370955161ULL; */
-    /*     long long neg_val = -922337203685477580LL; */
-    /*     long long val_in; */
-    /*     unsigned long long uval_in; */
-    /*     int ret; */
+    printf("Testing template calls with 8-byte ints...");
+    {
+        FILE *f;
+        /* unsigned long long val = 18446744073709551615ULL; */
+        /* long long neg_val = -9223372036854775807LL; */
+        unsigned long long val = 1844674407370955161ULL;
+        long long neg_val = -922337203685477580LL;
+        long long val_in;
+        unsigned long long uval_in;
+        int ret;
 
-    /*     /\* Open the test file. *\/ */
-    /*     if (!(f = fopen(TEST_FILE, "wb"))) */
-    /*         return G2C_EFILE; */
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
 
-    /*     /\* Write 1-byte ints, thrice. *\/ */
-    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_file_io_longlong(f, G2C_FILE_WRITE, &neg_val))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val))) */
-    /*         return ret; */
+        /* Write 1-byte ints, thrice. */
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        if ((ret = g2c_file_io_longlong(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_WRITE, &val)))
+            return ret;
 
-    /*     /\* Close file. *\/ */
-    /*     fclose(f); */
+        /* Close file. */
+        fclose(f);
 
-    /*     /\* Open the test file. *\/ */
-    /*     if (!(f = fopen(TEST_FILE, "rb"))) */
-    /*         return G2C_EFILE; */
+        /* /\* Open the test file. *\/ */
+        /* if (!(f = fopen(TEST_FILE, "rb"))) */
+        /*     return G2C_EFILE; */
 
-    /*     /\* Read three values. *\/ */
-    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
-    /*         return ret; */
-    /*     if (uval_in != val) */
-    /*         return G2C_ERROR; */
-    /*     if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in))) */
-    /*         return ret; */
-    /*     if (val_in != neg_val) */
-    /*         return G2C_ERROR; */
-    /*     if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
-    /*         return ret; */
-    /*     if (uval_in != val) */
-    /*         return G2C_ERROR; */
+        /* /\* Read three values. *\/ */
+        /* if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
+        /*     return ret; */
+        /* if (uval_in != val) */
+        /*     return G2C_ERROR; */
+        /* if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in))) */
+        /*     return ret; */
+        /* if (val_in != neg_val) */
+        /*     return G2C_ERROR; */
+        /* if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
+        /*     return ret; */
+        /* if (uval_in != val) */
+        /*     return G2C_ERROR; */
 
-    /*     /\* Close file. *\/ */
-    /*     fclose(f); */
-    /* } */
-    /* printf("ok!\n"); */
+        /* /\* Close file. *\/ */
+        /* fclose(f); */
+    }
+    printf("ok!\n");
     printf("SUCCESS!\n");
     return 0;
 }

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -132,52 +132,52 @@ main()
         fclose(f);
     }
     printf("ok!\n");
-    /* printf("Testing template calls with 1-byte ints..."); */
-    /* { */
-    /*     FILE *f; */
-    /*     unsigned char val = 250; */
-    /*     char neg_val = -120; */
-    /*     char val_in; */
-    /*     unsigned char uval_in; */
-    /*     int ret; */
+    printf("Testing template calls with 1-byte ints...");
+    {
+        FILE *f;
+        unsigned char val = 250;
+        char neg_val = -120;
+        char val_in;
+        unsigned char uval_in;
+        int ret;
 
-    /*     /\* Open the test file. *\/ */
-    /*     if (!(f = fopen(TEST_FILE, "wb"))) */
-    /*         return G2C_EFILE; */
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
 
-    /*     /\* Write 1-byte ints, thrice. *\/ */
-    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_file_io_byte(f, G2C_FILE_WRITE, &neg_val))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val))) */
-    /*         return ret; */
+        /* Write 1-byte ints, thrice. */
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        if ((ret = g2c_file_io_byte(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
+            return ret;
 
-    /*     /\* Close file. *\/ */
-    /*     fclose(f); */
+        /* Close file. */
+        fclose(f);
 
-    /*     /\* Open the test file. *\/ */
-    /*     if (!(f = fopen(TEST_FILE, "rb"))) */
-    /*         return G2C_EFILE; */
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
 
-    /*     /\* Read three values. *\/ */
-    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in))) */
-    /*         return ret; */
-    /*     if (uval_in != val) */
-    /*         return G2C_ERROR; */
-    /*     if ((ret = g2c_file_io_byte(f, G2C_FILE_READ, &val_in))) */
-    /*         return ret; */
-    /*     if (val_in != neg_val) */
-    /*         return G2C_ERROR; */
-    /*     if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in))) */
-    /*         return ret; */
-    /*     if (uval_in != val) */
-    /*         return G2C_ERROR; */
+        /* Read three values. */
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_byte(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
 
-    /*     /\* Close file. *\/ */
-    /*     fclose(f); */
-    /* } */
-    /* printf("ok!\n"); */
+        /* Close file. */
+        fclose(f);
+    }
+    printf("ok!\n");
     /* printf("Testing template calls with 2-byte ints..."); */
     /* { */
     /*     FILE *f; */

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -19,6 +19,7 @@ main()
         int val = 42;
         int neg_val = -42;
         int val_in;
+        unsigned int uval = 42, uval_in;
         int ret;
 
         /* Open the test file. */
@@ -30,7 +31,7 @@ main()
             return ret;
         if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &neg_val)))
             return ret;
-        if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &val)))
+        if ((ret = g2c_file_be_uint4(f, G2C_FILE_WRITE, &uval)))
             return ret;
 
         /* Close file. */
@@ -53,9 +54,9 @@ main()
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_be_int4(f, G2C_FILE_READ, &val_in)))
+        if ((ret = g2c_file_be_uint4(f, G2C_FILE_READ, &uval_in)))
             return ret;
-        if (val_in != val)
+        if (uval_in != uval)
             return G2C_ERROR;
 
         /* Close file. */

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -178,52 +178,52 @@ main()
         fclose(f);
     }
     printf("ok!\n");
-    /* printf("Testing template calls with 2-byte ints..."); */
-    /* { */
-    /*     FILE *f; */
-    /*     unsigned short val = 65530; */
-    /*     short neg_val = -32760; */
-    /*     short val_in; */
-    /*     unsigned short uval_in; */
-    /*     int ret; */
+    printf("Testing template calls with 2-byte ints...");
+    {
+        FILE *f;
+        unsigned short val = 65530;
+        short neg_val = -32760;
+        short val_in;
+        unsigned short uval_in;
+        int ret;
 
-    /*     /\* Open the test file. *\/ */
-    /*     if (!(f = fopen(TEST_FILE, "wb"))) */
-    /*         return G2C_EFILE; */
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
 
-    /*     /\* Write 1-byte ints, thrice. *\/ */
-    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_file_io_short(f, G2C_FILE_WRITE, &neg_val))) */
-    /*         return ret; */
-    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val))) */
-    /*         return ret; */
+        /* Write 1-byte ints, thrice. */
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        if ((ret = g2c_file_io_short(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_WRITE, &val)))
+            return ret;
 
-    /*     /\* Close file. *\/ */
-    /*     fclose(f); */
+        /* Close file. */
+        fclose(f);
 
-    /*     /\* Open the test file. *\/ */
-    /*     if (!(f = fopen(TEST_FILE, "rb"))) */
-    /*         return G2C_EFILE; */
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
 
-    /*     /\* Read three values. *\/ */
-    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in))) */
-    /*         return ret; */
-    /*     if (uval_in != val) */
-    /*         return G2C_ERROR; */
-    /*     if ((ret = g2c_file_io_short(f, G2C_FILE_READ, &val_in))) */
-    /*         return ret; */
-    /*     if (val_in != neg_val) */
-    /*         return G2C_ERROR; */
-    /*     if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in))) */
-    /*         return ret; */
-    /*     if (uval_in != val) */
-    /*         return G2C_ERROR; */
+        /* Read three values. */
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_short(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_io_ushort(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
 
-    /*     /\* Close file. *\/ */
-    /*     fclose(f); */
-    /* } */
-    /* printf("ok!\n"); */
+        /* Close file. */
+        fclose(f);
+    }
+    printf("ok!\n");
     /* printf("Testing template calls with 8-byte ints..."); */
     /* { */
     /*     FILE *f; */

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -231,7 +231,7 @@ main()
         /* long long neg_val = -9223372036854775807LL; */
         unsigned long long val = 1844674407370955161ULL;
         long long neg_val = -922337203685477580LL;
-        /* long long val_in; */
+        long long val_in;
         unsigned long long uval_in;
         int ret;
 
@@ -260,10 +260,11 @@ main()
         printf("uval_in %llu\n", uval_in);
         if (uval_in != val)
             return G2C_ERROR;
-        /* if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in))) */
-        /*     return ret; */
-        /* if (val_in != neg_val) */
-        /*     return G2C_ERROR; */
+        if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        printf("val_in %lld\n", val_in);
+        if (val_in != neg_val)
+            return G2C_ERROR;
         /* if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
         /*     return ret; */
         /* if (uval_in != val) */

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -232,7 +232,7 @@ main()
         unsigned long long val = 1844674407370955161ULL;
         long long neg_val = -922337203685477580LL;
         /* long long val_in; */
-        /* unsigned long long uval_in; */
+        unsigned long long uval_in;
         int ret;
 
         /* Open the test file. */
@@ -250,15 +250,16 @@ main()
         /* Close file. */
         fclose(f);
 
-        /* /\* Open the test file. *\/ */
-        /* if (!(f = fopen(TEST_FILE, "rb"))) */
-        /*     return G2C_EFILE; */
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
 
-        /* /\* Read three values. *\/ */
-        /* if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
-        /*     return ret; */
-        /* if (uval_in != val) */
-        /*     return G2C_ERROR; */
+        /* Read three values. */
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        printf("uval_in %llu\n", uval_in);
+        if (uval_in != val)
+            return G2C_ERROR;
         /* if ((ret = g2c_file_io_longlong(f, G2C_FILE_READ, &val_in))) */
         /*     return ret; */
         /* if (val_in != neg_val) */
@@ -268,8 +269,8 @@ main()
         /* if (uval_in != val) */
         /*     return G2C_ERROR; */
 
-        /* /\* Close file. *\/ */
-        /* fclose(f); */
+        /* Close file. */
+        fclose(f);
     }
     printf("ok!\n");
     printf("SUCCESS!\n");

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -13,19 +13,50 @@ int
 main()
 {
     printf("Testing g2c I/O functions.\n");
-    printf("Testing simple calls...\n");
+    printf("Testing simple calls with 4-byte ints...\n");
     {
         FILE *f;
         int val = 42;
+        int neg_val = -42;
+        int val_in;
         int ret;
 
         /* Open the test file. */
         if (!(f = fopen(TEST_FILE, "wb")))
             return G2C_EFILE;
 
-        /* Write 4 bytes. */
+        /* Write 4 bytes, thrice. */
         if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &val)))
             return ret;
+        if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_be_int4(f, G2C_FILE_WRITE, &val)))
+            return ret;
+
+        /* Close file. */
+        fclose(f);
+
+        /* Reposition at start of file. */
+        /* if (fseek(f, 0, SEEK_SET)) */
+        /*     return G2C_EFILE; */
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
+
+        /* Read three values. */
+        if ((ret = g2c_file_be_int4(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_be_int4(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_be_int4(f, G2C_FILE_READ, &val_in)))
+            return ret;
+        if (val_in != val)
+            return G2C_ERROR;
 
         /* Close file. */
         fclose(f);

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -60,15 +60,15 @@ main()
             return G2C_EFILE;
 
         /* Read as template values. */
-        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 1, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, -4, &val_in)))
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
@@ -90,11 +90,11 @@ main()
             return G2C_EFILE;
 
         /* Write 4 bytes, thrice. */
-        if ((ret = g2c_file_template_int(f, G2C_FILE_WRITE, 0, &val)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_WRITE, 4, &val)))
             return ret;
-        if ((ret = g2c_file_template_int(f, G2C_FILE_WRITE, 1, &neg_val)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_WRITE, -4, &neg_val)))
             return ret;
-        if ((ret = g2c_file_template_int(f, G2C_FILE_WRITE, 0, &val)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_WRITE, 4, &val)))
             return ret;
 
         /* Close file. */
@@ -105,15 +105,15 @@ main()
             return G2C_EFILE;
 
         /* Read as template values. */
-        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 1, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, -4, &val_in)))
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_template_int(f, G2C_FILE_READ, 0, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -27,11 +27,11 @@ main()
             return G2C_EFILE;
 
         /* Write 4 bytes, thrice. */
-        if ((ret = g2c_file_be_int(f, G2C_FILE_WRITE, &val)))
+        if ((ret = g2c_file_io_int(f, G2C_FILE_WRITE, &val)))
             return ret;
-        if ((ret = g2c_file_be_int(f, G2C_FILE_WRITE, &neg_val)))
+        if ((ret = g2c_file_io_int(f, G2C_FILE_WRITE, &neg_val)))
             return ret;
-        if ((ret = g2c_file_be_uint(f, G2C_FILE_WRITE, &uval)))
+        if ((ret = g2c_file_io_uint(f, G2C_FILE_WRITE, &uval)))
             return ret;
 
         /* Close file. */
@@ -42,15 +42,15 @@ main()
             return G2C_EFILE;
 
         /* Read three values. */
-        if ((ret = g2c_file_be_int(f, G2C_FILE_READ, &val_in)))
+        if ((ret = g2c_file_io_int(f, G2C_FILE_READ, &val_in)))
             return ret;
         if (val_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_be_int(f, G2C_FILE_READ, &val_in)))
+        if ((ret = g2c_file_io_int(f, G2C_FILE_READ, &val_in)))
             return ret;
         if (val_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_be_uint(f, G2C_FILE_READ, &uval_in)))
+        if ((ret = g2c_file_io_uint(f, G2C_FILE_READ, &uval_in)))
             return ret;
         if (uval_in != uval)
             return G2C_ERROR;

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -265,10 +265,10 @@ main()
         printf("val_in %lld\n", val_in);
         if (val_in != neg_val)
             return G2C_ERROR;
-        /* if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in))) */
-        /*     return ret; */
-        /* if (uval_in != val) */
-        /*     return G2C_ERROR; */
+        if ((ret = g2c_file_io_ulonglong(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        if (uval_in != val)
+            return G2C_ERROR;
 
         /* Close file. */
         fclose(f);

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -13,7 +13,7 @@ int
 main()
 {
     printf("Testing g2c I/O functions.\n");
-    printf("Testing simple calls with 4-byte ints...\n");
+    printf("Testing simple calls with 4-byte ints...");
     {
         FILE *f;
         int val = 42;
@@ -37,10 +37,6 @@ main()
         /* Close file. */
         fclose(f);
 
-        /* Reposition at start of file. */
-        /* if (fseek(f, 0, SEEK_SET)) */
-        /*     return G2C_EFILE; */
-
         /* Open the test file. */
         if (!(f = fopen(TEST_FILE, "rb")))
             return G2C_EFILE;
@@ -57,6 +53,69 @@ main()
         if ((ret = g2c_file_be_uint4(f, G2C_FILE_READ, &uval_in)))
             return ret;
         if (uval_in != uval)
+            return G2C_ERROR;
+
+        /* Reposition at start of file. */
+        if (fseek(f, 0, SEEK_SET))
+            return G2C_EFILE;
+
+        /* Read as template values. */
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+            return ret;
+        if (val_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 1, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+            return ret;
+        if (val_in != val)
+            return G2C_ERROR;
+
+        /* Close file. */
+        fclose(f);
+    }
+    printf("ok!\n");
+    printf("Testing template calls with 4-byte ints...");
+    {
+        FILE *f;
+        int val = 42;
+        int neg_val = -42;
+        int val_in;
+        int ret;
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "wb")))
+            return G2C_EFILE;
+
+        /* Write 4 bytes, thrice. */
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_WRITE, 0, &val)))
+            return ret;
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_WRITE, 1, &neg_val)))
+            return ret;
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_WRITE, 0, &val)))
+            return ret;
+
+        /* Close file. */
+        fclose(f);
+
+        /* Open the test file. */
+        if (!(f = fopen(TEST_FILE, "rb")))
+            return G2C_EFILE;
+
+        /* Read as template values. */
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+            return ret;
+        if (val_in != val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 1, &val_in)))
+            return ret;
+        if (val_in != neg_val)
+            return G2C_ERROR;
+        if ((ret = g2c_file_template_int4(f, G2C_FILE_READ, 0, &val_in)))
+            return ret;
+        if (val_in != val)
             return G2C_ERROR;
 
         /* Close file. */


### PR DESCRIPTION
Fixes #373 

In this PR I add some g2c_file_io_*() functions, which will perform reads and writes of different types of integer to GRIB2 files, including special negative number handling.

These functions replace the macros I was using for this purpose. (Which did not handle negative numbers.)

I also replace the function that reads/writes template numbers so it also handles negative and positive values correctly.

I am added more testing but this code is ready for review.
