### PR TITLE
Fix Doxygen quoting in simunpack.c

### DIFF
--- a/src/simunpack.c
+++ b/src/simunpack.c
@@ -17,7 +17,7 @@
  * Representation Template 5.0.
  * @param ndpts The number of data values to unpack.
  * @param fld A pointer that gets the unpacked data values. fld must be
-`* allocated with at least ndpts * sizeof(float) bytes before calling
+ * allocated with at least `ndpts * sizeof(float)` bytes before calling
  * this routine.
  *
  * @return 0 for success, error code otherwise.


### PR DESCRIPTION
With doxygen 1.17.0 I'm getting:
```
Parsing file /builddir/build/BUILD/g2clib-2.3.0-build/NCEPLIBS-g2c-2.3.0/src/gbits/builddir/build/BUILD/g2clib-2.3.0-build/NCEPLIBS-g2c-2.3.0/src/simunpack.c:68: error: Reached end of file while still searching closing '`' of a verbatim block starting at line 20 (warning treated as error, aborting now)
```