### PR TITLE
Update for g2cio.c and test

### DIFF
--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -41,7 +41,7 @@ int
 g2c_file_io(FILE *f, int write, int g2ctype, void *var)
 {
     void *void_be;
-    char *bvar = NULL;
+    signed char *bvar = NULL;
     short *svar = NULL;
     int *ivar = NULL;
     long long int *i64var = NULL;
@@ -313,7 +313,7 @@ g2c_file_io_ushort(FILE *f, int write, unsigned short *var)
  * @author Ed Hartnett 11/13/22
  */
 int
-g2c_file_io_byte(FILE *f, int write, char *var)
+g2c_file_io_byte(FILE *f, int write, signed char *var)
 {
     return g2c_file_io(f, write, G2C_BYTE, var);
 }

--- a/src/g2cio.c
+++ b/src/g2cio.c
@@ -313,7 +313,7 @@ g2c_file_io_ushort(FILE *f, int write, unsigned short *var)
  * @author Ed Hartnett 11/13/22
  */
 int
-g2c_file_io_byte(FILE *f, int write, signed char *var)
+g2c_file_io_byte(FILE *f, int write, char *var)
 {
     return g2c_file_io(f, write, G2C_BYTE, var);
 }

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -388,7 +388,7 @@ int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
 int g2c_file_io(FILE *f, int write, int g2ctype, void *var);
-int g2c_file_io_byte(FILE *f, int write, char *var);
+int g2c_file_io_byte(FILE *f, int write, signed char *var);
 int g2c_file_io_ubyte(FILE *f, int write, unsigned char *var);
 int g2c_file_io_short(FILE *f, int write, short *var);
 int g2c_file_io_ushort(FILE *f, int write, unsigned short *var);

--- a/src/grib2_int.h
+++ b/src/grib2_int.h
@@ -388,7 +388,7 @@ int g2c_check_msg(unsigned char *cgrib, g2int *lencurr, int verbose);
 
 /* Basic file I/O. */
 int g2c_file_io(FILE *f, int write, int g2ctype, void *var);
-int g2c_file_io_byte(FILE *f, int write, signed char *var);
+int g2c_file_io_byte(FILE *f, int write, char *var);
 int g2c_file_io_ubyte(FILE *f, int write, unsigned char *var);
 int g2c_file_io_short(FILE *f, int write, short *var);
 int g2c_file_io_ushort(FILE *f, int write, unsigned short *var);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -96,12 +96,11 @@ endif()
 # Build a C program test.
 function(g2c_build_test name)
   add_executable(${name} ${name}.c g2c_test_util.c)
-  target_link_libraries(${name} PUBLIC g2c::g2c)
-endfunction()
-
-# Build a C program test.
-function(g2c_build_test name)
-  add_executable(${name} ${name}.c g2c_test_util.c)
+  if("${name}" STREQUAL "tst_io")
+    if(CMAKE_C_COMPILER_ID MATCHES "^(GNU|Clang|AppleClang)$")
+      set_source_files_properties(${name}.c PROPERTIES COMPILE_FLAGS "-Wno-error=pointer-sign")
+    endif()
+  endif()
   target_link_libraries(${name} PUBLIC g2c::g2c)
 endfunction()
 

--- a/tests/tst_io.c
+++ b/tests/tst_io.c
@@ -137,8 +137,8 @@ main()
     {
         FILE *f;
         unsigned char val = 250;
-        char neg_val = -120;
-        char val_in;
+        signed char neg_val = -120;
+        signed char val_in;
         unsigned char uval_in;
         int ret;
 
@@ -146,12 +146,21 @@ main()
         if (!(f = fopen(TEST_FILE, "wb")))
             return G2C_EFILE;
 
-        /* Write 1-byte ints, thrice. */
+        /* Write 1-byte ints. */
         if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
             return ret;
         if ((ret = g2c_file_io_byte(f, G2C_FILE_WRITE, &neg_val)))
             return ret;
         if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &val)))
+            return ret;
+        /* This fourth write mimics writing a signed char as unsigned
+         * which is the same as defining a generic char on ARM-based
+         * Linux. The variable neg_val has a value of -120, which
+         * has a bit representation of "10001000" using two's
+         * complement. Writing this in accordance with the GRIB2
+         * standard will perform some bit shifting/manipulation.
+         */
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_WRITE, &neg_val)))
             return ret;
 
         /* Close file. */
@@ -161,7 +170,7 @@ main()
         if (!(f = fopen(TEST_FILE, "rb")))
             return G2C_EFILE;
 
-        /* Read three values. */
+        /* Read four values. */
         if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
             return ret;
         if (uval_in != val)
@@ -174,6 +183,22 @@ main()
             return ret;
         if (uval_in != val)
             return G2C_ERROR;
+        /* Now lets read the fourth value. Recall it was a signed
+         * char (-120) written using g2c_file_io_ubyte().
+         *
+         * Now we will read using the unsigned byte function because
+         * we want to mimic read as a generic char, which is unsigned
+         * on ARM-based Linux. An unsigned char with a bit representation
+         * of "10001000" which is a value of 136.
+         */
+        if ((ret = g2c_file_io_ubyte(f, G2C_FILE_READ, &uval_in)))
+            return ret;
+        /* The test...value read in must not be equal to the original
+         * negative value; and must be equal to 136; and when cast to
+         * an unsigned char must equal the original negative value.
+         */
+        if (uval_in != neg_val && uval_in == 136 && (signed char)uval_in == neg_val)
+            return G2C_NOERROR;
 
         /* Close file. */
         fclose(f);


### PR DESCRIPTION
In g2c_file_io(), define chat *bvar as signed char. The generic char on majority of platforms is signed, except ARM Linux where it is unsigned.

Updated test for 1-byte ints to add a fourth read/write and test special condition where the value read will not equal what is written that mimics Arm Linux.