### PR TITLE
switched developer workflow to jasper 4.0.0

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -1,4 +1,4 @@
-[name: MacOS
+name: MacOS
 on:
   push:
     branches:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -39,19 +39,20 @@ jobs:
         brew update
         brew install openjpeg jpeg-turbo
 
-    - name: checkout-jasper
-      uses: actions/checkout@v2
-      with:
-        repository: jasper-software/jasper
-        path: jasper
-        ref: version-4.0.0
-
     - name: cache-jasper
       id: cache-jasper
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-${{ runner.os }}-4.0.0-macOS
+        key: jasper-${{ runner.os }}-4.0.0-macOS-1
+
+    - name: checkout-jasper
+      if: steps.cache-jasper.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: jasper-software/jasper
+        path: jasper
+        ref: version-4.0.0
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,14 +44,14 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-3.0.5
+        ref: version-4.0.0
 
     - name: cache-jasper
       id: cache-jasper
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-${{ runner.os }}-3.0.5-macOS
+        key: jasper-${{ runner.os }}-4.0.0-macOS
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -59,7 +59,7 @@ jobs:
         cd jasper
         mkdir cmake_build
         cd cmake_build
-        cmake -DCMAKE_INSTALL_PREFIX=~/jasper -DJAS_ENABLE_LIBJPEG=OFF ..
+        cmake -DCMAKE_INSTALL_PREFIX=~/jasper
         make -j2
         make install
 

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -1,4 +1,4 @@
-name: MacOS
+[name: MacOS
 on:
   push:
     branches:
@@ -23,7 +23,7 @@ jobs:
         config:
         - {
             name: "png_on jasper_on openjpeg_off",
-            options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/Jasper"
+            options: "-DUSE_PNG=ON  -DUSE_Jasper=ON  -DUSE_OpenJPEG=OFF -DJasper_ROOT=~/jasper"
           }
         - {
             name: "png_on jasper_off openjpeg_on",
@@ -44,14 +44,14 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-2.0.25
+        ref: version-3.0.5
 
     - name: cache-jasper
       id: cache-jasper
       uses: actions/cache@v2
       with:
-        path: ~/Jasper
-        key: jasper-${{ runner.os }}-2.0.25-macOS
+        path: ~/jasper
+        key: jasper-${{ runner.os }}-3.0.5-macOS
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -59,7 +59,7 @@ jobs:
         cd jasper
         mkdir cmake_build
         cd cmake_build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper -DJAS_ENABLE_LIBJPEG=OFF
+        cmake -DCMAKE_INSTALL_PREFIX=~/jasper -DJAS_ENABLE_LIBJPEG=OFF ..
         make -j2
         make install
 

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-${{ runner.os }}-3.0.5-macOS-2
+        key: jasper-${{ runner.os }}-3.0.6-macOS-2
 
     - name: checkout-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-3.0.5
+        ref: version-3.0.6
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -57,6 +57,8 @@ jobs:
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
       run: |
+        pwd
+        ls -l
         cd jasper
         mkdir cmake_build
         cd cmake_build

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-${{ runner.os }}-4.0.0-macOS-1
+        key: jasper-${{ runner.os }}-3.0.5-macOS-2
 
     - name: checkout-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-4.0.0
+        ref: version-3.0.5
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -44,7 +44,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/jasper
-        key: jasper-${{ runner.os }}-3.0.6-macOS-2
+        key: jasper-${{ runner.os }}-4.0.0-macOS-2
 
     - name: checkout-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -52,7 +52,7 @@ jobs:
       with:
         repository: jasper-software/jasper
         path: jasper
-        ref: version-3.0.6
+        ref: version-4.0.0
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -57,12 +57,13 @@ jobs:
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
       run: |
+        set -e
         pwd
         ls -l
         cd jasper
         mkdir cmake_build
         cd cmake_build
-        cmake -DCMAKE_INSTALL_PREFIX=~/jasper
+        cmake -DCMAKE_INSTALL_PREFIX=~/jasper ..
         make -j2
         make install
 

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -25,19 +25,20 @@ jobs:
         sudo apt-get install libpng-dev zlib1g-dev libjpeg-dev doxygen libopenjp2-7-dev
         python3 -m pip install gcovr
 
-    - name: checkout-jasper
-      uses: actions/checkout@v2
-      with:
-        repository: jasper-software/jasper
-        path: jasper
-        ref: version-3.0.3
-
     - name: cache-jasper
       id: cache-jasper
       uses: actions/cache@v2
       with:
-        path: ~/Jasper
-        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}
+        path: ~/jasper
+        key: jasper-${{ runner.os }}-4.0.0
+
+    - name: checkout-jasper
+      if: steps.cache-jasper.outputs.cache-hit != 'true'
+      uses: actions/checkout@v2
+      with:
+        repository: jasper-software/jasper
+        path: jasper
+        ref: version-4.0.0
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -46,7 +47,7 @@ jobs:
         cd jasper
         mkdir cmake_build
         cd cmake_build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
+        cmake -DCMAKE_INSTALL_PREFIX=~/jasper ..
         make -j2
         make install
 
@@ -69,7 +70,7 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper -DLOGGING=On -DENABLE_DOCS=On -DPTHREADS=ON -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_BUILD_TYPE=Debug .. 
+        cmake -DJasper_ROOT=~/jasper -DLOGGING=On -DENABLE_DOCS=On -DPTHREADS=ON -DFTP_TEST_FILES=ON -DTEST_FILE_DIR=/home/runner/data -DCMAKE_BUILD_TYPE=Debug .. 
         make -j2 VERBOSE=1
 
     - name: test


### PR DESCRIPTION
Fixes #399 
Part of #398 

In this PR I update the developer and MacOS workflows to use the newly-released Jasper-4.0.

THis solves a problem in the MacOS build. So that's good.

But what's bad is that MacOS requires Jasper-4.0 to pass tests. We need to somehow accomodate that in the CMake file...