### PR TITLE
Fix installed cmake package files

### DIFF
--- a/cmake/PackageConfig.cmake.in
+++ b/cmake/PackageConfig.cmake.in
@@ -5,6 +5,11 @@
 # Include targets file.  This will create IMPORTED target @PROJECT_NAME@
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@-targets.cmake")
 
+if(@BUILD_SHARED_LIBS@)
 get_target_property(@PROJECT_NAME@_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@ IMPORTED_CONFIGURATIONS)
+endif()
+if(@BUILD_STATIC_LIBS@)
+  get_target_property(@PROJECT_NAME@_static_BUILD_TYPES @PROJECT_NAME@::@PROJECT_NAME@_static IMPORTED_CONFIGURATIONS)
+endif()
 
 check_required_components("@PROJECT_NAME@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -157,6 +157,14 @@ CONFIGURE_FILE("${CMAKE_CURRENT_SOURCE_DIR}/grib2.h.in" "${CMAKE_CURRENT_BINARY_
 
 target_include_directories(${lib_name}_objlib PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_SOURCE_DIR}>"
                                                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+if(BUILD_SHARED_LIBS)
+  target_include_directories(${lib_name}_shared PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_SOURCE_DIR}>"
+                                                       $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+endif()
+if(BUILD_STATIC_LIBS)
+  target_include_directories(${lib_name}_static PUBLIC "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR};${CMAKE_CURRENT_SOURCE_DIR}>"
+                                                       $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>)
+endif()
 
 if (NOT WIN32)
   target_link_libraries(${lib_name}_objlib INTERFACE m)


### PR DESCRIPTION
This PR fixes two issues in installed cmake package files (See #520)

1) Add if checks to determine whether to run get_target_property depending on which target is installed (g2c or g2c_static or both)

 2) Add target_include_directories for shared and static targets so that installed config files properly set INTERFACE_INCLUDE_DIRECTORIES for all targets. 

Fixes #520