### PR TITLE
Fix cdash

### DIFF
--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -22,6 +22,7 @@ jobs:
       uses: NOAA-EMC/ci-build-nceplibs@oneinstalldir
       with:
         jasper-version: version-4.0.0
+        key-suffix: oneinstalldir
 
     - name: CDash
       uses: NOAA-EMC/ci-cdash@develop

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -22,7 +22,8 @@ jobs:
       uses: NOAA-EMC/ci-build-nceplibs@oneinstalldir
       with:
         jasper-version: version-4.0.0
-        key-suffix: oneinstalldir
+        key-prefix: cdash-build
+        key-suffix: oneinstalldir-1
 
     - name: CDash
       uses: NOAA-EMC/ci-cdash@develop


### PR DESCRIPTION
The cdash workflow was failing because dependency installation was mishandling cache keys. This PR fixes that.
See https://github.com/AlexanderRichert-NOAA/NCEPLIBS-g2c/actions/runs/14647391045/job/41104916444 and https://my.cdash.org/index.php?project=NCEPLIBS-g2c (20250424-041be51fedaa4c5d7c44c42a8e45197b37e9fe85).