### PR TITLE
Support png bit depths 1, 2 and 4

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -201,7 +201,7 @@ export(EXPORT ${PROJECT_NAME}Exports
 
 # g2c-config.cmake
 configure_package_config_file(
-  ${CMAKE_SOURCE_DIR}/cmake/PackageConfig.cmake.in ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
+  ${PROJECT_SOURCE_DIR}/cmake/PackageConfig.cmake.in ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
   INSTALL_DESTINATION ${CONFIG_INSTALL_DESTINATION})
 install(FILES ${CMAKE_BINARY_DIR}/${PROJECT_NAME}-config.cmake
   DESTINATION ${CONFIG_INSTALL_DESTINATION})

--- a/src/decenc_png.c
+++ b/src/decenc_png.c
@@ -101,7 +101,7 @@ dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
         unsigned char *cout)
 {
     int interlace, color, compres, filter, bit_depth;
-    g2int j, k, n, bytes, clen;
+    g2int j, k, n, bytes;
     png_structp png_ptr;
     png_infop info_ptr, end_info;
     png_bytepp row_pointers;
@@ -171,11 +171,13 @@ dec_png(unsigned char *pngbuf, g2int *width, g2int *height,
 
     /* Copy image data to output string   */
     n = 0;
-    bytes = bit_depth / 8;
-    clen = (*width) * bytes;
+    bytes = (*width * bit_depth) / 8;
+    if ((*width * bit_depth) % 8 != 0) {
+        bytes++;
+    }
     for (j = 0; j < *height; j++)
     {
-        for (k = 0; k < clen; k++)
+        for (k = 0; k < bytes; k++)
         {
             cout[n] = *(row_pointers[j] + k);
             n++;
@@ -254,10 +256,15 @@ enc_png(unsigned char *data, g2int width, g2int height, g2int nbits,
                  PNG_COMPRESSION_TYPE_DEFAULT, PNG_FILTER_TYPE_DEFAULT);
 
     /* Put image data into the PNG info structure. */
-    bytes = nbits / 8;
+    bytes = (width * nbits) / 8;
+    if ((width * nbits) % 8 != 0) {
+        bytes++;
+    }
+
     row_pointers = malloc(height * sizeof(png_bytep));
     for (j = 0; j < height; j++)
-        row_pointers[j] = (png_bytep *)(data + (j * width * bytes));
+        row_pointers[j] = (png_bytep *)(data + (j * bytes));
+
     png_set_rows(png_ptr, info_ptr, (png_bytepp)row_pointers);
 
     /* Do the PNG encoding, and write out PNG stream. */

--- a/src/pngpack.c
+++ b/src/pngpack.c
@@ -168,7 +168,13 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
 
         /* Pack data into full octets, then do PNG encode and
          * calculate the length of the packed data in bytes. */
-        if (nbits <= 8)
+        if (nbits <= 1)
+            nbits = 1;
+        else if (nbits <= 2)
+            nbits = 2;
+        else if (nbits <= 4)
+            nbits = 4;
+        else if (nbits <= 8)
             nbits = 8;
         else if (nbits <= 16)
             nbits = 16;
@@ -177,9 +183,14 @@ pngpack_int(void *fld, int fld_is_double, g2int width, g2int height, g2int *idrs
         else
             nbits = 32;
 
-        nbytes = (nbits / 8) * ndpts;
+        int bytes_per_row = (nbits * width) / 8;
+        if ((width * nbits) % 8 != 0) {
+            bytes_per_row++;
+        }
+        nbytes = bytes_per_row * height;
         ctemp = calloc(nbytes, 1);
-        sbits(ctemp, ifld, 0, nbits, 0, ndpts);
+        for (j = 0; j < height; j++)
+            sbits(ctemp + (j * bytes_per_row), ifld + (j * width), 0, nbits, 0, width);
 
         /* Encode data into PNG Format. */
         if ((*lcpack = (g2int)enc_png(ctemp, width, height, nbits, cpack)) <= 0)

--- a/src/pngunpack.c
+++ b/src/pngunpack.c
@@ -68,7 +68,15 @@ pngunpack_int(unsigned char *cpack, g2int len, g2int *idrstmpl, g2int ndpts,
             return G2C_ENOMEM;
         }
         dec_png(cpack, &width, &height, ctemp);
-        gbits(ctemp, ifld, 0, nbits, 0, ndpts);
+
+        int bytes_per_row = (nbits * width) / 8;
+        if ((width * nbits) % 8 != 0) {
+            bytes_per_row++;
+        }
+        for (j = 0; j < height; j++) {
+            gbits(ctemp + (j * bytes_per_row), ifld + (j * width), 0, nbits, 0, width);
+        }
+
         for (j = 0; j < ndpts; j++)
         {
             if (fld_is_double)

--- a/tests/tst_png.c
+++ b/tests/tst_png.c
@@ -69,6 +69,90 @@ main()
         }
     }
     printf("ok!\n");
+    printf("Testing pngpack()/pngunpack() calls bit_depth 1 ...");
+    {
+        g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN;
+        float fld[DATA_LEN] = {1.0, 2.0, 1.0, 2.0};
+        float fld_in[DATA_LEN];
+        unsigned char cpack[PACKED_LEN];
+        g2int lcpack;
+        g2int idrstmpl[5] = {0, 0, 0, 0, 0};
+        int i;
+
+        /* Pack the data. */
+        pngpack(fld, width, height, idrstmpl, cpack, &lcpack);
+
+        /* Unpack the data. */
+        if (pngunpack(cpack, len, idrstmpl, ndpts, fld_in))
+            return G2C_ERROR;
+
+        if (idrstmpl[3] != 1)
+            return G2C_ERROR;
+
+        for (i = 0; i < DATA_LEN; i++)
+        {
+            /* printf("%g %g\n", fld[i], fld_in[i]); */
+            if (fld[i] != fld_in[i])
+                return G2C_ERROR;
+        }
+    }
+    printf("ok!\n");
+    printf("Testing pngpack()/pngunpack() calls bit_depth 2 ...");
+    {
+        g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN;
+        float fld[DATA_LEN] = {1.0, 2.0, 3.0, 4.0};
+        float fld_in[DATA_LEN];
+        unsigned char cpack[PACKED_LEN];
+        g2int lcpack;
+        g2int idrstmpl[5] = {0, 0, 0, 0, 0};
+        int i;
+
+        /* Pack the data. */
+        pngpack(fld, width, height, idrstmpl, cpack, &lcpack);
+
+        /* Unpack the data. */
+        if (pngunpack(cpack, len, idrstmpl, ndpts, fld_in))
+            return G2C_ERROR;
+
+        if (idrstmpl[3] != 2)
+            return G2C_ERROR;
+
+        for (i = 0; i < DATA_LEN; i++)
+        {
+            /* printf("%g %g\n", fld[i], fld_in[i]); */
+            if (fld[i] != fld_in[i])
+                return G2C_ERROR;
+        }
+    }
+    printf("ok!\n");
+    printf("Testing pngpack()/pngunpack() calls bit_depth 4 ...");
+    {
+        g2int height = 2, width = 2, ndpts = DATA_LEN, len = PACKED_LEN;
+        float fld[DATA_LEN] = {1.0, 4.0, 8.0, 16.0};
+        float fld_in[DATA_LEN];
+        unsigned char cpack[PACKED_LEN];
+        g2int lcpack;
+        g2int idrstmpl[5] = {0, 0, 0, 0, 0};
+        int i;
+
+        /* Pack the data. */
+        pngpack(fld, width, height, idrstmpl, cpack, &lcpack);
+
+        /* Unpack the data. */
+        if (pngunpack(cpack, len, idrstmpl, ndpts, fld_in))
+            return G2C_ERROR;
+
+        if (idrstmpl[3] != 4)
+            return G2C_ERROR;
+
+        for (i = 0; i < DATA_LEN; i++)
+        {
+            /* printf("%g %g\n", fld[i], fld_in[i]); */
+            if (fld[i] != fld_in[i])
+                return G2C_ERROR;
+        }
+    }
+    printf("ok!\n");
     printf("Testing g2c_pngpackd()/g2c_pngunpackd() calls...");
     {
         size_t height = 2, width = 2;


### PR DESCRIPTION
Update png pack/unpack and encode/decode routines to support bit depths 1, 2 and 4. 

Fixes #508