### PR TITLE
Changing occurrence of C++ reserved name 'template' in header file

### DIFF
--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -334,9 +334,9 @@ int g2c_get_prod(int g2cid, int msg_num, int prod_num, int *num_data_points,
 
 /* Templates. */
 int g2c_get_grid_template(int grid_template_num, int *maplen, int *map, int *needext);
-int g2c_get_grid_template_extension(int grid_template_num, int *template,
+int g2c_get_grid_template_extension(int grid_template_num, int *g2c_template,
                                     int *extlen, int *ext);
-int g2c_get_pds_template_extension(int pds_template_num, int *template,
+int g2c_get_pds_template_extension(int pds_template_num, int *g2c_template,
                                    int *extlen, int *ext);
 int g2c_get_pds_template(int pds_template_num, int *maplen, int *map, int *needext);
 int g2c_get_drs_template(int drs_template_num, int *maplen, int *map, int *needext);


### PR DESCRIPTION
This is a rather small PR, but I figured it would be worth contributing back to the main repository since I may not be the only person who tries to do this. 

C++ is cool in that you can call compiled C code natively just by adding a special header include statement, in addition to performing the linking step against the static or shared library:
```
extern "C" {
#include <grib2.h>
}
...
```
Such a use case is desireable because g2c can be used to interact with and read the grib2 data, and then higher-level abstractions in C++ (such as std::unordered_map) can be used to handle grouping of array data and metadata. 

However, the current g2c header file has a few occurrences of variables named ```template```, which is a C++ reserved name, and this conflict prevents compiling a C++ program that calls g2c. This only matters for the header file, and not for the compiled ```.c``` files. I renamed the two occurences of ```template``` as ```g2c_template```, which successfully allows for C/C++ cross compilation. 

Fixes #452 