### PR TITLE
Remove unused unistd.h from grib2.h.in

### DIFF
--- a/src/grib2.h.in
+++ b/src/grib2.h.in
@@ -21,7 +21,6 @@
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>
-#include <unistd.h>
 
 #define G2C_VERSION "@pVersion@" /**< Current version of NCEPLIBS-g2c library. */
 


### PR DESCRIPTION
The unistd.h header is not needed for the library, and is preventing the compilation of the library on Windows.  I was able to compile on Linux without it and tried combinations of features.  It seems that unistd.h is primarily used to supply getopt for the command line utilities.  For Windows (which I am trying to put together a conda package for), I think it is fine to just have the library available.