### PR TITLE
more CI cleanup, require that all workflows pass before merge to develop

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -80,6 +80,6 @@ jobs:
     - name: test
       run: |
         cd $GITHUB_WORKSPACE/g2c/build
-        ctest  --output-on-failure --rerun-failed
+        ctest --verbose --output-on-failure --rerun-failed
 
       

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -75,7 +75,7 @@ jobs:
         mkdir build
         cd build
         cmake -DJasper_ROOT=~/Jasper ..
-        make -j2
+        make -j2 VERBOSE=1
 
     - name: test
       run: |

--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -92,4 +92,4 @@ jobs:
         cd build
         cmake ${{ matrix.config.options }} -DCMAKE_C_FLAGS="-g -fsanitize=address -Wall -Werror" ..
         make -j2
-        ctest --output-on-failure
+        ctest --verbose --output-on-failure --rerun-failed

--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -77,7 +77,7 @@ jobs:
         mkdir cmake_build
         cd cmake_build
         cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
-        make -j2
+        make -j2 VERBOSE=1
         make install
 
     - name: checkout

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -26,26 +26,25 @@ jobs:
     - name: install-dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install libpng-dev zlib1g-dev libjpeg-dev doxygen libopenjp2-7-dev
-        python3 -m pip install gcovr
+        sudo apt-get install libpng-dev zlib1g-dev libjpeg-dev libopenjp2-7-dev
         if [[ ${{ matrix.ccompiler }} == "clang" ]]; then
           sudo apt-get install clang
         fi
-        
-
-    - name: checkout-jasper
-      uses: actions/checkout@v2
-      with:
-        repository: jasper-software/jasper
-        path: jasper
-        ref: version-${{ matrix.jasper-version }}
 
     - name: cache-jasper
       id: cache-jasper
       uses: actions/cache@v2
       with:
-        path: ~/Jasper
-        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}
+        path: ~/jasper
+        key: jasper-${{ runner.os }}-${{ matrix.jasper-version }}
+
+    - name: checkout-jasper
+      if: steps.cache-jasper.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: jasper-software/jasper
+        path: jasper
+        ref: version-${{ matrix.jasper-version }}
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -58,7 +57,7 @@ jobs:
         cd jasper
         mkdir cmake_build
         cd cmake_build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
+        cmake .. -DCMAKE_INSTALL_PREFIX=~/jasper
         make -j2
         make install
 
@@ -77,7 +76,7 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper -DENABLE_OpenJPEG=ON .. 
+        cmake -DJasper_ROOT=~/jasper -DENABLE_OpenJPEG=ON .. 
         make -j2
 
     - name: test

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -73,26 +73,16 @@ jobs:
           export CC=clang
         elif [[ ${{ matrix.ccompiler }} == "gcc" ]]; then
           export CC=gcc
-          export CFLAGS='-Wall -Werror -g -fprofile-abs-path -fprofile-arcs -ftest-coverage -O0 -fsanitize=address'
         fi
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper -DLOGGING=On -DENABLE_DOCS=On -DENABLE_OpenJPEG=ON .. 
+        cmake -DJasper_ROOT=~/Jasper -DENABLE_OpenJPEG=ON .. 
         make -j2
 
     - name: test
       run: |
         set -e          
         cd $GITHUB_WORKSPACE/g2c/build
-        ctest --verbose 
-        gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
-        ls -l
-          
-    - name: upload-test-coverage
-      uses: actions/upload-artifact@v2
-      with:
-        name: g2c-test-coverage
-        path: |
-          g2c/build/*.html
-          g2c/build/*.css
+        ctest --verbose --output-on-failure --rerun-failed
+

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -77,7 +77,7 @@ jobs:
         mkdir build
         cd build
         cmake -DJasper_ROOT=~/jasper -DENABLE_OpenJPEG=ON .. 
-        make -j2
+        make -j2 VERBOSE=1
 
     - name: test
       run: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -102,5 +102,5 @@ jobs:
     - name: test
       run: |
         cd $GITHUB_WORKSPACE/g2c/build
-        ctest  --output-on-failure --rerun-failed
+        ctest --verbose --output-on-failure --rerun-failed
 

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -97,7 +97,7 @@ jobs:
         mkdir build
         cd build
         cmake ${{ matrix.config.options }} ..
-        make -j2
+        make -j2 VERBOSE=1
 
     - name: test
       run: |

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -22,10 +22,6 @@ jobs:
       matrix:
         config:
         - {
-            name: "png_on jasper_off openjpeg_off",
-            options: "-DUSE_PNG=ON  -DUSE_Jasper=OFF -DUSE_OpenJPEG=OFF"
-          }
-        - {
             name: "png_on jasper_on openjpeg_off",
             options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
           }

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -76,7 +76,7 @@ jobs:
       run: |
         set -e          
         cd $GITHUB_WORKSPACE/g2c/build
-        ctest --verbose 
+        ctest --verbose --output-on-failure --rerun-failed
         gcovr --root .. -v  --html-details --exclude ../tests --exclude CMakeFiles --print-summary -o test-coverage.html
         ls -l
           

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -69,8 +69,8 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper -DLOGGING=On -DENABLE_DOCS=On -DPTHREADS=ON -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data ..
-        make -j2
+        cmake -DJasper_ROOT=~/Jasper -DLOGGING=On -DENABLE_DOCS=On -DPTHREADS=ON -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_BUILD_TYPE=Debug .. 
+        make -j2 VERBOSE=1
 
     - name: test
       run: |


### PR DESCRIPTION
Fixes #388.

Continued minor improvements...

Now all CI workflows are required to successfully complete before merge to develop.