### PR TITLE
rename function to g2c_open_index()

### DIFF
--- a/src/g2cindex.c
+++ b/src/g2cindex.c
@@ -481,7 +481,7 @@ g2c_write_index(int g2cid, int mode, const char *index_file)
  * @author Ed Hartnett @date 10/12/22
  */
 int
-g2c_read_index(const char *data_file, const char *index_file, int mode,
+g2c_open_index(const char *data_file, const char *index_file, int mode,
                int *g2cid)
 {
     FILE *f;
@@ -494,7 +494,7 @@ g2c_read_index(const char *data_file, const char *index_file, int mode,
     if (strlen(data_file) > G2C_MAX_NAME)
         return G2C_ENAMETOOLONG;
 
-    LOG((1, "g2c_read_index index_file %s", index_file));
+    LOG((1, "g2c_open_index index_file %s", index_file));
 
     /* Open the index file. */
     if (!(f = fopen(index_file, "rb")))

--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -307,9 +307,9 @@ g2int jpcunpack(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
 
 /* File handling functions. */
 int g2c_open(const char *path, int mode, int *g2cid);
+int g2c_open_index(const char *data_file, const char *index_file, int mode, int *g2cid);
 int g2c_close(int g2cid);
 int g2c_write_index(int g2cid, int mode, const char *index_file);
-int g2c_read_index(const char *data_file, const char *index_file, int mode, int *g2cid);
 
 /* Inquiry functions. */
 int g2c_inq(int g2cid, int *num_msg);

--- a/tests/tst_degrib2.c
+++ b/tests/tst_degrib2.c
@@ -133,7 +133,7 @@ main()
             return ret;
     }
     printf("ok!\n");
-    printf("Testing g2c_read_index() to make a degrib2 file...");
+    printf("Testing g2c_open_index() to make a degrib2 file...");
     {
         int g2cid;
         int num_msg;
@@ -141,7 +141,7 @@ main()
 
         /* g2c_set_log_level(10); */
         /* Open the data file using the index file. */
-        if ((ret = g2c_read_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid)))
+        if ((ret = g2c_open_index(WAVE_FILE, REF_INDEX_FILE, 0, &g2cid)))
             return ret;
 
         /* Check some stuff. */
@@ -189,7 +189,7 @@ main()
             return ret;
 
         /* Reopen the data file, using the index we just generated. */
-        if ((ret = g2c_read_index(WAVE_FILE, TEST_INDEX_FILE, 0, &g2cid)))
+        if ((ret = g2c_open_index(WAVE_FILE, TEST_INDEX_FILE, 0, &g2cid)))
             return ret;
 
         /* Output a degrib2 file. */
@@ -267,7 +267,7 @@ main()
             if (t)
             {
                 printf("\ttesting degrib2 on file %s downloaded via FTP using index...", FTP_FILE);
-                if ((ret = g2c_read_index(FTP_FILE, REF_FTP_INDEX_FILE, 0, &g2cid)))
+                if ((ret = g2c_open_index(FTP_FILE, REF_FTP_INDEX_FILE, 0, &g2cid)))
                     return ret;
             }
             else
@@ -346,7 +346,7 @@ main()
             if (t)
             {
                 printf("\ttesting degrib2 on file %s downloaded via FTP using index...", GDAS_FILE);
-                if ((ret = g2c_read_index(GDAS_FILE, REF_GDAS_INDEX_FILE, 0, &g2cid)))
+                if ((ret = g2c_open_index(GDAS_FILE, REF_GDAS_INDEX_FILE, 0, &g2cid)))
                     return ret;
             }
             else

--- a/tests/tst_index.c
+++ b/tests/tst_index.c
@@ -1,6 +1,6 @@
 /* This is a test for the NCEPLIBS-g2c project. 
  *
- * This test is for the g2c_write_index()/g2c_read_index() functions,
+ * This test is for the g2c_write_index()/g2c_open_index() functions,
  * which write and read and index file that contians the byte offsets
  * to various parts of a GRIB2 file.
  *
@@ -51,23 +51,23 @@ main()
 {
     printf("Testing g2c index functions.\n");
 #ifdef JPEG
-    printf("Testing g2c_read_index() on file %s...", WAVE_FILE);
+    printf("Testing g2c_open_index() on file %s...", WAVE_FILE);
     {
         int g2cid;
         int num_msg;
         int ret;
 
         /* Will not work. */
-        if (g2c_read_index(NULL, NULL, 0, &g2cid) != G2C_EINVAL)
+        if (g2c_open_index(NULL, NULL, 0, &g2cid) != G2C_EINVAL)
             return G2C_ERROR;
-        if (g2c_read_index("bad", NULL, 0, &g2cid) != G2C_EINVAL)
+        if (g2c_open_index("bad", NULL, 0, &g2cid) != G2C_EINVAL)
             return G2C_ERROR;
-        if (g2c_read_index("bad", "bad", 0, &g2cid) != G2C_EFILE)
+        if (g2c_open_index("bad", "bad", 0, &g2cid) != G2C_EFILE)
             return G2C_ERROR;
 
         /* Open the data file using the index file. */
         /* g2c_set_log_level(10); */
-        if ((ret = g2c_read_index(WAVE_FILE, REF_FILE, 0, &g2cid)))
+        if ((ret = g2c_open_index(WAVE_FILE, REF_FILE, 0, &g2cid)))
             return ret;
 
         /* Check some stuff. */
@@ -153,7 +153,7 @@ main()
 	    return ret;
 
         /* Now reopen the file using the index we just generated. */
-	if ((ret = g2c_read_index(WAVE_FILE, INDEX_FILE, 0, &g2cid)))
+	if ((ret = g2c_open_index(WAVE_FILE, INDEX_FILE, 0, &g2cid)))
 	    return ret;
 
         /* Check some stuff. */
@@ -168,7 +168,7 @@ main()
     }
     printf("ok!\n");
 #ifdef FTP_TEST_FILES
-    printf("Testing g2c_read_index() on file %s downloaded via FTP...", FTP_FILE);
+    printf("Testing g2c_open_index() on file %s downloaded via FTP...", FTP_FILE);
     {
 	int g2cid;
         int num_msg;
@@ -182,7 +182,7 @@ main()
 
 	/* g2c_set_log_level(11); */
 	/* Open the data file using the index file. */
-	if ((ret = g2c_read_index(FTP_FILE, REF_FTP_FILE, 0, &g2cid)))
+	if ((ret = g2c_open_index(FTP_FILE, REF_FTP_FILE, 0, &g2cid)))
 	    return ret;
 
         /* Check some stuff. */
@@ -215,7 +215,7 @@ main()
 	    return ret;
     }
     printf("ok!\n");
-    printf("Testing speed of g2c_read_index() on file %s downloaded via FTP...\n", FTP_FILE);
+    printf("Testing speed of g2c_open_index() on file %s downloaded via FTP...\n", FTP_FILE);
     {
 	int g2cid;
         int num_msg;
@@ -247,7 +247,7 @@ main()
 	/* Open the data file using the index file. */
         if (gettimeofday(&start_time, NULL))
             return G2C_ERROR;
-	if ((ret = g2c_read_index(FTP_FILE, REF_FTP_FILE, 0, &g2cid)))
+	if ((ret = g2c_open_index(FTP_FILE, REF_FTP_FILE, 0, &g2cid)))
 	    return ret;
         if (gettimeofday(&end_time, NULL)) 
             return G2C_ERROR;

--- a/tests/tst_inq.c
+++ b/tests/tst_inq.c
@@ -32,7 +32,7 @@ main()
             /* Open our test file, with or without an index file. */
             if (op)
             {
-                if ((ret = g2c_read_index(WAVE_FILE, REF_FILE, 0, &g2cid)))
+                if ((ret = g2c_open_index(WAVE_FILE, REF_FILE, 0, &g2cid)))
                     return ret;
             }
             else


### PR DESCRIPTION
For consistency, rename g2c_read_index() to g2c_open_index().

Part of #209