### PR TITLE
change template values internally to signed 64-bit ints

### DIFF
--- a/src/g2_unpack7.c
+++ b/src/g2_unpack7.c
@@ -249,8 +249,8 @@ g2_unpack7(unsigned char *cgrib, g2int *iofst, g2int igdsnum, g2int *igdstmpl,
  * @author Stephen Gilbert @date 2002-10-31
  */
 int
-g2c_unpack7(unsigned char *cgrib, int igdsnum, int gds_tmpl_len, int *gdstmpl,
-            int idrsnum, int drs_tmpl_len, int *drstmpl, int ndpts, float *fld)
+g2c_unpack7(unsigned char *cgrib, int igdsnum, int gds_tmpl_len, long long int *gdstmpl,
+            int idrsnum, int drs_tmpl_len, long long int *drstmpl, int ndpts, float *fld)
 {
     g2int iofst = 0;
     g2int *igdstmpl = NULL, *idrstmpl;

--- a/src/g2cdegrib2.c
+++ b/src/g2cdegrib2.c
@@ -625,8 +625,9 @@ g2c_degrib2(int g2cid, const char *fileout)
             fprintf(f, "  SECTION 3:  %d %d %d %d %d\n", sec3_info->source_grid_def, sec3_info->num_data_points, sec3_info->num_opt,
                     sec3_info->interp_list, sec3_info->grid_def);
             fprintf(f, "  GRID TEMPLATE 3. %d : ", sec3_info->grid_def);
+            /* Cast to int to match behavior of  degrib2.F90. */            
             for (t = 0; t < sec3->template_len; t++)
-                fprintf(f, " %lld", sec3->template[t]);
+                fprintf(f, " %d", (int)sec3->template[t]);
             fprintf(f, "\n");
             if (!sec3_info->optional)
                 fprintf(f, "  NO Optional List Defining Number of Data Points.\n");
@@ -643,8 +644,9 @@ g2c_degrib2(int g2cid, const char *fileout)
                 return ret;
             fprintf(f, "( PARAMETER = %-8s %d %lld %lld ) ", abbrev, sec->msg->discipline, sec->template[0],
 		    sec->template[1]);
+            /* Cast to int to match behavior of  degrib2.F90. */            
             for (t = 0; t < sec->template_len; t++)
-                fprintf(f, " %lld", sec->template[t]);
+                fprintf(f, " %d", (int)sec->template[t]);
             fprintf(f, "\n");
 
 	    /* Using the product template number, and the template
@@ -681,12 +683,9 @@ g2c_degrib2(int g2cid, const char *fileout)
             else
                 fprintf(f, "  Num. of Data Points =  %d     NO BIT-MAP \n", sec5_info->num_data_points);
 	    fprintf(f, "  DRS TEMPLATE 5. %d : ", sec5_info->data_def);
-            /* Cast to int for the first template value. That's
-             * because degrib2.F90 shows these as signed ints, even if
-             * they are unsigned. */
-            fprintf(f, " %d", (int)sec5->template[0]);
-            for (t = 1; t < sec5->template_len; t++)
-                fprintf(f, " %lld", sec5->template[t]);
+            /* Cast to int to match behavior of  degrib2.F90. */
+            for (t = 0; t < sec5->template_len; t++)
+                fprintf(f, " %d", (int)sec5->template[t]);
             fprintf(f, "\n");
 	    fprintf(f, "  Data Values:\n");
 	    fprintf(f, "  Num. of Data Points =  %d   Num. of Data Undefined = 0\n", sec5_info->num_data_points);

--- a/src/g2cdegrib2.c
+++ b/src/g2cdegrib2.c
@@ -45,7 +45,7 @@ extern G2C_CODE_TABLE_T *g2c_table;
  * @author Ed Hartnett @date Sep 28, 2022
  */
 static int
-get_datetime(int ipdtn, int *ipdtmpl, short year, unsigned char month, unsigned char day,
+get_datetime(int ipdtn, long long int *ipdtmpl, short year, unsigned char month, unsigned char day,
         unsigned char hour, unsigned char minute, unsigned char second, char *tabbrev)
 {
     int iutpos, iutpos2, iunit, iunit2;
@@ -178,7 +178,7 @@ get_datetime(int ipdtn, int *ipdtmpl, short year, unsigned char month, unsigned 
     
   /* write(tmpval, '(I0)') itemp */
 
-    sprintf(tabbrev, "valid at  %d", ipdtmpl[iutpos + 1]);
+    sprintf(tabbrev, "valid at  %lld", ipdtmpl[iutpos + 1]);
   /* write(tabbrev, fmt = '("valid at  ", i4)') ipdtmpl(iutpos + 1) */
 
   /* Determine Reference Time: Year, Month, Day, Hour, Minute, Second. */
@@ -236,7 +236,7 @@ get_datetime(int ipdtn, int *ipdtmpl, short year, unsigned char month, unsigned 
  * @author Ed Hartnett @date Sep 28, 2022
  */
 static int
-get_level_desc(int ipdtn, int *ipdtmpl, char *level_desc)
+get_level_desc(int ipdtn, long long int *ipdtmpl, char *level_desc)
 {
     int ipos;
 
@@ -581,7 +581,7 @@ g2c_degrib2(int g2cid, const char *fileout)
                     sec3_info->interp_list, sec3_info->grid_def);
             fprintf(f, "  GRID TEMPLATE 3. %d : ", sec3_info->grid_def);
             for (t = 0; t < sec3->template_len; t++)
-                fprintf(f, " %d", sec3->template[t]);
+                fprintf(f, " %lld", sec3->template[t]);
             fprintf(f, "\n");
             if (!sec3_info->optional)
                 fprintf(f, "  NO Optional List Defining Number of Data Points.\n");
@@ -596,10 +596,10 @@ g2c_degrib2(int g2cid, const char *fileout)
              * number. */
             if ((ret = g2c_param_abbrev(msg->discipline, sec->template[0], sec->template[1], abbrev)))
                 return ret;
-            fprintf(f, "( PARAMETER = %-8s %d %d %d ) ", abbrev, sec->msg->discipline, sec->template[0],
+            fprintf(f, "( PARAMETER = %-8s %d %lld %lld ) ", abbrev, sec->msg->discipline, sec->template[0],
 		    sec->template[1]);
             for (t = 0; t < sec->template_len; t++)
-                fprintf(f, " %d", sec->template[t]);
+                fprintf(f, " %lld", sec->template[t]);
             fprintf(f, "\n");
 
 	    /* Using the product template number, and the template
@@ -628,7 +628,7 @@ g2c_degrib2(int g2cid, const char *fileout)
 	    fprintf(f, "  Num. of Data Points =  %d    with BIT-MAP  0\n", sec5_info->num_data_points);
 	    fprintf(f, "  DRS TEMPLATE 5. %d : ", sec5_info->data_def);
             for (t = 0; t < sec5->template_len; t++)
-                fprintf(f, " %d", sec5->template[t]);
+                fprintf(f, " %lld", sec5->template[t]);
             fprintf(f, "\n");
 	    fprintf(f, "  Data Values:\n");
 	    fprintf(f, "  Num. of Data Points =  %d   Num. of Data Undefined = 0\n", sec5_info->num_data_points);

--- a/src/g2cdegrib2.c
+++ b/src/g2cdegrib2.c
@@ -46,7 +46,7 @@ extern G2C_CODE_TABLE_T *g2c_table;
  * @author Ed Hartnett @date Sep 28, 2022
  */
 int
-g2c_get_datetime(int ipdtn, int *ipdtmpl, short year, unsigned char month, unsigned char day,
+g2c_get_datetime(int ipdtn, long long int *ipdtmpl, short year, unsigned char month, unsigned char day,
                  unsigned char hour, unsigned char minute, unsigned char second, char *tabbrev)
 {
     int iutpos, iutpos2, iunit, iunit2;
@@ -275,7 +275,7 @@ format_level(char *cbuf, int ival, int scale)
  * @author Ed Hartnett @date Sep 28, 2022
  */
 int
-g2c_get_level_desc(int ipdtn, int *ipdtmpl, char *level_desc)
+g2c_get_level_desc(int ipdtn, long long int *ipdtmpl, char *level_desc)
 {
     int ipos;
     int ret;
@@ -681,8 +681,10 @@ g2c_degrib2(int g2cid, const char *fileout)
             else
                 fprintf(f, "  Num. of Data Points =  %d     NO BIT-MAP \n", sec5_info->num_data_points);
 	    fprintf(f, "  DRS TEMPLATE 5. %d : ", sec5_info->data_def);
+            /* Cast to int here. That's because degrib2.F90 shows
+             * these as signed ints, even if they are unsigned. */
             for (t = 0; t < sec5->template_len; t++)
-                fprintf(f, " %lld", sec5->template[t]);
+                fprintf(f, " %d", (int)sec5->template[t]);
             fprintf(f, "\n");
 	    fprintf(f, "  Data Values:\n");
 	    fprintf(f, "  Num. of Data Points =  %d   Num. of Data Undefined = 0\n", sec5_info->num_data_points);

--- a/src/g2cdegrib2.c
+++ b/src/g2cdegrib2.c
@@ -681,10 +681,12 @@ g2c_degrib2(int g2cid, const char *fileout)
             else
                 fprintf(f, "  Num. of Data Points =  %d     NO BIT-MAP \n", sec5_info->num_data_points);
 	    fprintf(f, "  DRS TEMPLATE 5. %d : ", sec5_info->data_def);
-            /* Cast to int here. That's because degrib2.F90 shows
-             * these as signed ints, even if they are unsigned. */
-            for (t = 0; t < sec5->template_len; t++)
-                fprintf(f, " %d", (int)sec5->template[t]);
+            /* Cast to int for the first template value. That's
+             * because degrib2.F90 shows these as signed ints, even if
+             * they are unsigned. */
+            fprintf(f, " %d", (int)sec5->template[0]);
+            for (t = 1; t < sec5->template_len; t++)
+                fprintf(f, " %lld", sec5->template[t]);
             fprintf(f, "\n");
 	    fprintf(f, "  Data Values:\n");
 	    fprintf(f, "  Num. of Data Points =  %d   Num. of Data Undefined = 0\n", sec5_info->num_data_points);

--- a/src/g2cfile.c
+++ b/src/g2cfile.c
@@ -353,7 +353,7 @@ g2c_rw_section3_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     if (!rw_flag)
     {
         sec->template_len = maplen;
-        if (!(sec->template = calloc(sizeof(int) * maplen, 1)))
+        if (!(sec->template = calloc(sizeof(long long int) * maplen, 1)))
             return G2C_ENOMEM;
     }
 
@@ -443,7 +443,7 @@ g2c_rw_section4_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     if (!rw_flag)
     {
         sec->template_len = maplen;
-        if (!(sec->template = calloc(sizeof(int) * maplen, 1)))
+        if (!(sec->template = calloc(sizeof(long long int) * maplen, 1)))
             return G2C_ENOMEM;
     }
 
@@ -525,7 +525,7 @@ g2c_rw_section5_metadata(FILE *f, int rw_flag, G2C_SECTION_INFO_T *sec)
     if (!rw_flag)
     {
         sec->template_len = maplen;
-        if (!(sec->template = calloc(sizeof(int) * maplen, 1)))
+        if (!(sec->template = calloc(sizeof(long long int) * maplen, 1)))
             return G2C_ENOMEM;
     }
 

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -405,7 +405,7 @@ g2c_file_io_ulonglong(FILE *f, int write, unsigned long long *var)
  * @author Ed Hartnett 11/7/22
  */
 int
-g2c_file_io_template(FILE *f, int rw_flag, int map, int *template_value)
+g2c_file_io_template(FILE *f, int rw_flag, int map, long long int *template_value)
 {
     int ret;
 

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -375,8 +375,8 @@ int g2c_log_file(int g2cid);
 const char *g2c_strerror(int g2cerr);
 
 /* Compression. */
-int g2c_unpack7(unsigned char *cgrib, int igdsnum, int gds_tmpl_len, int *gdstmpl,
-                int idrsnum, int drs_tmpl_len, int *drstmpl, int ndpts, float *fld);
+int g2c_unpack7(unsigned char *cgrib, int igdsnum, int gds_tmpl_len, long long int *gdstmpl,
+                int idrsnum, int drs_tmpl_len, long long int *drstmpl, int ndpts, float *fld);
 int g2c_pngpackf(float *fld, size_t width, size_t height, int *idrstmpl,
                  unsigned char *cpack, int *lcpack);
 int g2c_pngpackd(double *fld, size_t width, size_t height, int *idrstmpl,

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -285,9 +285,9 @@ gtemplate *getgridtemplate(g2int number);
 gtemplate *extgridtemplate(g2int number, g2int *list);
 
 /* Level and date/time info. */
-int g2c_get_datetime(int ipdtn, int *ipdtmpl, short year, unsigned char month, unsigned char day,
+int g2c_get_datetime(int ipdtn, long long int *ipdtmpl, short year, unsigned char month, unsigned char day,
                      unsigned char hour, unsigned char minute, unsigned char second, char *tabbrev);
-int g2c_get_level_desc(int ipdtn, int *ipdtmpl, char *level_desc);
+int g2c_get_level_desc(int ipdtn, long long int *ipdtmpl, char *level_desc);
 
 /* Packing and unpacking data. */
 void simpack(float *fld, g2int ndpts, g2int *idrstmpl,

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -154,7 +154,7 @@ typedef struct g2c_section_info
     void *sec_info; /**< Pointer to struct specific for section 3, 4, 5, 6, or 7. */
     struct g2c_section_info *next; /**< Pointer to next in list. */
     struct g2c_section_info *prev; /**< Pointer to previous in list. */
-    int *template; /**< Grid, product, or data template. */
+    long long int *template; /**< Grid, product, or data template. */
     int template_len; /**< Number of entries in template. */
 } G2C_SECTION_INFO_T;
 
@@ -167,8 +167,8 @@ typedef struct g2c_section3_info
     unsigned char num_opt; /**< Number of octets for optional list of numbers defining number of points. */
     unsigned char interp_list; /**< Interpetation of list of numbers defining number of points (See Table 3.11). */
     unsigned short grid_def; /**< Grid definition template number (= N) (See Table 3.1). */
-    int *optional; /**< Optional list of numbers defining number of points. */}
-    G2C_SECTION3_INFO_T;
+    int *optional; /**< Optional list of numbers defining number of points. */
+} G2C_SECTION3_INFO_T;
 
 /** Information about [Section 4 PRODUCT DEFINITION
  * SECTION](https://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_doc/grib2_sect4.shtml). */
@@ -340,7 +340,7 @@ int g2c_file_io_int(FILE *f, int write, int *var);
 int g2c_file_io_uint(FILE *f, int write, unsigned int *var);
 int g2c_file_io_longlong(FILE *f, int write, long long *var);
 int g2c_file_io_ulonglong(FILE *f, int write, unsigned long long *var);
-int g2c_file_io_template(FILE *f, int rw_flag, int map, int *template_value);
+int g2c_file_io_template(FILE *f, int rw_flag, int map, long long int *template_value);
 
 /* Read and remember file, message, and section metadata. */
 int g2c_add_file(const char *path, int mode, int *g2cid);

--- a/tests/tst_decode.c
+++ b/tests/tst_decode.c
@@ -76,9 +76,9 @@ int main()
     printf("Testing g2c_unpack7()...");
     {
         int igdsnum = 0;
-        int *igdstmpl = NULL;
+        long long int *igdstmpl = NULL;
         int idrsnum = 0;
-        int idrstmpl[5] = {0, 0, 0, 1, 0};
+        long long int idrstmpl[5] = {0, 0, 0, 1, 0};
         int ndpts = 121;
         float *fld;
 

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -71,7 +71,7 @@ degrib2_lines_not_equal(char *l1, char *l2)
     else
     {
         printf("\n%s\n", l1);
-        printf("%s\n", l2);
+        printf("expected:\n%s\n", l2);
         return G2C_ERROR;
     }
 

--- a/tests/tst_degrib2_int.c
+++ b/tests/tst_degrib2_int.c
@@ -17,7 +17,7 @@ main()
     {
 #define DATE_TIME_LEN 100
         int prod_template_num[NUM_PROD_TEST] = {0, 0};
-        int prod_template_value[NUM_PROD_TEST][G2C_MAX_PDS_TEMPLATE_MAPLEN] = {
+        long long int prod_template_value[NUM_PROD_TEST][G2C_MAX_PDS_TEMPLATE_MAPLEN] = {
             {2, 1, 2, 0, 11, 0, 0, 1, 0, 1, 0, 1, 255, 0, 0},
             {2, 10, 0, 0, 81, 0, 0, 1, 0, 100, 0, 80000, 255, 0, 0}
         };

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -19,6 +19,7 @@ main()
         int val = 42;
         int neg_val = -42;
         int val_in;
+        long long int llval_in;
         unsigned int uval = 42, uval_in;
         int ret;
 
@@ -70,17 +71,17 @@ main()
             return G2C_EFILE;
 
         /* Read as template values. */
-        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &llval_in)))
             return ret;
-        if (val_in != val)
+        if (llval_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, -4, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, -4, &llval_in)))
             return ret;
-        if (val_in != neg_val)
+        if (llval_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &llval_in)))
             return ret;
-        if (val_in != val)
+        if (llval_in != val)
             return G2C_ERROR;
 
         /* Close file. */
@@ -90,9 +91,9 @@ main()
     printf("Testing template calls with 4-byte ints...");
     {
         FILE *f;
-        int val = 42;
-        int neg_val = -42;
-        int val_in;
+        long long int val = 42;
+        long long int neg_val = -42;
+        long long int llval_in;
         int ret;
 
         /* Open the test file. */
@@ -115,17 +116,17 @@ main()
             return G2C_EFILE;
 
         /* Read as template values. */
-        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &llval_in)))
             return ret;
-        if (val_in != val)
+        if (llval_in != val)
             return G2C_ERROR;
-        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, -4, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, -4, &llval_in)))
             return ret;
-        if (val_in != neg_val)
+        if (llval_in != neg_val)
             return G2C_ERROR;
-        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &val_in)))
+        if ((ret = g2c_file_io_template(f, G2C_FILE_READ, 4, &llval_in)))
             return ret;
-        if (val_in != val)
+        if (llval_in != val)
             return G2C_ERROR;
 
         /* Close file. */


### PR DESCRIPTION
GRIB2 sometimes stores 4-byte unsigned floats in templates.

To handle this, internally we need to store template values as long long int. Interestingly, the degrib2.F90 prints every template value as a signed int, even if it is an unsigned int. So some numbers show up as negative in degrib2 output. In g2cdegrib2.c I cast back to int to match the behavior of degrib2.F90.

Part of #209 

