### PR TITLE
Add Spack-based CI, including recipe

### DIFF
--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -64,7 +64,7 @@ jobs:
         echo 'Loading g2c through Spack and checking $G2C_LIB ...'
         spack load g2c
         if [ ${{ matrix.libs }} == "libs=shared" ]; then suffix="so" ; else suffix="a"; fi
-        ls ${G2C_LIB${{ matrix.precision }}} | grep -cE '/libg2c_${{ matrix.precision }}\.'$suffix'$'
+        ls ${G2C_LIB${{ matrix.precision }}} | grep -cE '/libg2c\.'$suffix'$'
         # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -63,10 +63,12 @@ jobs:
         # Run 'spack load' to check for obvious errors in setup_run_environment
         echo 'Loading g2c through Spack and checking $G2C_LIB ...'
         spack load g2c
-        set -x
         if [ ${{ matrix.libs }} == 'shared' ]; then suffix="so" ; else suffix="a"; fi
         ls $G2C_LIB | grep -cE '/libg2c\.'$suffix'$'
-        ls $(spack location -i g2c)/bin/{g2c_compare,g2c_degrib2,g2c_index}
+        if [[ ${{ matrix.png }} == '+png' && ${{ matrix.libs }} == 'shared' ]]; then ldd $G2C_LIB | grep -c libpng; fi
+        if [ ${{ matrix.utils }} == '+utils' ]; then
+          ls $(spack location -i g2c)/bin/{g2c_compare,g2c_degrib2,g2c_index}
+        fi
         # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -1,0 +1,94 @@
+# This is a CI workflow for the NCEPLIBS-g2c project.
+#
+# This workflow builds g2c with Spack, including installing with the "--test
+# root" option to run the CTest suite. It also has a one-off job that validates
+# the recipe by ensuring that every CMake option that should be set in the
+# Spack recipe is so set.
+#
+# Alex Richert, Sep 2023
+name: Spack
+on:
+  push:
+    branches:
+    - develop
+  pull_request:
+    branches:
+    - develop
+
+jobs:
+  # This job builds with Spack using every combination of variants and runs the CTest suite each time
+  Spack:
+
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+        png: ["+png", "~png"]
+        jpeg: ["+jasper~openjpeg", "~jasper+openjpeg"]
+        pic: ["+pic", "~pic"]
+        libs: ["libs=shared", "libs=static"]
+        pthreads: ["+pthreads", "~pthreads"]
+        utils: ["+utils", "~utils"]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+
+    - name: checkout-g2c
+      uses: actions/checkout@v4
+      with:
+        path: g2c
+
+    - name: cache-spack
+      id: cache-spack
+      uses: actions/cache@v3
+      with:
+        path: ~/spack-build-cache
+        key: spack-build-cache-${{ matrix.os }}-1
+
+    - name: spack-build-and-test
+      run: |
+        git clone -c feature.manyFiles=true https://github.com/spack/spack
+        . spack/share/spack/setup-env.sh
+        spack env create g2c-env
+        spack env activate g2c-env
+        cp $GITHUB_WORKSPACE/g2c/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/g2c/package.py
+        mv $GITHUB_WORKSPACE/g2c $SPACK_ENV/g2c
+        spack develop --no-clone g2c@develop
+        spack add g2c@develop%gcc@11
+        spack external find cmake gmake
+        spack mirror add spack-build-cache ~/spack-build-cache
+        spack concretize
+        # Run installation and run CTest suite
+        spack install --fail-fast --no-check-signature --test root
+        # Print test results
+        cat $(spack location -i g2c)/.spack/install-time-test-log.txt
+        # Run 'spack load' to check for obvious errors in setup_run_environment
+        echo "Loading g2c through Spack..."
+        spack load g2c
+        spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
+
+    - name: Upload test results
+      uses: actions/upload-artifact@v3
+      if: ${{ failure() }}
+      with:
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.openmp }}
+        path: ${{ github.workspace }}/g2c/spack-build-*/Testing/Temporary/LastTest.log
+
+  # This job validates the Spack recipe by making sure each cmake build option is represented
+  recipe-check:
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: checkout-g2c
+      uses: actions/checkout@v4
+      with:
+        path: g2c
+
+    - name: recipe-check
+      run: |
+        echo "If this jobs fails, look at the most recently output CMake option below and make sure that option appears in spack/package.py"
+        excl="ENABLE_DOCS|FTP_TEST_FILES|FTP_LARGE_TEST_FILES|FTP_EXTRA_TEST_FILES|LOGGING"
+        for opt in $(grep -ioP '^option\(\K(?!($excl))[^ ]+' $GITHUB_WORKSPACE/g2c/CMakeLists.txt) ; do
+          echo "Checking for presence of '$opt' CMake option in package.py"
+          grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/g2c/spack/package.py
+        done

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -88,7 +88,7 @@ jobs:
       run: |
         echo "If this jobs fails, look at the most recently output CMake option below and make sure that option appears in spack/package.py"
         excl="ENABLE_DOCS|FTP_TEST_FILES|FTP_LARGE_TEST_FILES|FTP_EXTRA_TEST_FILES|LOGGING"
-        for opt in $(grep -ioP '^option\(\K(?!($excl))[^ ]+' $GITHUB_WORKSPACE/g2c/CMakeLists.txt) ; do
+        for opt in $(grep -ioP "^option\(\K(?!($excl))[^ ]+" $GITHUB_WORKSPACE/g2c/CMakeLists.txt) ; do
           echo "Checking for presence of '$opt' CMake option in package.py"
           grep -cP "define.+\b${opt}\b" $GITHUB_WORKSPACE/g2c/spack/package.py
         done

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -51,8 +51,7 @@ jobs:
         spack env create g2c-env
         spack env activate g2c-env
         cp $GITHUB_WORKSPACE/g2c/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/g2c/package.py
-        mv $GITHUB_WORKSPACE/g2c $SPACK_ENV/g2c
-        spack develop --no-clone g2c@develop
+        spack develop --no-clone --path $GITHUB_WORKSPACE/g2c g2c@develop
         spack add g2c@develop%gcc@11
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
@@ -62,10 +61,11 @@ jobs:
         # Print test results
         cat $(spack location -i g2c)/.spack/install-time-test-log.txt
         # Run 'spack load' to check for obvious errors in setup_run_environment
-        echo Loading g2c through Spack and checking $G2C_LIB ...'
+        echo 'Loading g2c through Spack and checking $G2C_LIB ...'
         spack load g2c
         if [ ${{ matrix.libs }} == "libs=shared" ]; then suffix="so" ; else suffix="a"; fi
         ls ${G2C_LIB${{ matrix.precision }}} | grep -cE '/libg2c_${{ matrix.precision }}\.'$suffix'$'
+        # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
 
     - name: Upload test results

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -52,7 +52,7 @@ jobs:
         spack env activate g2c-env
         cp $GITHUB_WORKSPACE/g2c/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/g2c/package.py
         spack develop --no-clone --path $GITHUB_WORKSPACE/g2c g2c@develop
-        spack add g2c@develop%gcc@11 libs=${{ matrix.libs }}
+        spack add g2c@develop%gcc@11 ${{ matrix.png }} ${{ matrix.jpeg }} ${{ matrix.pic}} libs=${{ matrix.libs }} ${{ matrix.pthreads }} ${{ matrix.utils }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -68,6 +68,8 @@ jobs:
         if [[ ${{ matrix.png }} == '+png' && ${{ matrix.libs }} == 'shared' ]]; then ldd $G2C_LIB | grep -c libpng; fi
         if [ ${{ matrix.utils }} == '+utils' ]; then
           ls $(spack location -i g2c)/bin/{g2c_compare,g2c_degrib2,g2c_index}
+        else
+          if [ -d $(spack location -i g2c)/bin ]; then echo "utils were built but shouldn't have been!"; exit 1; fi
         fi
         # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/spack-build-cache
-        key: spack-build-cache-${{ matrix.os }}-1
+        key: spack-build-cache-${{ matrix.os }}-${{ matrix.jpeg }}-${{ matrix.png }}-1
 
     - name: spack-build-and-test
       run: |

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -25,7 +25,7 @@ jobs:
         png: ["+png", "~png"]
         jpeg: ["+jasper~openjpeg", "~jasper+openjpeg"]
         pic: ["+pic", "~pic"]
-        libs: ["libs=shared", "libs=static"]
+        libs: ["shared", "static"]
         pthreads: ["+pthreads", "~pthreads"]
         utils: ["+utils", "~utils"]
     runs-on: ${{ matrix.os }}
@@ -52,7 +52,7 @@ jobs:
         spack env activate g2c-env
         cp $GITHUB_WORKSPACE/g2c/spack/package.py $SPACK_ROOT/var/spack/repos/builtin/packages/g2c/package.py
         spack develop --no-clone --path $GITHUB_WORKSPACE/g2c g2c@develop
-        spack add g2c@develop%gcc@11
+        spack add g2c@develop%gcc@11 libs=${{ matrix.libs }}
         spack external find cmake gmake
         spack mirror add spack-build-cache ~/spack-build-cache
         spack concretize
@@ -63,8 +63,10 @@ jobs:
         # Run 'spack load' to check for obvious errors in setup_run_environment
         echo 'Loading g2c through Spack and checking $G2C_LIB ...'
         spack load g2c
-        if [ ${{ matrix.libs }} == "libs=shared" ]; then suffix="so" ; else suffix="a"; fi
+        set -x
+        if [ ${{ matrix.libs }} == 'shared' ]; then suffix="so" ; else suffix="a"; fi
         ls $G2C_LIB | grep -cE '/libg2c\.'$suffix'$'
+        ls $(spack location -i g2c)/bin/{g2c_compare,g2c_degrib2,g2c_index}
         # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -42,7 +42,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: ~/spack-build-cache
-        key: spack-build-cache-${{ matrix.os }}-${{ matrix.jpeg }}-${{ matrix.png }}-1
+        key: spack-build-cache-${{ matrix.os }}-${{ matrix.jpeg }}-${{ matrix.png }}-1 # Only include 'matrix' items that affect dependencies
 
     - name: spack-build-and-test
       run: |
@@ -78,7 +78,7 @@ jobs:
       uses: actions/upload-artifact@v3
       if: ${{ failure() }}
       with:
-        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.openmp }}
+        name: spackci-ctest-output-${{ matrix.os }}-${{ matrix.png }}-${{ matrix.jpeg }}-${{ matrix.pic}}-${{ matrix.libs }}-${{ matrix.pthreads }}-${{ matrix.utils }}
         path: ${{ github.workspace }}/g2c/spack-build-*/Testing/Temporary/LastTest.log
 
   # This job validates the Spack recipe by making sure each cmake build option is represented

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -64,7 +64,7 @@ jobs:
         echo 'Loading g2c through Spack and checking $G2C_LIB ...'
         spack load g2c
         if [ ${{ matrix.libs }} == "libs=shared" ]; then suffix="so" ; else suffix="a"; fi
-        ls ${G2C_LIB${{ matrix.precision }}} | grep -cE '/libg2c\.'$suffix'$'
+        ls $G2C_LIB | grep -cE '/libg2c\.'$suffix'$'
         # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
 

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -69,7 +69,7 @@ jobs:
         if [ ${{ matrix.utils }} == '+utils' ]; then
           ls $(spack location -i g2c)/bin/{g2c_compare,g2c_degrib2,g2c_index}
         else
-          if [ -d $(spack location -i g2c)/bin ]; then echo "utils were built but shouldn't have been!"; exit 1; fi
+          if [ -f $(spack location -i g2c)/bin/g2c_compare ]; then echo "utils were built but shouldn't have been!"; exit 1; fi
         fi
         # Setup build cache (automatically skipped if it already exists)
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -62,8 +62,10 @@ jobs:
         # Print test results
         cat $(spack location -i g2c)/.spack/install-time-test-log.txt
         # Run 'spack load' to check for obvious errors in setup_run_environment
-        echo "Loading g2c through Spack..."
+        echo Loading g2c through Spack and checking $G2C_LIB ...'
         spack load g2c
+        if [ ${{ matrix.libs }} == "libs=shared" ]; then suffix="so" ; else suffix="a"; fi
+        ls ${G2C_LIB${{ matrix.precision }}} | grep -cE '/libg2c_${{ matrix.precision }}\.'$suffix'$'
         spack buildcache push --only dependencies --unsigned ~/spack-build-cache g2c
 
     - name: Upload test results

--- a/spack/README
+++ b/spack/README
@@ -1,0 +1,3 @@
+This directory contains an authoritative, up-to-date Spack recipe for NCEPLIBS-g2c, which is found under Spack as "g2c".
+
+Before each release of NCEPLIBS-g2c, this file should be updated to accommodate changes in build options, etc., and .github/workflows/spack.yml should be updated to exercise all variants. Only the version entry should need to be updated after the release prior to incorporation into the Spack repository and the JCSDA Spack fork.

--- a/spack/package.py
+++ b/spack/package.py
@@ -50,6 +50,7 @@ class G2c(CMakePackage):
     depends_on("libpng", when="+png")
     depends_on("jasper", when="+jasper")
     depends_on("openjpeg", when="+openjpeg")
+    depends_on("libxml2@2.9:")
 
     conflicts("+jasper +openjpeg", msg="Either Jasper or OpenJPEG should be used, not both")
 

--- a/spack/package.py
+++ b/spack/package.py
@@ -1,0 +1,82 @@
+# Copyright 2013-2023 Lawrence Livermore National Security, LLC and other
+# Spack Project Developers. See the top-level COPYRIGHT file for details.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR MIT)
+
+from spack.package import *
+
+
+class G2c(CMakePackage):
+    """This library contains C decoder/encoder routines for GRIB edition 2.
+
+    This is part of NOAA's NCEPLIBS project."""
+
+    homepage = "https://github.com/NOAA-EMC/NCEPLIBS-g2c"
+    url = "https://github.com/NOAA-EMC/NCEPLIBS-g2c/archive/refs/tags/v1.6.4.tar.gz"
+    git = "https://github.com/NOAA-EMC/NCEPLIBS-g2c"
+
+    maintainers("AlexanderRichert-NOAA", "Hang-Lei-NOAA", "edwardhartnett")
+
+    version("develop", branch="develop")
+    version("1.7.0", sha256="73afba9da382fed73ed8692d77fa037bb313280879cd4012a5e5697dccf55175")
+    version("1.6.4", sha256="5129a772572a358296b05fbe846bd390c6a501254588c6a223623649aefacb9d")
+    version("1.6.2", sha256="b5384b48e108293d7f764cdad458ac8ce436f26be330b02c69c2a75bb7eb9a2c")
+
+    variant("png", default=True, description="Use PNG library")
+    variant("jasper", default=True, description="Use Jasper library")
+    variant("openjpeg", default=False, description="Use OpenJPEG library")
+    variant("pic", default=True, description="Build with position-independent-code")
+    variant(
+        "libs",
+        default=("shared", "static"),
+        values=("shared", "static"),
+        multi=True,
+        description="Build shared libs, static libs or both",
+        when="@1.7:",
+    )
+    variant(
+        "pthreads",
+        default=False,
+        description="Turn on thread-safety with pthreads",
+        when="@develop",
+    )
+    variant(
+        "utils",
+        default=True,
+        description="Build and install some utility programs",
+        when="@develop",
+    )
+
+    depends_on("libpng", when="+png")
+    depends_on("jasper", when="+jasper")
+    depends_on("openjpeg", when="+openjpeg")
+
+    conflicts("+jasper +openjpeg", msg="Either Jasper or OpenJPEG should be used, not both")
+
+    def cmake_args(self):
+        args = [
+            self.define_from_variant("CMAKE_POSITION_INDEPENDENT_CODE", "pic"),
+            self.define("BUILD_SHARED_LIBS", self.spec.satisfies("libs=shared")),
+            self.define("BUILD_STATIC_LIBS", self.spec.satisfies("libs=static")),
+            self.define_from_variant("USE_PNG", "png"),
+            self.define_from_variant("USE_Jasper", "jasper"),
+            self.define_from_variant("USE_OpenJPEG", "openjpeg"),
+            self.define_from_variant("PTHREADS", "pthreads"),
+            self.define_from_variant("UTILS", "utils"),
+            self.define("BUILD_TESTING", self.run_tests),
+        ]
+
+        return args
+
+    def setup_run_environment(self, env):
+        if self.spec.satisfies("@:1.6"):
+            shared = False
+        else:
+            shared = self.spec.satisfies("libs=shared")
+        lib = find_libraries("libg2c", root=self.prefix, shared=shared, recursive=True)
+        env.set("G2C_LIB", lib[0])
+        env.set("G2C_INC", join_path(self.prefix, "include"))
+
+    def check(self):
+        with working_dir(self.builder.build_directory):
+            make("test")


### PR DESCRIPTION
This PR adds Spack-based CI. It has some new modifications just added in grib-util, namely, build caching and improved checking of the ctest output.

Fixes #437

squash-n-merge