### PR TITLE
Make grib2int available to users

### DIFF
--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Intel:

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install libaec-dev libpng-dev zlib1g-dev libjpeg-dev doxygen
 
     - name: "Install Intel"
-      uses: NOAA-EMC/ci-install-intel-toolkit@develop
+      uses: NOAA-EMC/ci-install-intel-toolkit@env-setup-tweaks
       with:
         compiler-setup: ${{ matrix.compilers }}
 

--- a/.github/workflows/Intel.yml
+++ b/.github/workflows/Intel.yml
@@ -26,7 +26,7 @@ jobs:
         sudo apt-get install libaec-dev libpng-dev zlib1g-dev libjpeg-dev doxygen
 
     - name: "Install Intel"
-      uses: NOAA-EMC/ci-install-intel-toolkit@env-setup-tweaks
+      uses: NOAA-EMC/ci-install-intel-toolkit@develop
       with:
         compiler-setup: ${{ matrix.compilers }}
 

--- a/.github/workflows/Linux_options.yml
+++ b/.github/workflows/Linux_options.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Linux_options:

--- a/.github/workflows/Linux_versions.yml
+++ b/.github/workflows/Linux_versions.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Linux_versions:

--- a/.github/workflows/MacOS.yml
+++ b/.github/workflows/MacOS.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   MacOS:

--- a/.github/workflows/Spack.yml
+++ b/.github/workflows/Spack.yml
@@ -14,6 +14,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   # This job builds with Spack, exercising all variants, and runs the CTest suite each time

--- a/.github/workflows/cdash.yml
+++ b/.github/workflows/cdash.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - develop
+  workflow_dispatch:
 
 jobs:
   cdash:

--- a/.github/workflows/developer.yml
+++ b/.github/workflows/developer.yml
@@ -6,6 +6,11 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run biweekly
+    - cron: '0 0 1 * *'
+    - cron: '0 0 15 * *'
+  workflow_dispatch:
 
 # Cancel in-progress workflows when pushing to a branch
 concurrency:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
     - develop
+  schedule:
+    # Run monthly
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
 
 jobs:
   Windows:


### PR DESCRIPTION
Previous change in library code had caused some code unavailable for users. There may be some code like these under grib2int are only used by a limited few users, but it may plan critical functions in the whole operation system. Therefore, upon their request, these has to be available for users. 