### PR TITLE
Add Intel OneAPI (LLVM) support

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -16,9 +16,9 @@ defaults:
 jobs:
   Intel:
     runs-on: ubuntu-latest
-    env:
-      CC: icc
-      CXX: icpc
+    strategy:
+      matrix:
+        compilers: ["CC=icc FC=ifort CXX=icpc", "CC=icx FC=ifx CXX=icpx"]
 
     steps:
 
@@ -48,7 +48,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/Jasper
-        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}-intel
+        key: jasper-${{ runner.os }}-${{ hashFiles('jasper/VERSION') }}-${{ matrix.compilers }}
 
     - name: build-jasper
       if: steps.cache-jasper.outputs.cache-hit != 'true'
@@ -56,7 +56,7 @@ jobs:
         cd jasper
         mkdir cmake_build
         cd cmake_build
-        cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
+        ${{ matrix.compilers }} cmake .. -DCMAKE_INSTALL_PREFIX=~/Jasper
         make -j2
         make install
 
@@ -66,6 +66,7 @@ jobs:
         path: g2c
 
     - name: Initialize CodeQL
+      if: ${{ matrix.compilers == 'CC=icc FC=ifort CXX=icpc' }}
       uses: github/codeql-action/init@v2
       with:
         languages: cpp
@@ -76,10 +77,11 @@ jobs:
         cd g2c
         mkdir build
         cd build
-        cmake -DJasper_ROOT=~/Jasper ..
+        ${{ matrix.compilers }} cmake -DJasper_ROOT=~/Jasper ..
         make -j2 VERBOSE=1
 
     - name: Perform CodeQL Analysis
+      if: ${{ matrix.compilers == 'CC=icc FC=ifort CXX=icpc' }}
       uses: github/codeql-action/analyze@v2
       with:
         category: "/language:cpp"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,7 +97,7 @@ endif()
 find_package(LibXml2 2.9.0 REQUIRED)
 
 # Set the compiler flags.
-if(CMAKE_C_COMPILER_ID MATCHES "^(Intel)$")
+if(CMAKE_C_COMPILER_ID MATCHES "^(Intel|IntelLLVM)$")
   set(CMAKE_C_FLAGS "-g -traceback ${CMAKE_C_FLAGS}")
   set(CMAKE_C_FLAGS_RELEASE "-O3")
   set(CMAKE_C_FLAGS_DEBUG "-O0")


### PR DESCRIPTION
Might as well finish off adding IntelLLVM to remaining NCEPLIBS...

Disabling CodeQL for OneAPI because it fails (appears that the compiler isn't supported).