### PR TITLE
added link to old version of docs, also turned off brew update in macos CI workflow

### DIFF
--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -31,8 +31,6 @@ jobs:
       run: |
         find /Library/Frameworks/ -name "png*"
         sudo rm -rf /Library/Frameworks/Mono.framework
-
-        brew update
         brew install libaec openjpeg jpeg-turbo
 
     - name: cache-jasper

--- a/docs/user_guide.md
+++ b/docs/user_guide.md
@@ -90,6 +90,7 @@ and MSWord formats are available).
 
 ## Documentation for Previous Versions of NCEPLIBS-g2c
 
+* [NCEPLIBS-g2c Version 1.8.0](ver-1.8.0/index.html)
 * [NCEPLIBS-g2c Version 1.7.0](ver-1.7.0/index.html)
 * [NCEPLIBS-g2c Version 1.6.4](ver-1.6.4/index.html)
 


### PR DESCRIPTION
Part of #478 
Fixes #490

Adding link to old version of the docs.
Also turned off brew update in macos CI workflow.