### PR TITLE
Add CDash workflow

### DIFF
--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -1,0 +1,27 @@
+name: cdash
+on:
+  push:
+    branches:
+    - develop
+
+jobs:
+  cdash:
+    runs-on: ubuntu-latest
+
+    env:
+      FC: gfortran
+      CC: gcc
+      CDASH_TOKEN: ${{ secrets.CDASH_TOKEN }}
+
+    steps:
+
+    - name: "Install various dependencies with apt"
+      run: sudo apt-get install libpng-dev zlib1g-dev libjpeg-dev libopenjp2-7-dev libaec-dev
+
+    - name: "Build dependencies"
+      uses: NOAA-EMC/ci-build-nceplibs@oneinstalldir
+      with:
+        jasper-version: version-4.0.0
+
+    - name: CDash
+      uses: NOAA-EMC/ci-cdash@develop

--- a/spack/package.py
+++ b/spack/package.py
@@ -92,5 +92,5 @@ class G2c(CMakePackage):
         env.set("G2C_INC", join_path(self.prefix, "include"))
 
     def check(self):
-        with working_dir(self.builder.build_directory):
+        with working_dir(self.build_directory):
             make("test")


### PR DESCRIPTION
This PR adds a CI job that creates CDash info and pushes it to https://my.cdash.org/index.php?project=NCEPLIBS-g2c each time a commit is merged into develop.

Successful workflow run: https://github.com/AlexanderRichert-NOAA/NCEPLIBS-g2c/actions/runs/14504447083/job/40691113824